### PR TITLE
fix(ci): add workflow_dispatch for manual Docker publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:        # Manual trigger — always runs full publish pipeline
   schedule:
     - cron: "0 6 * * 1"  # Every Monday — rebuild to pick up base image security patches
 
@@ -122,15 +123,15 @@ jobs:
               - "scripts/**"
 
       - name: Set up QEMU
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
 
       - name: Set up Docker Buildx
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Log in to GitHub Container Registry
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
         with:
           registry: ghcr.io
@@ -139,7 +140,7 @@ jobs:
 
       - name: Generate image tags and labels
         id: meta
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6
         with:
           images: ghcr.io/${{ github.repository }}
@@ -153,7 +154,7 @@ jobs:
       # Build locally first so Trivy scans BEFORE anything is pushed.
       # A vulnerable image is never published — CVEs block the push step (#66).
       - name: Build image (local, for CVE scan)
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           context: .
@@ -165,7 +166,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Scan image for CVEs
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           image-ref: local-scan:latest
@@ -176,7 +177,7 @@ jobs:
           exit-code: 1
 
       - name: Upload Trivy results to GitHub Security tab
-        if: (steps.changes.outputs.app == 'true' || github.event_name == 'schedule') && always()
+        if: (steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && always()
         uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8  # v4.33.0
         with:
           sarif_file: trivy-results.sarif
@@ -184,7 +185,7 @@ jobs:
       # Smoke-test the local image before pushing (#88).
       # Reuses local-scan:latest built above — no extra docker build needed.
       - name: Smoke test image
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           docker run -d --name smoke-test \
             -e DB_PATH=/tmp/test.db \
@@ -207,7 +208,7 @@ jobs:
       # Build and push multi-platform only after the CVE scan and smoke test pass (#66, #88).
       # GHA cache from the local build above makes this fast (no layer re-download).
       - name: Build and push (multi-platform)
-        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule'
+        if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
         with:
           context: .


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the CI workflow so Docker builds can be triggered manually
- Updates all 9 publish-step `if` conditions to run on `workflow_dispatch` (same as `schedule`)
- Unblocks the arm64 `:latest` tag — after merge, run `gh workflow run CI` to publish

## Context
PR #182 added the `:latest` tag to the multi-platform publish step, but only `.github/workflows/ci.yml` changed, so the paths-filter skipped the Docker build on merge. The Pi still gets `no matching manifest for linux/arm64`.

## Test plan
- [ ] CI passes (tests + security — no app code changed)
- [ ] After merge: `gh workflow run CI` triggers full pipeline including Docker publish
- [ ] `docker manifest inspect ghcr.io/mshirel/song-history:latest` shows both `amd64` and `arm64`
- [ ] Pi: `docker compose pull && docker compose up -d` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)