### PR TITLE
fix(scripts): add CSRF token handling to PowerShell upload script

### DIFF
--- a/scripts/Submit-WorshipSlides.ps1
+++ b/scripts/Submit-WorshipSlides.ps1
@@ -94,10 +94,32 @@ function Save-Manifest {
     $Manifest | ConvertTo-Json -Depth 3 | Set-Content $manifestPath -Encoding UTF8
 }
 
+function Get-CsrfToken {
+    # Fetch /health to obtain the csrftoken cookie from the CSRF middleware.
+    # Use a WebSession so the cookie jar is populated automatically.
+    $baseUrl = $uploadUrl -replace '/upload$', ''
+    $healthUrl = "$baseUrl/health"
+    $session = New-Object Microsoft.PowerShell.Commands.WebRequestSession
+    Invoke-WebRequest -Uri $healthUrl -Method Get -WebSession $session -UseBasicParsing -TimeoutSec 15 | Out-Null
+    $csrfCookie = $session.Cookies.GetCookies($healthUrl) | Where-Object { $_.Name -eq "csrftoken" }
+    if (-not $csrfCookie) {
+        throw "Failed to obtain csrftoken cookie from $healthUrl"
+    }
+    return @{
+        Token   = $csrfCookie.Value
+        Session = $session
+    }
+}
+
 function Submit-File {
     param([string]$FilePath)
     $fileName = Split-Path $FilePath -Leaf
     $mimeType = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
+    # Obtain CSRF token before uploading (#235)
+    $csrf = Get-CsrfToken
+    $csrfToken = $csrf.Token
+    $session = $csrf.Session
 
     # Build multipart form data
     $fileBytes = [System.IO.File]::ReadAllBytes($FilePath)
@@ -119,9 +141,12 @@ function Submit-File {
     [System.Buffer]::BlockCopy($fileBytes, 0, $body, $headerBytes.Length, $fileBytes.Length)
     [System.Buffer]::BlockCopy($footerBytes, 0, $body, $headerBytes.Length + $fileBytes.Length, $footerBytes.Length)
 
-    $headers = @{ "Content-Type" = "multipart/form-data; boundary=$boundary" }
+    $headers = @{
+        "Content-Type"  = "multipart/form-data; boundary=$boundary"
+        "X-CSRFToken"   = $csrfToken
+    }
 
-    $response = Invoke-RestMethod -Uri $uploadUrl -Method Post -Body $body -Headers $headers -TimeoutSec 60
+    $response = Invoke-RestMethod -Uri $uploadUrl -Method Post -Body $body -Headers $headers -WebSession $session -TimeoutSec 60
     return $response
 }
 

--- a/tests/test_scripts.bats
+++ b/tests/test_scripts.bats
@@ -178,3 +178,24 @@
   run grep -E "sk-ant-|real-password|actual-token" scripts/Submit-WorshipSlides.env.example
   [ "$status" -ne 0 ]
 }
+
+# ---------------------------------------------------------------------------
+# Submit-WorshipSlides.ps1 CSRF token handling (#235)
+# ---------------------------------------------------------------------------
+
+@test "Submit-WorshipSlides.ps1 fetches CSRF token before upload" {
+  # The script must GET a page to obtain the csrftoken cookie
+  grep -q "csrftoken" scripts/Submit-WorshipSlides.ps1
+}
+
+@test "Submit-WorshipSlides.ps1 sends X-CSRFToken header on POST" {
+  grep -q "X-CSRFToken" scripts/Submit-WorshipSlides.ps1
+}
+
+@test "Submit-WorshipSlides.ps1 GETs health or upload page for CSRF cookie" {
+  # Must make a GET request to obtain the CSRF cookie before POSTing
+  grep -qE "Invoke-WebRequest|Invoke-RestMethod" scripts/Submit-WorshipSlides.ps1
+  # Verify it GETs a page (not just POSTs)
+  grep -q "Method.*Get\|GET\|-Method Get" scripts/Submit-WorshipSlides.ps1 || \
+    grep -q "SessionVariable" scripts/Submit-WorshipSlides.ps1
+}

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -681,3 +681,47 @@ class TestContentSecurityPolicy:
         assert resp.status_code == 200
         csp = resp.headers.get("content-security-policy")
         assert csp is not None, "Reports page missing CSP header"
+
+
+# ---------------------------------------------------------------------------
+# Issue #235 — Upload CSRF integration (PowerShell script compatibility)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def raw_client(db_with_songs, tmp_path, monkeypatch):
+    """Plain TestClient without CSRF token injection — for CSRF security tests."""
+    inbox = tmp_path / "inbox"
+    inbox.mkdir()
+    monkeypatch.setenv("DB_PATH", str(db_with_songs))
+    monkeypatch.setenv("INBOX_DIR", str(inbox))
+    from importlib import reload
+    import worship_catalog.web.app as app_module
+    reload(app_module)
+    return TestClient(app_module.app)
+
+
+class TestUploadCsrfIntegration:
+    """Upload endpoint CSRF behavior — issue #235."""
+
+    def test_upload_without_csrf_returns_403(self, raw_client):
+        """POST /upload without CSRF token must be rejected with 403."""
+        pptx_mime = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        resp = raw_client.post(
+            "/upload",
+            files={"file": ("test.pptx", io.BytesIO(b"PK\x03\x04dummy"), pptx_mime)},
+        )
+        assert resp.status_code == 403, (
+            f"Expected 403 for missing CSRF token, got {resp.status_code}"
+        )
+
+    def test_upload_with_csrf_token_succeeds(self, client):
+        """POST /upload with valid CSRF token must not be rejected by CSRF middleware."""
+        pptx_mime = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        # CsrfAwareClient automatically includes the token
+        resp = client.post(
+            "/upload",
+            files={"file": ("test.pptx", io.BytesIO(b"PK\x03\x04dummy"), pptx_mime)},
+        )
+        # 400 is OK here (bad PPTX content), but not 403 (CSRF rejection)
+        assert resp.status_code != 403, "CSRF token was rejected despite being valid"


### PR DESCRIPTION
## Summary
- **Submit-WorshipSlides.ps1** was POSTing to `/upload` without a CSRF token, causing 403 Forbidden errors from the CSRF middleware — breaking the entire automated Windows upload pipeline
- Added `Get-CsrfToken` function that GETs `/health` to obtain the `csrftoken` cookie via a `WebSession`, then sends both the cookie and `X-CSRFToken` header on the upload POST
- Added bats tests verifying the script contains CSRF token handling (csrftoken reference, X-CSRFToken header, GET request for cookie)
- Added Python integration tests in `test_web_security.py` confirming upload rejects without CSRF (403) and accepts with valid CSRF token

Closes #235

## Test plan
- [x] Bats tests confirm PS1 script contains `csrftoken`, `X-CSRFToken`, and GET-before-POST pattern
- [x] Python test `test_upload_without_csrf_returns_403` confirms upload rejects missing token
- [x] Python test `test_upload_with_csrf_token_succeeds` confirms upload accepts valid token
- [x] Full test suite: 841 passed, 19 skipped
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)