### PR TITLE
fix(web): upload form broken — move JS to external file, fix CSRF/CSP cluster

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -104,6 +104,7 @@ services:
       - ./config:/config
     environment:
       - DB_PATH=/data/worship.db
+      - CSRF_SECRET=${CSRF_SECRET:-}
     restart: unless-stopped
     stop_grace_period: 35s            # 30s executor timeout + 5s margin (#135)
     healthcheck:

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -99,7 +99,7 @@ app.add_middleware(
 app.add_middleware(RequestLoggingMiddleware)
 
 # Content-Security-Policy — defence-in-depth against XSS (#197).
-# script-src allows 'self' plus the unpkg CDN for htmx.
+# All scripts must be external files served from /static/ (no inline JS).
 _CSP_POLICY: str = (
     "default-src 'self'; "
     "script-src 'self'; "
@@ -124,9 +124,6 @@ app.add_middleware(_CSPMiddleware)
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _STATIC_DIR = Path(__file__).parent / "static"
 templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
-app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
-
-_STATIC_DIR = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 
 

--- a/src/worship_catalog/web/static/upload.js
+++ b/src/worship_catalog/web/static/upload.js
@@ -1,0 +1,55 @@
+/**
+ * Upload form handler — reads CSRF cookie and submits via fetch with the token header.
+ * This must be an external file (not inline) to comply with CSP script-src 'self'.
+ */
+(function () {
+  "use strict";
+
+  function getCsrfToken() {
+    var token = "";
+    document.cookie.split(";").forEach(function (c) {
+      var parts = c.trim().split("=");
+      if (parts[0] === "csrftoken") token = parts[1];
+    });
+    return token;
+  }
+
+  var form = document.getElementById("upload-form");
+  if (!form) return;
+
+  form.addEventListener("submit", function (e) {
+    e.preventDefault();
+    var btn = form.querySelector("button[type=submit]");
+    var result = document.getElementById("upload-result");
+    btn.disabled = true;
+    btn.textContent = "Uploading\u2026";
+    result.innerHTML = "";
+
+    var data = new FormData(form);
+    fetch("/upload", {
+      method: "POST",
+      headers: { "X-CSRFToken": getCsrfToken() },
+      body: data,
+    })
+      .then(function (resp) {
+        if (resp.ok) return resp.json();
+        return resp.json().then(function (j) {
+          throw new Error(j.detail || resp.statusText);
+        });
+      })
+      .then(function (j) {
+        result.innerHTML =
+          '<p style="color:green;">Accepted &mdash; job ID: <code>' +
+          j.job_id +
+          "</code>. Import is running in the background.</p>";
+      })
+      .catch(function (err) {
+        result.innerHTML =
+          '<p style="color:#c00;">Upload failed: ' + err.message + "</p>";
+      })
+      .finally(function () {
+        btn.disabled = false;
+        btn.textContent = "Upload";
+      });
+  });
+})();

--- a/src/worship_catalog/web/templates/services.html
+++ b/src/worship_catalog/web/templates/services.html
@@ -72,7 +72,7 @@
 <div class="card" style="text-align:center;padding:2rem;">
   <h2>No services yet</h2>
   <p>Import your first worship service to get started.</p>
-  <p>Upload a PPTX file on the <a href="/reports">Reports</a> page, or run:</p>
+  <p>Upload a PPTX file on the <a href="/upload">Upload</a> page, or run:</p>
   <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
 </div>
 {% else %}

--- a/src/worship_catalog/web/templates/songs.html
+++ b/src/worship_catalog/web/templates/songs.html
@@ -40,7 +40,7 @@
 <div class="card" style="text-align:center;padding:2rem;">
   <h2>No songs yet</h2>
   <p>Import your first worship service to get started.</p>
-  <p>Upload a PPTX file on the <a href="/reports">Reports</a> page, or run:</p>
+  <p>Upload a PPTX file on the <a href="/upload">Upload</a> page, or run:</p>
   <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
 </div>
 {% else %}

--- a/src/worship_catalog/web/templates/upload.html
+++ b/src/worship_catalog/web/templates/upload.html
@@ -20,39 +20,5 @@
   <div id="upload-result" style="margin-top:1rem;"></div>
 </div>
 
-<script>
-document.getElementById("upload-form").addEventListener("submit", function(e) {
-  e.preventDefault();
-  var form = e.target;
-  var btn = form.querySelector("button[type=submit]");
-  var result = document.getElementById("upload-result");
-  btn.disabled = true;
-  btn.textContent = "Uploading\u2026";
-  result.innerHTML = "";
-
-  var csrfToken = "";
-  document.cookie.split(";").forEach(function(c) {
-    var parts = c.trim().split("=");
-    if (parts[0] === "csrftoken") csrfToken = parts[1];
-  });
-
-  var data = new FormData(form);
-  fetch("/upload", {
-    method: "POST",
-    headers: {"X-CSRFToken": csrfToken},
-    body: data
-  }).then(function(resp) {
-    if (resp.ok) return resp.json();
-    return resp.json().then(function(j) { throw new Error(j.detail || resp.statusText); });
-  }).then(function(j) {
-    result.innerHTML = '<p style="color:green;">Accepted &mdash; job ID: <code>' +
-      j.job_id + '</code>. Import is running in the background.</p>';
-  }).catch(function(err) {
-    result.innerHTML = '<p style="color:#c00;">Upload failed: ' + err.message + '</p>';
-  }).finally(function() {
-    btn.disabled = false;
-    btn.textContent = "Upload";
-  });
-});
-</script>
+<script src="/static/upload.js"></script>
 {% endblock %}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2776,3 +2776,97 @@ class TestHtmxSelfHosted:
         resp = client.get("/static/htmx.min.js")
         assert resp.status_code == 200
         assert "htmx" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Issue #251 — Upload form must work without inline scripts (CSP compat)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadFormCSPCompatible:
+    """Upload form must not use inline scripts (CSP blocks them)."""
+
+    def test_upload_page_has_no_inline_scripts(self, client):
+        """upload.html must not contain bare <script> tags (blocked by CSP)."""
+        resp = client.get("/upload")
+        assert resp.status_code == 200
+        # All <script> tags must have a src= attribute (external files)
+        import re
+        inline_scripts = re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", resp.text)
+        assert not inline_scripts, (
+            f"Page has {len(inline_scripts)} inline <script> tag(s) "
+            "which are blocked by CSP script-src 'self'"
+        )
+
+    def test_upload_js_served_from_static(self, client):
+        """upload.js must be available at /static/upload.js."""
+        resp = client.get("/static/upload.js")
+        assert resp.status_code == 200
+        assert "fetch" in resp.text, "upload.js must use fetch to POST the form"
+        assert "csrftoken" in resp.text.lower(), "upload.js must read the CSRF cookie"
+
+    def test_upload_form_references_external_js(self, client):
+        """upload.html must load upload.js from /static/."""
+        resp = client.get("/upload")
+        assert "/static/upload.js" in resp.text
+
+
+class TestReportFormsCSPCompatible:
+    """Report download forms must handle CSRF without inline scripts (#238)."""
+
+    def test_reports_page_has_no_inline_scripts(self, client):
+        """reports.html must not use inline scripts."""
+        resp = client.get("/reports")
+        assert resp.status_code == 200
+        import re
+        inline_scripts = re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", resp.text)
+        assert not inline_scripts, (
+            "Reports page has inline scripts blocked by CSP"
+        )
+
+    def test_ccli_download_form_posts_with_csrf(self, client):
+        """CCLI CSV download must succeed (not 403) when submitted."""
+        resp = client.post(
+            "/reports/ccli",
+            data={"start_date": "2026-01-01", "end_date": "2026-12-31"},
+        )
+        assert resp.status_code != 403, "CCLI download returned 403 — CSRF token missing"
+
+    def test_stats_form_posts_with_csrf(self, client):
+        """Stats report must succeed (not 403) when submitted."""
+        resp = client.post(
+            "/reports/stats",
+            data={"start_date": "2026-01-01", "end_date": "2026-12-31"},
+        )
+        assert resp.status_code != 403, "Stats report returned 403 — CSRF token missing"
+
+
+class TestEmptyStateLinkTarget:
+    """Empty state card must link to Upload page, not Reports (#240)."""
+
+    def test_songs_empty_state_links_to_upload(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "empty.db"
+        db = Database(db_path)
+        db.connect()
+        db.init_schema()
+        db.close()
+        monkeypatch.setenv("DB_PATH", str(db_path))
+        monkeypatch.setenv("INBOX_DIR", str(tmp_path / "inbox"))
+        (tmp_path / "inbox").mkdir()
+        from importlib import reload
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        empty_client = TestClient(app_module.app)
+        resp = empty_client.get("/songs")
+        assert "/upload" in resp.text, "Empty state must link to /upload, not /reports"
+
+
+class TestNoDuplicateStaticMount:
+    """Static files must be mounted exactly once (#234)."""
+
+    def test_static_mount_not_duplicated(self):
+        import worship_catalog.web.app as app_module
+        import inspect
+        source = inspect.getsource(app_module)
+        count = source.count('app.mount("/static"')
+        assert count == 1, f"app.mount('/static') appears {count} times, expected 1"


### PR DESCRIPTION
## Summary

The upload form was **completely non-functional in real browsers**. CSP `script-src 'self'` blocked the inline `<script>` that sends the CSRF token, causing the form to fall back to a GET request (browser default). No upload ever reached the server.

### Fixes in this PR

| Issue | Fix |
|---|---|
| **#251** | Move upload JS from inline `<script>` to `/static/upload.js` (CSP-compatible) |
| **#247** | Same root cause — CSP blocking inline JS |
| **#234** | Remove duplicate `app.mount("/static")` call |
| **#240** | Empty state cards link to `/upload` instead of `/reports` |
| **#237** | Add `CSRF_SECRET` to local `compose.yml` web service |

Closes #251, closes #247, closes #234, closes #240, closes #237

## Test plan
- [x] `TestUploadFormCSPCompatible` — no inline scripts, upload.js served, references external JS
- [x] `TestReportFormsCSPCompatible` — report forms work with CSRF
- [x] `TestEmptyStateLinkTarget` — links to /upload
- [x] `TestNoDuplicateStaticMount` — exactly one static mount
- [x] Full suite: 847 passed, 0 failures
- [ ] Manual: upload PPTX via browser on Pi after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)