### PR TITLE
fix(deploy): fix Pi healthcheck, Docker network, and TLS config

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - /opt/song-history/data:/data
       - /opt/song-history/inbox:/inbox
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8000/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -85,6 +85,8 @@ services:
       - "traefik.http.routers.songs.rule=Host(`songs.highland-coc.com`)"
       - "traefik.http.routers.songs.entrypoints=websecure"
       - "traefik.http.routers.songs.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.songs.tls.domains[0].main=highland-coc.com"
+      - "traefik.http.routers.songs.tls.domains[0].sans=*.highland-coc.com"
       - "traefik.http.services.songs.loadbalancer.server.port=8000"
       # HTTP → HTTPS redirect
       - "traefik.http.routers.songs-http.rule=Host(`songs.highland-coc.com`)"

--- a/deploy/pi/traefik/traefik.yml
+++ b/deploy/pi/traefik/traefik.yml
@@ -21,6 +21,8 @@ certificatesResolvers:
       storage: /acme.json
       dnsChallenge:
         provider: cloudflare          # requires CF_DNS_API_TOKEN env var
+        delayBeforeCheck: 30s
+        disablePropagationCheck: true  # skip DNS propagation query — avoids DNS interception issues
         resolvers:
           - "1.1.1.1:53"
           - "8.8.8.8:53"
@@ -29,7 +31,7 @@ certificatesResolvers:
 providers:
   docker:
     exposedByDefault: false           # require traefik.enable=true label
-    network: bridge
+    network: song-history_default
 
 # --- API / dashboard (LAN-only, no auth needed) ----------------------------
 api:


### PR DESCRIPTION
## Summary
- **Healthcheck**: `curl` → `python3 urllib` — slim image has no curl, causing perpetual "unhealthy" state and Traefik filtering the container
- **Docker network**: `bridge` → `song-history_default` — Traefik couldn't discover containers on the Compose-created network
- **TLS**: wildcard cert (`*.highland-coc.com`) + `disablePropagationCheck: true` — DNS interception on the church LAN blocked ACME propagation queries

## Test plan
- [ ] CI passes
- [ ] After merge, rsync to Pi: `rsync -av deploy/pi/ songs@pi-songs:/opt/song-history/`
- [ ] `docker compose down && docker compose up -d` starts cleanly
- [ ] Healthcheck passes: `docker inspect ... --format '{{.State.Health.Status}}'` → `healthy`
- [ ] Traefik discovers the app: routers show `songs@docker`
- [ ] TLS cert is valid Let's Encrypt wildcard (not TRAEFIK DEFAULT CERT)
- [ ] `https://songs.highland-coc.com/songs` loads the song list

🤖 Generated with [Claude Code](https://claude.com/claude-code)