### PR TITLE
fix(ci): include workflow_dispatch in publish job-level gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,8 +94,8 @@ jobs:
 
   publish:
     needs: [test, security]
-    # Only publish on pushes to main or the weekly scheduled run — not on PRs
-    if: github.event_name == 'push' || github.event_name == 'schedule'
+    # Only publish on pushes to main, the weekly scheduled run, or manual dispatch — not on PRs
+    if: github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- The publish job has a job-level `if` that gates whether it runs at all
- PR #183 added `workflow_dispatch` to the step-level conditions but missed this job-level gate
- Run #132 confirmed: publish job was `skipped` entirely on `workflow_dispatch`
- This adds `workflow_dispatch` to the job-level condition so the publish job actually starts

## Test plan
- [ ] CI passes
- [ ] After merge: `gh workflow run CI` → publish job runs (not skipped)
- [ ] `docker manifest inspect ghcr.io/mshirel/song-history:latest` shows `amd64` + `arm64`
- [ ] Pi: `docker compose pull && docker compose up -d` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)