### PR TITLE
fix(web): call init_schema() only once per process (#191)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -204,11 +204,17 @@ def _validate_date_range(start_date: str, end_date: str) -> None:
         )
 
 
+_schema_ready: bool = False
+
+
 def _get_db() -> Database:
+    global _schema_ready  # noqa: PLW0603
     db_path = Path(os.environ.get("DB_PATH", "data/worship.db"))
     db = Database(db_path)
     db.connect()
-    db.init_schema()
+    if not _schema_ready:
+        db.init_schema()
+        _schema_ready = True
     return db
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2294,3 +2294,41 @@ class TestBackgroundImportNotification:
         _db2.close()
         assert row["status"] == "failed"
         assert row["error_message"] is not None
+
+
+class TestGetDbSchemaInit:
+    """Verify that init_schema() is only called once, not on every request."""
+
+    def test_init_schema_called_once_across_multiple_get_db_calls(self) -> None:
+        """init_schema should run only on the first _get_db call, not every request."""
+        from unittest.mock import patch
+
+        import worship_catalog.web.app as app_module
+
+        app_module._schema_ready = False
+
+        with patch.object(Database, "init_schema") as mock_init:
+            with patch.object(Database, "connect"):
+                app_module._get_db()
+                app_module._get_db()
+                app_module._get_db()
+
+                mock_init.assert_called_once()
+
+        app_module._schema_ready = False
+
+    def test_schema_ready_flag_set_after_first_call(self) -> None:
+        """The _schema_ready flag should be True after first _get_db call."""
+        from unittest.mock import patch
+
+        import worship_catalog.web.app as app_module
+
+        app_module._schema_ready = False
+
+        with patch.object(Database, "init_schema"):
+            with patch.object(Database, "connect"):
+                assert not app_module._schema_ready
+                app_module._get_db()
+                assert app_module._schema_ready
+
+        app_module._schema_ready = False


### PR DESCRIPTION
## Summary
- Added `_schema_ready` module-level flag to `_get_db()` in `web/app.py`
- `init_schema()` now runs only on the first call, not every HTTP request
- Eliminates redundant `CREATE TABLE IF NOT EXISTS` and `PRAGMA user_version` writes

## Test plan
- [x] 2 new tests in `TestGetDbSchemaInit` verifying single-call behavior and flag state
- [x] 753 tests passing, 93% coverage, ruff + mypy clean

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)