### PR TITLE
fix: harden deploy config and notify variable safety (#193, #194, #195)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY data/library_index.json /app/data/library_index.json
 RUN chmod +x scripts/import-new.sh
 
 # Install the package with web extras
-RUN pip install --no-cache-dir -e ".[web]"
+RUN pip install --no-cache-dir ".[web]"
 
 # Create a non-root user and group for runtime (#26)
 # Fixed UID/GID so host volume permissions can be set to match:

--- a/deploy/pi/.env.example
+++ b/deploy/pi/.env.example
@@ -14,10 +14,9 @@ CSRF_SECRET=your-random-secret-here
 # Leave blank to disable OCR fallback.
 ANTHROPIC_API_KEY=
 
-# Pushover credentials for backup failure alerts.
-# backup.sh sends a notification to your phone when a backup fails.
+# Pushover credentials — used for backup failure alerts and import notifications.
 # Get your app token at https://pushover.net/apps
 # Get your user key from the Pushover home screen.
 # Leave blank to disable alerting.
-# PUSHOVER_APP_TOKEN=your-app-token-here
-# PUSHOVER_USER_KEY=your-user-key-here
+PUSHOVER_APP_TOKEN=your-app-token-here
+PUSHOVER_USER_KEY=your-user-key-here

--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       INBOX_DIR: /inbox
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       CSRF_SECRET: "${CSRF_SECRET}"
+      PUSHOVER_USER_KEY: "${PUSHOVER_USER_KEY:-}"
+      PUSHOVER_APP_TOKEN: "${PUSHOVER_APP_TOKEN:-}"
     volumes:
       - /opt/song-history/data:/data
       - /opt/song-history/inbox:/inbox

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -558,6 +558,11 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
     so that the inbox is always cleaned up regardless of success or failure.
     """
     db = _get_db()
+    # Initialize notify variables with safe defaults so the finally block never
+    # hits UnboundLocalError if db.update_import_job() raises (#193).
+    _notify_title = "Import failed"
+    _notify_message = f"{pptx_path.name} — unknown error"
+    _notify_priority = -1
     try:
         from worship_catalog.extractor import extract_songs
         from worship_catalog.pptx_reader import compute_file_hash

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2295,6 +2295,58 @@ class TestBackgroundImportNotification:
         assert row["status"] == "failed"
         assert row["error_message"] is not None
 
+    def test_notify_vars_safe_when_update_import_job_raises_in_except(
+        self, tmp_path, monkeypatch,
+    ):
+        """If update_import_job raises in the except block, notify vars must not be unbound (#193)."""
+        from unittest.mock import MagicMock
+        from worship_catalog.db import Database
+
+        db_path = tmp_path / "notify_unbound.db"
+        _db = Database(db_path)
+        _db.connect()
+        _db.init_schema()
+        job_id = str(_uuid_mod.uuid4())
+        _db.create_import_job(job_id, filename="crash.pptx")
+        _db.close()
+
+        monkeypatch.setenv("DB_PATH", str(db_path))
+
+        import worship_catalog.web.app as app_module
+        from importlib import reload
+        reload(app_module)
+
+        mock_pushover = MagicMock()
+        monkeypatch.setattr(app_module, "send_pushover", mock_pushover)
+
+        # Make extract_songs raise, then make update_import_job ALSO raise
+        import worship_catalog.extractor as extractor_mod
+        monkeypatch.setattr(
+            extractor_mod, "extract_songs",
+            lambda p, **kw: (_ for _ in ()).throw(ValueError("bad pptx")),
+        )
+
+        monkeypatch.setattr(
+            Database, "update_import_job",
+            lambda self, jid, **kw: (_ for _ in ()).throw(RuntimeError("DB write failed")),
+        )
+
+        pptx_path = tmp_path / "crash.pptx"
+        pptx_path.write_bytes(b"fake")
+
+        # The RuntimeError from update_import_job propagates, but critically
+        # it must NOT be UnboundLocalError — the safe defaults prevent that.
+        # The finally block (including send_pushover) still runs.
+        try:
+            app_module._run_import_in_background(job_id, pptx_path)
+        except RuntimeError:
+            pass  # Expected — update_import_job raised inside except block
+
+        # send_pushover should still be called with the safe defaults
+        mock_pushover.assert_called_once()
+        call_kwargs = mock_pushover.call_args[1]
+        assert "crash.pptx" in call_kwargs["message"]
+
 
 class TestGetDbSchemaInit:
     """Verify that init_schema() is only called once, not on every request."""


### PR DESCRIPTION
## Summary
- **#193**: Initialize `_notify_title`/`_notify_message`/`_notify_priority` before the try block in `_run_import_in_background()` so the finally block never hits `UnboundLocalError` if `update_import_job()` raises
- **#194**: Add `PUSHOVER_USER_KEY` and `PUSHOVER_APP_TOKEN` env vars to Pi deploy compose + uncomment in `.env.example`
- **#195**: Remove `-e` (editable install) from production Dockerfile

## Test plan
- [x] New test: `test_notify_vars_safe_when_update_import_job_raises_in_except` — verifies no UnboundLocalError when both extract_songs and update_import_job raise
- [x] 752 tests passing, 93% coverage, ruff + mypy clean

Closes #193, closes #194, closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)