### PR TITLE
refactor(arch): move web SQL query helpers into Database (#166)

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -857,3 +857,189 @@ class Database:
                 (threshold,),
             )
         self._maybe_commit()
+
+    # ------------------------------------------------------------------
+    # Web query methods (moved from web/app.py — #166)
+    # ------------------------------------------------------------------
+
+    _SONGS_SORT_COLS: frozenset[str] = frozenset(
+        {"display_title", "words_by", "music_by", "arranger", "performance_count"}
+    )
+    _SERVICES_SORT_COLS: frozenset[str] = frozenset(
+        {"service_date", "service_name", "song_leader", "preacher", "song_count"}
+    )
+
+    def query_songs_paginated(
+        self,
+        search: str | None = None,
+        sort: str = "performance_count",
+        sort_dir: str = "desc",
+        page: int = 1,
+        per_page: int = 50,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return songs with performance count, optionally filtered and sorted."""
+        sort = _safe_order_by(sort, self._SONGS_SORT_COLS)
+        order = f"{sort} {sort_dir.upper()}, s.display_title"
+        cursor = self._conn.cursor()
+        base = """
+            SELECT s.id, s.display_title, s.canonical_title,
+                   se.words_by, se.music_by, se.arranger,
+                   COUNT(DISTINCT ss.service_id) AS performance_count
+            FROM songs s
+            LEFT JOIN song_editions se ON se.song_id = s.id
+            LEFT JOIN service_songs ss ON ss.song_id = s.id
+        """
+        count_base = """
+            SELECT COUNT(DISTINCT s.id)
+            FROM songs s
+            LEFT JOIN song_editions se ON se.song_id = s.id
+            LEFT JOIN service_songs ss ON ss.song_id = s.id
+        """
+        offset = (page - 1) * per_page
+        if search:
+            like = f"%{search}%"
+            where = """
+                WHERE LOWER(s.display_title) LIKE LOWER(?)
+                   OR LOWER(COALESCE(se.words_by, '')) LIKE LOWER(?)
+                   OR LOWER(COALESCE(se.music_by, '')) LIKE LOWER(?)
+            """
+            cursor.execute(count_base + where, (like, like, like))
+            total: int = cursor.fetchone()[0]
+            cursor.execute(
+                base + where + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
+                (like, like, like, per_page, offset),
+            )
+        else:
+            cursor.execute(count_base)
+            total = cursor.fetchone()[0]
+            cursor.execute(
+                base + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
+                (per_page, offset),
+            )
+        return [dict(row) for row in cursor.fetchall()], total
+
+    def query_all_services_paginated(
+        self,
+        sort: str = "service_date",
+        sort_dir: str = "desc",
+        q_service: str = "",
+        q_leader: str = "",
+        q_preacher: str = "",
+        q_sermon: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        page: int = 1,
+        per_page: int = 50,
+    ) -> tuple[list[dict[str, Any]], int]:
+        """Return services with optional filtering, sorting, and pagination."""
+        where_clauses: list[str] = []
+        params: list[Any] = []
+        if q_service:
+            where_clauses.append("LOWER(sv.service_name) LIKE LOWER(?)")
+            params.append(f"%{q_service}%")
+        if q_leader:
+            where_clauses.append("LOWER(COALESCE(sv.song_leader,'')) LIKE LOWER(?)")
+            params.append(f"%{q_leader}%")
+        if q_preacher:
+            where_clauses.append("LOWER(COALESCE(sv.preacher,'')) LIKE LOWER(?)")
+            params.append(f"%{q_preacher}%")
+        if q_sermon:
+            where_clauses.append("LOWER(COALESCE(sv.sermon_title,'')) LIKE LOWER(?)")
+            params.append(f"%{q_sermon}%")
+        if start_date:
+            where_clauses.append("sv.service_date >= ?")
+            params.append(start_date)
+        if end_date:
+            where_clauses.append("sv.service_date <= ?")
+            params.append(end_date)
+
+        where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+        sort = _safe_order_by(sort, self._SERVICES_SORT_COLS)
+        order = f"{sort} {sort_dir.upper()}, sv.service_name"
+        offset = (page - 1) * per_page
+        cursor = self._conn.cursor()
+        cursor.execute(
+            f"SELECT COUNT(DISTINCT sv.id) FROM services sv {where_sql}",
+            params,
+        )
+        total: int = cursor.fetchone()[0]
+        cursor.execute(
+            f"""
+            SELECT sv.*, COUNT(DISTINCT ss.song_id) AS song_count
+            FROM services sv
+            LEFT JOIN service_songs ss ON ss.service_id = sv.id
+            {where_sql}
+            GROUP BY sv.id
+            ORDER BY {order}
+            LIMIT ? OFFSET ?
+            """,
+            params + [per_page, offset],
+        )
+        return [dict(row) for row in cursor.fetchall()], total
+
+    def query_song_by_id(self, song_id: int) -> dict[str, Any] | None:
+        """Return a single song row or None."""
+        cursor = self._conn.cursor()
+        cursor.execute("SELECT * FROM songs WHERE id = ?", (song_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def query_song_editions(self, song_id: int) -> list[dict[str, Any]]:
+        """Return all editions for a song."""
+        cursor = self._conn.cursor()
+        cursor.execute(
+            "SELECT * FROM song_editions WHERE song_id = ? ORDER BY id",
+            (song_id,),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+    def query_song_services(self, song_id: int) -> list[dict[str, Any]]:
+        """Return all services where a song was performed."""
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            SELECT sv.id AS service_id, sv.service_date, sv.service_name, sv.song_leader,
+                   ss.ordinal,
+                   GROUP_CONCAT(DISTINCT ce.reproduction_type) AS copy_types
+            FROM services sv
+            JOIN service_songs ss ON ss.service_id = sv.id
+            LEFT JOIN copy_events ce ON ce.service_id = sv.id
+                                     AND ce.song_id = ss.song_id
+                                     AND ce.reportable = 1
+            WHERE ss.song_id = ?
+            GROUP BY sv.id
+            ORDER BY sv.service_date DESC
+            """,
+            (song_id,),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+    def query_service_by_id(self, service_id: int) -> dict[str, Any] | None:
+        """Return a single service row or None."""
+        cursor = self._conn.cursor()
+        cursor.execute("SELECT * FROM services WHERE id = ?", (service_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def query_service_songs(self, service_id: int) -> list[dict[str, Any]]:
+        """Return songs for a service in setlist order, with full credits."""
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            SELECT ss.ordinal, ss.occurrences,
+                   s.id AS song_id, s.display_title, s.canonical_title,
+                   se.publisher, se.words_by, se.music_by, se.arranger, se.copyright_notice,
+                   GROUP_CONCAT(ce.reproduction_type, ', ') AS copy_types
+            FROM service_songs ss
+            JOIN songs s ON ss.song_id = s.id
+            LEFT JOIN song_editions se ON ss.song_edition_id = se.id
+            LEFT JOIN copy_events ce ON ce.service_id = ss.service_id
+                                     AND ce.song_id = ss.song_id
+                                     AND ce.reportable = 1
+            WHERE ss.service_id = ?
+            GROUP BY ss.id
+            ORDER BY ss.ordinal
+            """,
+            (service_id,),
+        )
+        return [dict(row) for row in cursor.fetchall()]

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -252,9 +252,6 @@ async def root() -> RedirectResponse:
     return RedirectResponse(url="/songs")
 
 
-_SONGS_SORT_COLS = {"display_title", "words_by", "music_by", "arranger", "performance_count"}
-
-
 @app.get("/songs", response_class=HTMLResponse)
 async def songs(
     request: Request,
@@ -264,10 +261,12 @@ async def songs(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=50, ge=10, le=500),
 ) -> HTMLResponse:
-    sort = sort if sort in _SONGS_SORT_COLS else "performance_count"
+    sort = sort if sort in Database._SONGS_SORT_COLS else "performance_count"
     sort_dir = "asc" if sort_dir == "asc" else "desc"
     db = _get_db()
-    rows, total = _query_songs(db, q, sort=sort, sort_dir=sort_dir, page=page, per_page=per_page)
+    rows, total = db.query_songs_paginated(
+        q, sort=sort, sort_dir=sort_dir, page=page, per_page=per_page,
+    )
     db.close()
 
     total_pages = math.ceil(total / per_page) if total > 0 else 1
@@ -413,22 +412,19 @@ async def reports_stats_xlsx(
 @app.get("/songs/{song_id}", response_class=HTMLResponse)
 async def song_detail(request: Request, song_id: int) -> HTMLResponse:
     db = _get_db()
-    song = _query_song_by_id(db, song_id)
+    song = db.query_song_by_id(song_id)
     if not song:
         db.close()
         _log.warning("Song not found", extra={"song_id": song_id})
         raise HTTPException(status_code=404, detail="Song not found")
-    editions = _query_song_editions(db, song_id)
-    service_history = _query_song_services(db, song_id)
+    editions = db.query_song_editions(song_id)
+    service_history = db.query_song_services(song_id)
     db.close()
     return templates.TemplateResponse(
         request,
         "song_detail.html",
         {"song": song, "editions": editions, "service_history": service_history},
     )
-
-
-_SERVICES_SORT_COLS = {"service_date", "service_name", "song_leader", "preacher", "song_count"}
 
 
 @app.get("/services", response_class=HTMLResponse)
@@ -445,11 +441,11 @@ async def services_list(
     page: int = Query(default=1, ge=1),
     per_page: int = Query(default=50, ge=10, le=500),
 ) -> HTMLResponse:
-    sort = sort if sort in _SERVICES_SORT_COLS else "service_date"
+    sort = sort if sort in Database._SERVICES_SORT_COLS else "service_date"
     sort_dir = "asc" if sort_dir == "asc" else "desc"
     db = _get_db()
-    services, total = _query_all_services(
-        db, sort=sort, sort_dir=sort_dir,
+    services, total = db.query_all_services_paginated(
+        sort=sort, sort_dir=sort_dir,
         q_service=q_service, q_leader=q_leader, q_preacher=q_preacher,
         q_sermon=q_sermon, start_date=start_date, end_date=end_date,
         page=page, per_page=per_page,
@@ -470,12 +466,12 @@ async def services_list(
 @app.get("/services/{service_id}", response_class=HTMLResponse)
 async def service_detail(request: Request, service_id: int) -> HTMLResponse:
     db = _get_db()
-    service = _query_service_by_id(db, service_id)
+    service = db.query_service_by_id(service_id)
     if not service:
         db.close()
         _log.warning("Service not found", extra={"service_id": service_id})
         raise HTTPException(status_code=404, detail="Service not found")
-    songs = _query_service_songs(db, service_id)
+    songs = db.query_service_songs(service_id)
     db.close()
     return templates.TemplateResponse(
         request, "service_detail.html", {"service": service, "songs": songs}
@@ -705,186 +701,3 @@ async def get_job(job_id: str) -> JSONResponse:
     return JSONResponse(content=job)
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _query_songs(
-    db: Database,
-    search: str | None = None,
-    sort: str = "performance_count",
-    sort_dir: str = "desc",
-    page: int = 1,
-    per_page: int = 50,
-) -> tuple[list[dict[str, Any]], int]:
-    """Return songs with performance count, optionally filtered and sorted, with pagination."""
-    from worship_catalog.db import _safe_order_by
-    sort = _safe_order_by(sort, frozenset(_SONGS_SORT_COLS))
-    order = f"{sort} {sort_dir.upper()}, s.display_title"
-    cursor = db.cursor()
-    base = """
-        SELECT s.id, s.display_title, s.canonical_title,
-               se.words_by, se.music_by, se.arranger,
-               COUNT(DISTINCT ss.service_id) AS performance_count
-        FROM songs s
-        LEFT JOIN song_editions se ON se.song_id = s.id
-        LEFT JOIN service_songs ss ON ss.song_id = s.id
-    """
-    count_base = """
-        SELECT COUNT(DISTINCT s.id)
-        FROM songs s
-        LEFT JOIN song_editions se ON se.song_id = s.id
-        LEFT JOIN service_songs ss ON ss.song_id = s.id
-    """
-    offset = (page - 1) * per_page
-    if search:
-        like = f"%{search}%"
-        where = """
-            WHERE LOWER(s.display_title) LIKE LOWER(?)
-               OR LOWER(COALESCE(se.words_by, '')) LIKE LOWER(?)
-               OR LOWER(COALESCE(se.music_by, '')) LIKE LOWER(?)
-        """
-        cursor.execute(count_base + where, (like, like, like))
-        total = cursor.fetchone()[0]
-        cursor.execute(
-            base + where + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
-            (like, like, like, per_page, offset),
-        )
-    else:
-        cursor.execute(count_base)
-        total = cursor.fetchone()[0]
-        cursor.execute(base + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
-                       (per_page, offset))
-    return [dict(row) for row in cursor.fetchall()], total
-
-
-def _query_song_by_id(db: Database, song_id: int) -> dict[str, Any] | None:
-    cursor = db.cursor()
-    cursor.execute("SELECT * FROM songs WHERE id = ?", (song_id,))
-    row = cursor.fetchone()
-    return dict(row) if row else None
-
-
-def _query_song_editions(db: Database, song_id: int) -> list[dict[str, Any]]:
-    cursor = db.cursor()
-    cursor.execute(
-        "SELECT * FROM song_editions WHERE song_id = ? ORDER BY id",
-        (song_id,),
-    )
-    return [dict(row) for row in cursor.fetchall()]
-
-
-def _query_song_services(db: Database, song_id: int) -> list[dict[str, Any]]:
-    """Return all services where a song was performed, with position and copy types."""
-    cursor = db.cursor()
-    cursor.execute(
-        """
-        SELECT sv.id AS service_id, sv.service_date, sv.service_name, sv.song_leader,
-               ss.ordinal,
-               GROUP_CONCAT(DISTINCT ce.reproduction_type) AS copy_types
-        FROM services sv
-        JOIN service_songs ss ON ss.service_id = sv.id
-        LEFT JOIN copy_events ce ON ce.service_id = sv.id
-                                 AND ce.song_id = ss.song_id
-                                 AND ce.reportable = 1
-        WHERE ss.song_id = ?
-        GROUP BY sv.id
-        ORDER BY sv.service_date DESC
-        """,
-        (song_id,),
-    )
-    return [dict(row) for row in cursor.fetchall()]
-
-
-def _query_all_services(
-    db: Database,
-    sort: str = "service_date",
-    sort_dir: str = "desc",
-    q_service: str = "",
-    q_leader: str = "",
-    q_preacher: str = "",
-    q_sermon: str = "",
-    start_date: str = "",
-    end_date: str = "",
-    page: int = 1,
-    per_page: int = 50,
-) -> tuple[list[dict[str, Any]], int]:
-    """Return services with optional filtering, sorting, and pagination."""
-    where_clauses = []
-    params: list[Any] = []
-    if q_service:
-        where_clauses.append("LOWER(sv.service_name) LIKE LOWER(?)")
-        params.append(f"%{q_service}%")
-    if q_leader:
-        where_clauses.append("LOWER(COALESCE(sv.song_leader,'')) LIKE LOWER(?)")
-        params.append(f"%{q_leader}%")
-    if q_preacher:
-        where_clauses.append("LOWER(COALESCE(sv.preacher,'')) LIKE LOWER(?)")
-        params.append(f"%{q_preacher}%")
-    if q_sermon:
-        where_clauses.append("LOWER(COALESCE(sv.sermon_title,'')) LIKE LOWER(?)")
-        params.append(f"%{q_sermon}%")
-    if start_date:
-        where_clauses.append("sv.service_date >= ?")
-        params.append(start_date)
-    if end_date:
-        where_clauses.append("sv.service_date <= ?")
-        params.append(end_date)
-
-    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
-    from worship_catalog.db import _safe_order_by
-    sort = _safe_order_by(sort, frozenset(_SERVICES_SORT_COLS))
-    order = f"{sort} {sort_dir.upper()}, sv.service_name"
-    offset = (page - 1) * per_page
-    cursor = db.cursor()
-    # Count query
-    cursor.execute(
-        f"SELECT COUNT(DISTINCT sv.id) FROM services sv {where_sql}",
-        params,
-    )
-    total = cursor.fetchone()[0]
-    cursor.execute(
-        f"""
-        SELECT sv.*, COUNT(DISTINCT ss.song_id) AS song_count
-        FROM services sv
-        LEFT JOIN service_songs ss ON ss.service_id = sv.id
-        {where_sql}
-        GROUP BY sv.id
-        ORDER BY {order}
-        LIMIT ? OFFSET ?
-        """,
-        params + [per_page, offset],
-    )
-    return [dict(row) for row in cursor.fetchall()], total
-
-
-def _query_service_by_id(db: Database, service_id: int) -> dict[str, Any] | None:
-    """Return a single service row or None."""
-    cursor = db.cursor()
-    cursor.execute("SELECT * FROM services WHERE id = ?", (service_id,))
-    row = cursor.fetchone()
-    return dict(row) if row else None
-
-
-def _query_service_songs(db: Database, service_id: int) -> list[dict[str, Any]]:
-    """Return songs for a service in setlist order, with full credits."""
-    cursor = db.cursor()
-    cursor.execute(
-        """
-        SELECT ss.ordinal, ss.occurrences,
-               s.id AS song_id, s.display_title, s.canonical_title,
-               se.publisher, se.words_by, se.music_by, se.arranger, se.copyright_notice,
-               GROUP_CONCAT(ce.reproduction_type, ', ') AS copy_types
-        FROM service_songs ss
-        JOIN songs s ON ss.song_id = s.id
-        LEFT JOIN song_editions se ON ss.song_edition_id = se.id
-        LEFT JOIN copy_events ce ON ce.service_id = ss.service_id
-                                 AND ce.song_id = ss.song_id
-                                 AND ce.reportable = 1
-        WHERE ss.service_id = ?
-        GROUP BY ss.id
-        ORDER BY ss.ordinal
-        """,
-        (service_id,),
-    )
-    return [dict(row) for row in cursor.fetchall()]

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -1764,3 +1764,252 @@ class TestInsertCopyEventDeprecation:
             f"insert_or_get_copy_event must return same id for duplicate insert, "
             f"got {id1} and {id2}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Web query methods moved to Database (#166)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestQuerySongsPaginated:
+    """Tests for Database.query_songs_paginated (#166)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_returns_songs_with_performance_count(self, temp_db):
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        service_id = temp_db.insert_or_update_service(
+            "2026-01-01", "AM Worship", "test.pptx", "abc", song_leader="Matt"
+        )
+        temp_db.insert_service_song(service_id, song_id, ordinal=1)
+        rows, total = temp_db.query_songs_paginated()
+        assert total == 1
+        assert rows[0]["performance_count"] == 1
+
+    def test_search_filters_by_title(self, temp_db):
+        temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        temp_db.insert_or_get_song("holy holy holy", "Holy Holy Holy")
+        rows, total = temp_db.query_songs_paginated(search="amazing")
+        assert total == 1
+        assert rows[0]["display_title"] == "Amazing Grace"
+
+    def test_search_filters_by_credits(self, temp_db):
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        temp_db.insert_or_get_song_edition(song_id, words_by="John Newton")
+        rows, total = temp_db.query_songs_paginated(search="Newton")
+        assert total == 1
+
+    def test_pagination(self, temp_db):
+        for i in range(5):
+            temp_db.insert_or_get_song(f"song {i}", f"Song {i}")
+        rows, total = temp_db.query_songs_paginated(page=1, per_page=2)
+        assert total == 5
+        assert len(rows) == 2
+        rows2, _ = temp_db.query_songs_paginated(page=2, per_page=2)
+        assert len(rows2) == 2
+
+    def test_sort_by_display_title(self, temp_db):
+        temp_db.insert_or_get_song("b song", "B Song")
+        temp_db.insert_or_get_song("a song", "A Song")
+        rows, _ = temp_db.query_songs_paginated(sort="display_title", sort_dir="asc")
+        assert rows[0]["display_title"] == "A Song"
+
+    def test_invalid_sort_column_raises(self, temp_db):
+        with pytest.raises(ValueError, match="Invalid sort column"):
+            temp_db.query_songs_paginated(sort="DROP TABLE songs")
+
+    def test_empty_database(self, temp_db):
+        rows, total = temp_db.query_songs_paginated()
+        assert total == 0
+        assert rows == []
+
+
+@pytest.mark.integration
+class TestQueryAllServicesPaginated:
+    """Tests for Database.query_all_services_paginated (#166)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_returns_services_with_song_count(self, temp_db):
+        sid = temp_db.insert_or_update_service(
+            "2026-01-01", "AM", "f.pptx", "h1", song_leader="Alice"
+        )
+        song_id = temp_db.insert_or_get_song("test song", "Test Song")
+        temp_db.insert_service_song(sid, song_id, ordinal=1)
+        rows, total = temp_db.query_all_services_paginated()
+        assert total == 1
+        assert rows[0]["song_count"] == 1
+
+    def test_filter_by_leader(self, temp_db):
+        temp_db.insert_or_update_service("2026-01-01", "AM", "f.pptx", "h1", song_leader="Alice")
+        temp_db.insert_or_update_service("2026-01-08", "PM", "g.pptx", "h2", song_leader="Bob")
+        rows, total = temp_db.query_all_services_paginated(q_leader="Alice")
+        assert total == 1
+        assert rows[0]["song_leader"] == "Alice"
+
+    def test_filter_by_date_range(self, temp_db):
+        temp_db.insert_or_update_service("2026-01-01", "AM", "f.pptx", "h1")
+        temp_db.insert_or_update_service("2026-06-01", "AM", "g.pptx", "h2")
+        rows, total = temp_db.query_all_services_paginated(
+            start_date="2026-05-01", end_date="2026-07-01"
+        )
+        assert total == 1
+
+    def test_invalid_sort_column_raises(self, temp_db):
+        with pytest.raises(ValueError, match="Invalid sort column"):
+            temp_db.query_all_services_paginated(sort="malicious")
+
+    def test_empty_database(self, temp_db):
+        rows, total = temp_db.query_all_services_paginated()
+        assert total == 0
+        assert rows == []
+
+
+@pytest.mark.integration
+class TestQuerySongById:
+    """Tests for Database.query_song_by_id (#166)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_returns_song(self, temp_db):
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        result = temp_db.query_song_by_id(song_id)
+        assert result is not None
+        assert result["display_title"] == "Amazing Grace"
+
+    def test_returns_none_for_missing(self, temp_db):
+        assert temp_db.query_song_by_id(99999) is None
+
+
+@pytest.mark.integration
+class TestQuerySongEditions:
+    """Tests for Database.query_song_editions (#166)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_returns_editions_for_song(self, temp_db):
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        temp_db.insert_or_get_song_edition(song_id, words_by="John Newton")
+        editions = temp_db.query_song_editions(song_id)
+        assert len(editions) == 1
+        assert editions[0]["words_by"] == "John Newton"
+
+    def test_returns_empty_for_no_editions(self, temp_db):
+        song_id = temp_db.insert_or_get_song("new song", "New Song")
+        assert temp_db.query_song_editions(song_id) == []
+
+
+@pytest.mark.integration
+class TestQuerySongServices:
+    """Tests for Database.query_song_services (#166)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_returns_services_for_song(self, temp_db):
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        service_id = temp_db.insert_or_update_service(
+            "2026-01-01", "AM", "f.pptx", "h1", song_leader="Matt"
+        )
+        temp_db.insert_service_song(service_id, song_id, ordinal=1)
+        services = temp_db.query_song_services(song_id)
+        assert len(services) == 1
+        assert services[0]["service_date"] == "2026-01-01"
+        assert services[0]["song_leader"] == "Matt"
+
+    def test_returns_empty_for_unplayed_song(self, temp_db):
+        song_id = temp_db.insert_or_get_song("new song", "New Song")
+        assert temp_db.query_song_services(song_id) == []
+
+
+@pytest.mark.integration
+class TestQueryServiceById:
+    """Tests for Database.query_service_by_id (#166)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_returns_service(self, temp_db):
+        sid = temp_db.insert_or_update_service("2026-01-01", "AM", "f.pptx", "h1")
+        result = temp_db.query_service_by_id(sid)
+        assert result is not None
+        assert result["service_date"] == "2026-01-01"
+
+    def test_returns_none_for_missing(self, temp_db):
+        assert temp_db.query_service_by_id(99999) is None
+
+
+@pytest.mark.integration
+class TestQueryServiceSongs:
+    """Tests for Database.query_service_songs (#166)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_returns_songs_for_service(self, temp_db):
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        edition_id = temp_db.insert_or_get_song_edition(song_id, words_by="John Newton")
+        service_id = temp_db.insert_or_update_service("2026-01-01", "AM", "f.pptx", "h1")
+        temp_db.insert_service_song(service_id, song_id, ordinal=1, song_edition_id=edition_id)
+        songs = temp_db.query_service_songs(service_id)
+        assert len(songs) == 1
+        assert songs[0]["display_title"] == "Amazing Grace"
+        assert songs[0]["words_by"] == "John Newton"
+
+    def test_returns_empty_for_empty_service(self, temp_db):
+        sid = temp_db.insert_or_update_service("2026-01-01", "AM", "f.pptx", "h1")
+        assert temp_db.query_service_songs(sid) == []

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1720,12 +1720,13 @@ class TestDownloadFilenameContract:
 
 
 # ---------------------------------------------------------------------------
-# Issue #132 — ORDER BY whitelist guard inside _query_songs / _query_all_services
+# Issue #132 — ORDER BY whitelist guard inside query_songs_paginated / query_all_services_paginated
+# Methods moved from app.py to Database (#166)
 # ---------------------------------------------------------------------------
 
 
 class TestQuerySongsInternalWhitelist:
-    """_query_songs() must validate sort column internally — issue #132."""
+    """Database.query_songs_paginated() must validate sort column — issue #132."""
 
     @pytest.fixture
     def temp_db(self, tmp_path):
@@ -1737,40 +1738,35 @@ class TestQuerySongsInternalWhitelist:
         db.close()
 
     def test_valid_sort_col_works(self, temp_db):
-        """Passing a valid sort column to _query_songs succeeds without error."""
-        from worship_catalog.web.app import _query_songs
-        # Should not raise
-        rows, total = _query_songs(temp_db, sort="display_title", sort_dir="asc")
+        """Passing a valid sort column succeeds without error."""
+        rows, total = temp_db.query_songs_paginated(sort="display_title", sort_dir="asc")
         assert isinstance(rows, list)
 
     def test_invalid_sort_col_raises_value_error(self, temp_db):
-        """Passing an invalid sort column directly to _query_songs raises ValueError."""
-        from worship_catalog.web.app import _query_songs
+        """Invalid sort column raises ValueError."""
         with pytest.raises(ValueError, match="Invalid sort column"):
-            _query_songs(temp_db, sort="not_a_real_column")
+            temp_db.query_songs_paginated(sort="not_a_real_column")
 
     def test_sql_injection_sort_raises_value_error(self, temp_db):
-        """SQL injection string as sort column is rejected by _query_songs."""
-        from worship_catalog.web.app import _query_songs
+        """SQL injection string as sort column is rejected."""
         with pytest.raises(ValueError):
-            _query_songs(temp_db, sort="title; DROP TABLE songs--")
+            temp_db.query_songs_paginated(sort="title; DROP TABLE songs--")
 
     def test_empty_sort_col_raises_value_error(self, temp_db):
         """Empty string sort column is rejected."""
-        from worship_catalog.web.app import _query_songs
         with pytest.raises(ValueError):
-            _query_songs(temp_db, sort="")
+            temp_db.query_songs_paginated(sort="")
 
     def test_all_valid_songs_sort_cols_work(self, temp_db):
         """Every column in _SONGS_SORT_COLS must be accepted without error."""
-        from worship_catalog.web.app import _query_songs, _SONGS_SORT_COLS
-        for col in _SONGS_SORT_COLS:
-            rows, total = _query_songs(temp_db, sort=col)
+        from worship_catalog.db import Database
+        for col in Database._SONGS_SORT_COLS:
+            rows, total = temp_db.query_songs_paginated(sort=col)
             assert isinstance(rows, list), f"Column {col!r} failed unexpectedly"
 
 
 class TestQueryServicesInternalWhitelist:
-    """_query_all_services() must validate sort column internally — issue #132."""
+    """Database.query_all_services_paginated() must validate sort column — issue #132."""
 
     @pytest.fixture
     def temp_db(self, tmp_path):
@@ -1782,28 +1778,25 @@ class TestQueryServicesInternalWhitelist:
         db.close()
 
     def test_valid_sort_col_works(self, temp_db):
-        """Passing a valid sort column to _query_all_services succeeds."""
-        from worship_catalog.web.app import _query_all_services
-        rows, total = _query_all_services(temp_db, sort="service_date", sort_dir="asc")
+        """Passing a valid sort column succeeds."""
+        rows, total = temp_db.query_all_services_paginated(sort="service_date", sort_dir="asc")
         assert isinstance(rows, list)
 
     def test_invalid_sort_col_raises_value_error(self, temp_db):
-        """Invalid sort column to _query_all_services raises ValueError."""
-        from worship_catalog.web.app import _query_all_services
+        """Invalid sort column raises ValueError."""
         with pytest.raises(ValueError, match="Invalid sort column"):
-            _query_all_services(temp_db, sort="not_valid_col")
+            temp_db.query_all_services_paginated(sort="not_valid_col")
 
     def test_sql_injection_sort_raises_value_error(self, temp_db):
-        """SQL injection string as sort column raises ValueError in _query_all_services."""
-        from worship_catalog.web.app import _query_all_services
+        """SQL injection string as sort column raises ValueError."""
         with pytest.raises(ValueError):
-            _query_all_services(temp_db, sort="service_date; DROP TABLE services--")
+            temp_db.query_all_services_paginated(sort="service_date; DROP TABLE services--")
 
     def test_all_valid_services_sort_cols_work(self, temp_db):
         """Every column in _SERVICES_SORT_COLS must be accepted without error."""
-        from worship_catalog.web.app import _query_all_services, _SERVICES_SORT_COLS
-        for col in _SERVICES_SORT_COLS:
-            rows, total = _query_all_services(temp_db, sort=col)
+        from worship_catalog.db import Database
+        for col in Database._SERVICES_SORT_COLS:
+            rows, total = temp_db.query_all_services_paginated(sort=col)
             assert isinstance(rows, list), f"Column {col!r} failed unexpectedly"
 
 


### PR DESCRIPTION
## Summary
- Move 7 `_query_*` SQL functions from `web/app.py` into `Database` methods in `db.py`
- Move `_SONGS_SORT_COLS` and `_SERVICES_SORT_COLS` whitelists into `Database` class attributes
- Web routes now delegate to `db.query_songs_paginated()`, `db.query_all_services_paginated()`, etc.
- Removes ~180 lines of raw SQL from the web layer

Closes #166

## Test plan
- [x] 22 new integration tests for all 7 Database query methods
- [x] Updated existing sort-whitelist tests to use Database methods
- [x] Full suite: 781 passed, 0 failures
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)