### PR TITLE
fix(ci): add minimum test count to integration step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,16 @@ jobs:
       # This step explicitly runs the integration subset to surface any
       # unexpected skip-all regressions — closes #137.
       - name: Integration tests (DB-only subset)
-        run: python3 -m pytest -m "integration and not slow" -v --tb=short
+        run: |
+          python3 -m pytest -m "integration and not slow" -v --tb=short 2>&1 | tee /tmp/integration.log
+          # Verify at least 5 integration tests actually passed.
+          # Without this check, pytest -m exits 0 even when zero tests match,
+          # silently defeating the purpose of this step (#200).
+          count=$(grep -oP '\d+ passed' /tmp/integration.log | grep -oP '\d+')
+          if [ -z "$count" ] || [ "$count" -lt 5 ]; then
+            echo "ERROR: Expected at least 5 integration tests to pass, got ${count:-0}"
+            exit 1
+          fi
 
   security:
     runs-on: ubuntu-latest

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -1,0 +1,53 @@
+# tests/test_ci_config.py
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+CI_PATH = Path(".github/workflows/ci.yml")
+
+
+@pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
+class TestIntegrationTestStep:
+    """CI integration test step must enforce a minimum test count."""
+
+    def test_integration_step_exists(self) -> None:
+        """The CI workflow must have an integration test step."""
+        content = CI_PATH.read_text()
+        assert "integration and not slow" in content, (
+            "Integration test step not found in ci.yml"
+        )
+
+    def test_integration_step_uses_minimum_count(self) -> None:
+        """The integration test step must check that enough tests ran."""
+        workflow = yaml.safe_load(CI_PATH.read_text())
+        test_job = workflow["jobs"]["test"]
+        steps = test_job["steps"]
+
+        # Find the integration test step by name
+        integration_step = None
+        for step in steps:
+            run_cmd = step.get("run", "")
+            if "integration and not slow" in run_cmd:
+                integration_step = step
+                break
+
+        assert integration_step is not None, (
+            "Integration test step not found in ci.yml"
+        )
+
+        run_block = integration_step["run"]
+
+        # The run block must contain an explicit minimum count check.
+        # A bare `pytest -m ...` exits 0 even when zero tests match,
+        # so we need a post-run assertion that enough tests passed.
+        has_count_check = any(
+            keyword in run_block.lower()
+            for keyword in ["passed", "-lt", "minimum", "at least"]
+        )
+        assert has_count_check, (
+            "Integration test step has no minimum test count assertion — "
+            "if all integration tests disappear, CI will pass silently"
+        )


### PR DESCRIPTION
## Summary
- Adds a post-run assertion to the CI integration test step that verifies at least 5 integration tests actually passed
- Without this check, `pytest -m "integration and not slow"` exits 0 even when zero tests match the marker, silently defeating the purpose of the step added in #137
- Adds `tests/test_ci_config.py` to verify the CI workflow contains the minimum count check

Closes #200

## Test plan
- [x] New `tests/test_ci_config.py` with two tests: step existence and minimum count assertion
- [x] Tests written first and confirmed to fail before implementation
- [x] Full test suite passes (pre-existing failures in test_web.py are unrelated)
- [x] `ruff` and `mypy` pass with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)