### PR TITLE
fix: harden deploy config and notify variable safety

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY data/library_index.json /app/data/library_index.json
 RUN chmod +x scripts/import-new.sh
 
 # Install the package with web extras
-RUN pip install --no-cache-dir -e ".[web]"
+RUN pip install --no-cache-dir ".[web]"
 
 # Create a non-root user and group for runtime (#26)
 # Fixed UID/GID so host volume permissions can be set to match:

--- a/deploy/pi/.env.example
+++ b/deploy/pi/.env.example
@@ -14,10 +14,9 @@ CSRF_SECRET=your-random-secret-here
 # Leave blank to disable OCR fallback.
 ANTHROPIC_API_KEY=
 
-# Pushover credentials for backup failure alerts.
-# backup.sh sends a notification to your phone when a backup fails.
+# Pushover credentials — used for backup failure alerts and import notifications.
 # Get your app token at https://pushover.net/apps
 # Get your user key from the Pushover home screen.
 # Leave blank to disable alerting.
-# PUSHOVER_APP_TOKEN=your-app-token-here
-# PUSHOVER_USER_KEY=your-user-key-here
+PUSHOVER_APP_TOKEN=your-app-token-here
+PUSHOVER_USER_KEY=your-user-key-here

--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       INBOX_DIR: /inbox
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       CSRF_SECRET: "${CSRF_SECRET}"
+      PUSHOVER_USER_KEY: "${PUSHOVER_USER_KEY:-}"
+      PUSHOVER_APP_TOKEN: "${PUSHOVER_APP_TOKEN:-}"
     volumes:
       - /opt/song-history/data:/data
       - /opt/song-history/inbox:/inbox

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -551,6 +551,12 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
     so that the inbox is always cleaned up regardless of success or failure.
     """
     db = _get_db()
+    # Initialize notify variables with safe defaults so the finally block never
+    # hits UnboundLocalError — even if db.update_import_job() raises in the
+    # except block before these are reassigned.  (#193)
+    _notify_title = "Import failed"
+    _notify_message = f"{pptx_path.name} — unknown error"
+    _notify_priority = -1
     try:
         from worship_catalog.extractor import extract_songs
         from worship_catalog.pptx_reader import compute_file_hash
@@ -633,13 +639,27 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
         db.update_import_job(
             job_id, status="complete", songs_imported=len(result.songs)
         )
+        _notify_title = "Import complete"
+        _notify_message = f"{pptx_path.name} — {len(result.songs)} songs imported"
+        _notify_priority = -1
     except Exception as exc:  # noqa: BLE001
         # update_import_job runs outside the transaction block — commits even on rollback
         db.update_import_job(
             job_id, status="failed", error_message=str(exc)[:500]
         )
+        _notify_title = "Import failed"
+        _notify_message = f"{pptx_path.name} — {str(exc)[:200]}"
+        _notify_priority = 1
     finally:
         db.close()
+        _log.info(
+            "Import notify metadata",
+            extra={
+                "notify_title": _notify_title,
+                "notify_message": _notify_message,
+                "notify_priority": _notify_priority,
+            },
+        )
         # Always clean up the inbox file regardless of success or failure (#138)
         try:
             if pptx_path.exists():

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2091,3 +2091,78 @@ class TestGracefulShutdown:
         source = inspect.getsource(app_module._lifespan)
         assert "shutdown" in source, "lifespan must call executor.shutdown"
         assert "wait=True" in source, "lifespan executor.shutdown must use wait=True"
+
+
+class TestBackgroundImportNotification:
+    """Verify notify variables are safely initialized to prevent UnboundLocalError."""
+
+    def test_no_unbound_error_when_update_import_job_raises_in_except(
+        self, tmp_path, monkeypatch
+    ):
+        """If update_import_job raises inside the except block, the finally block
+        must not hit UnboundLocalError on the _notify_* variables.
+
+        The finally block logs notification metadata (_notify_title, _notify_message,
+        _notify_priority).  If those variables are only set inside try/except, a
+        failure in the except block before they are assigned would cause
+        UnboundLocalError.  They must be initialized before the try block.
+        """
+        from worship_catalog.db import Database
+        from importlib import reload
+        import logging
+
+        db_path = tmp_path / "notify_test.db"
+        _db = Database(db_path)
+        _db.connect()
+        _db.init_schema()
+        job_id = str(_uuid_mod.uuid4())
+        _db.create_import_job(job_id, filename="crash.pptx")
+        _db.close()
+
+        monkeypatch.setenv("DB_PATH", str(db_path))
+
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+
+        pptx_path = tmp_path / "crash.pptx"
+        pptx_path.write_bytes(b"not a real pptx")
+
+        # Make update_import_job raise so the except block fails before it can
+        # set any notify variables.
+        def exploding_update(self_db, *args, **kwargs):
+            raise RuntimeError("DB connection lost")
+
+        monkeypatch.setattr(Database, "update_import_job", exploding_update)
+
+        # Capture log output from the finally block to confirm the notify
+        # variables were accessible (i.e., initialized before the try block).
+        captured: list[logging.LogRecord] = []
+
+        class _CapturingHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        cap_handler = _CapturingHandler()
+        cap_handler.setLevel(logging.DEBUG)
+        # Attach to the exact logger used by the (reloaded) app module
+        app_logger = app_module._log
+        app_logger.addHandler(cap_handler)
+        app_logger.setLevel(logging.DEBUG)
+
+        try:
+            app_module._run_import_in_background(job_id, pptx_path)
+        except RuntimeError:
+            pass  # Expected — the exploding update_import_job propagates
+
+        app_logger.removeHandler(cap_handler)
+
+        # The finally block must have logged a notification message containing
+        # the default _notify_title without raising UnboundLocalError.
+        notify_logs = [
+            r for r in captured
+            if hasattr(r, "msg") and "notify" in r.msg.lower()
+        ]
+        assert len(notify_logs) >= 1, (
+            "Finally block must log notification metadata even when except block raises. "
+            f"All log messages: {[r.msg for r in captured]}"
+        )


### PR DESCRIPTION
## Summary
- **#193**: Initialize `_notify_title`, `_notify_message`, `_notify_priority` with safe defaults before the try block in `_run_import_in_background()` to prevent `UnboundLocalError` if `db.update_import_job()` raises in the except path
- **#194**: Add `PUSHOVER_USER_KEY` and `PUSHOVER_APP_TOKEN` env vars to Pi deploy `docker-compose.yml` and uncomment them in `.env.example` with updated docs noting they serve import notifications too
- **#195**: Remove `-e` (editable install) from production `Dockerfile` — editable installs are unnecessary in containers and can cause import issues

## Test plan
- [x] New test `TestBackgroundImportNotification::test_no_unbound_error_when_update_import_job_raises_in_except` — patches `update_import_job` to raise in except path, verifies no `UnboundLocalError` and notification metadata is logged
- [x] Full test suite passes (726 passed, 16 skipped)
- [x] ruff + mypy clean
- [ ] CI passes

Closes #193, closes #194, closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)