### PR TITLE
fix(web): call init_schema() only once per process

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -203,11 +203,17 @@ def _validate_date_range(start_date: str, end_date: str) -> None:
         )
 
 
+_schema_ready: bool = False
+
+
 def _get_db() -> Database:
+    global _schema_ready  # noqa: PLW0603
     db_path = Path(os.environ.get("DB_PATH", "data/worship.db"))
     db = Database(db_path)
     db.connect()
-    db.init_schema()
+    if not _schema_ready:
+        db.init_schema()
+        _schema_ready = True
     return db
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2091,3 +2091,46 @@ class TestGracefulShutdown:
         source = inspect.getsource(app_module._lifespan)
         assert "shutdown" in source, "lifespan must call executor.shutdown"
         assert "wait=True" in source, "lifespan executor.shutdown must use wait=True"
+
+
+class TestGetDbSchemaInit:
+    """Verify that init_schema() is only called once, not on every request."""
+
+    def test_init_schema_called_once_across_multiple_get_db_calls(self):
+        """init_schema should run only on the first _get_db call, not every request."""
+        from unittest.mock import patch
+
+        import worship_catalog.web.app as app_module
+
+        # Reset the flag for test isolation
+        app_module._schema_ready = False
+
+        with patch.object(Database, "init_schema") as mock_init:
+            with patch.object(Database, "connect"):
+                # First call should trigger init_schema
+                app_module._get_db()
+                # Second call should skip init_schema
+                app_module._get_db()
+                # Third call should also skip
+                app_module._get_db()
+
+                mock_init.assert_called_once()
+
+        # Reset so other tests aren't affected
+        app_module._schema_ready = False
+
+    def test_schema_ready_flag_set_after_first_call(self):
+        """The _schema_ready flag should be True after first _get_db call."""
+        from unittest.mock import patch
+
+        import worship_catalog.web.app as app_module
+
+        app_module._schema_ready = False
+
+        with patch.object(Database, "init_schema"):
+            with patch.object(Database, "connect"):
+                assert not app_module._schema_ready
+                app_module._get_db()
+                assert app_module._schema_ready
+
+        app_module._schema_ready = False


### PR DESCRIPTION
## Summary
- `_get_db()` was calling `db.init_schema()` on every HTTP request, running unnecessary `CREATE TABLE IF NOT EXISTS` and `PRAGMA user_version` queries
- Added a module-level `_schema_ready` flag so `init_schema()` only executes on the first `_get_db()` call per process
- Schema initialization still happens reliably at startup (via lifespan's `_get_db()` call) and on the first request

## Test plan
- [x] `TestGetDbSchemaInit::test_init_schema_called_once_across_multiple_get_db_calls` — verifies `init_schema()` is called exactly once across 3 `_get_db()` calls
- [x] `TestGetDbSchemaInit::test_schema_ready_flag_set_after_first_call` — verifies the `_schema_ready` flag is set after first call
- [x] Full test suite passes (727 passed, 16 skipped)
- [x] ruff + mypy clean

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)