### PR TITLE
fix(web): send Pushover notifications on early upload rejections

### DIFF
--- a/src/worship_catalog/notify.py
+++ b/src/worship_catalog/notify.py
@@ -35,6 +35,7 @@ def send_pushover(
     app_token = os.environ.get("PUSHOVER_APP_TOKEN", "")
 
     if not user_key or not app_token:
+        _log.debug("Pushover notification skipped — credentials not configured")
         return
 
     payload = urllib.parse.urlencode(

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -814,6 +814,12 @@ async def upload(
     if cl_header is not None:
         try:
             if int(cl_header) > MAX_UPLOAD_BYTES:
+                _max_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
+                send_pushover(
+                    title="Upload rejected",
+                    message=f"File exceeds {_max_mb} MB limit (Content-Length: {cl_header})",
+                    priority=-1,
+                )
                 return JSONResponse(
                     content={"detail": f"File exceeds maximum allowed size of {MAX_UPLOAD_BYTES} bytes"},  # noqa: E501
                     status_code=413,
@@ -824,6 +830,11 @@ async def upload(
             )
     # Validate MIME type
     if file.content_type != _PPTX_MIME:
+        send_pushover(
+            title="Upload rejected",
+            message=f"Wrong MIME type: {file.content_type}",
+            priority=-1,
+        )
         return JSONResponse(
             content={"detail": "Only PPTX files are accepted (pptx mime type required)"},
             status_code=400,
@@ -833,6 +844,11 @@ async def upload(
     filename = _sanitize_header_filename(raw_filename)
     # Validate extension (re-check after sanitization)
     if not filename.lower().endswith(".pptx"):
+        send_pushover(
+            title="Upload rejected",
+            message=f"{filename} — file must have a .pptx extension",
+            priority=-1,
+        )
         return JSONResponse(
             content={"detail": "File must have a .pptx extension"},
             status_code=400,
@@ -847,6 +863,12 @@ async def upload(
     # Read and enforce size limit
     content = await file.read()
     if len(content) > MAX_UPLOAD_BYTES:
+        _max_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
+        send_pushover(
+            title="Upload rejected",
+            message=f"{filename} — file exceeds {_max_mb} MB limit",
+            priority=-1,
+        )
         return JSONResponse(
             content={"detail": f"File exceeds maximum allowed size of {MAX_UPLOAD_BYTES} bytes"},
             status_code=413,

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -44,6 +44,18 @@ class TestSendPushover:
             send_pushover(title="Test", message="Test message")
             mock_urlopen.assert_not_called()
 
+    def test_missing_credentials_logs_debug(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When credentials are missing, send_pushover should log at DEBUG level."""
+        monkeypatch.delenv("PUSHOVER_USER_KEY", raising=False)
+        monkeypatch.delenv("PUSHOVER_APP_TOKEN", raising=False)
+        from worship_catalog.notify import send_pushover
+
+        with patch("worship_catalog.notify._log") as mock_log:
+            send_pushover(title="Test", message="Test message")
+            mock_log.debug.assert_called_once()
+            assert "not configured" in mock_log.debug.call_args[0][0].lower() or \
+                   "skipped" in mock_log.debug.call_args[0][0].lower()
+
     def test_failure_notification_includes_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Failed import notification should include the error summary."""
         monkeypatch.setenv("PUSHOVER_USER_KEY", "u")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3015,3 +3015,75 @@ class TestDbConnectionCleanup:
             f"Found {direct_calls} direct _get_db() call(s) in route handlers. "
             "Routes must use Depends(get_db) for automatic connection cleanup."
         )
+
+
+# ---------------------------------------------------------------------------
+# Pushover notifications on early upload rejections (#267)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadRejectionPushover:
+    """Early upload rejection paths (413, 400) must send Pushover notifications."""
+
+    def test_pushover_called_on_oversized_upload(self, client, monkeypatch):
+        """413 rejection must send a Pushover notification with low priority."""
+        from unittest.mock import MagicMock
+        import worship_catalog.web.app as app_module
+
+        mock_pushover = MagicMock()
+        monkeypatch.setattr(app_module, "send_pushover", mock_pushover)
+        monkeypatch.setattr(app_module, "MAX_UPLOAD_BYTES", 10)
+
+        resp = _upload(client, b"X" * 100, "big.pptx", VALID_PPTX_MIME)
+        assert resp.status_code == 413
+        mock_pushover.assert_called_once()
+        call_kwargs = mock_pushover.call_args[1]
+        assert call_kwargs["priority"] == -1
+        assert "rejected" in call_kwargs["title"].lower() or "upload" in call_kwargs["title"].lower()
+
+    def test_pushover_called_on_bad_mime_type(self, client, monkeypatch):
+        """400 wrong MIME rejection must send a Pushover notification."""
+        from unittest.mock import MagicMock
+        import worship_catalog.web.app as app_module
+
+        mock_pushover = MagicMock()
+        monkeypatch.setattr(app_module, "send_pushover", mock_pushover)
+
+        resp = _upload(client, b"hello", "test.txt", "text/plain")
+        assert resp.status_code == 400
+        mock_pushover.assert_called_once()
+        call_kwargs = mock_pushover.call_args[1]
+        assert call_kwargs["priority"] == -1
+
+    def test_pushover_called_on_bad_extension(self, client, monkeypatch):
+        """400 wrong extension rejection must send a Pushover notification."""
+        from unittest.mock import MagicMock
+        import worship_catalog.web.app as app_module
+
+        mock_pushover = MagicMock()
+        monkeypatch.setattr(app_module, "send_pushover", mock_pushover)
+
+        resp = _upload(client, SMALL_PPTX_BYTES, "sunday.ppt", VALID_PPTX_MIME)
+        assert resp.status_code == 400
+        mock_pushover.assert_called_once()
+        call_kwargs = mock_pushover.call_args[1]
+        assert call_kwargs["priority"] == -1
+
+    def test_pushover_called_on_content_length_rejection(self, client, monkeypatch):
+        """413 from Content-Length pre-flight must also send a notification."""
+        from unittest.mock import MagicMock
+        import worship_catalog.web.app as app_module
+
+        mock_pushover = MagicMock()
+        monkeypatch.setattr(app_module, "send_pushover", mock_pushover)
+        monkeypatch.setattr(app_module, "MAX_UPLOAD_BYTES", 10)
+
+        resp = client.post(
+            "/upload",
+            files={"file": ("big.pptx", io.BytesIO(b"X" * 5), VALID_PPTX_MIME)},
+            headers={"content-length": "999999"},
+        )
+        assert resp.status_code == 413
+        mock_pushover.assert_called_once()
+        call_kwargs = mock_pushover.call_args[1]
+        assert call_kwargs["priority"] == -1


### PR DESCRIPTION
## Summary

- **Part 2:** Upload validation failures (413 oversized, 400 bad MIME, 400 bad extension) now call `send_pushover()` with `priority=-1` so operators get mobile alerts for rejected uploads, not just successful/failed imports.
- **Part 3:** `send_pushover()` now logs at DEBUG when credentials are missing, making it diagnosable when Pushover is silently disabled on a deployment.
- **Part 1 (deploy):** Verified `deploy/pi/docker-compose.yml` already passes `PUSHOVER_USER_KEY` and `PUSHOVER_APP_TOKEN` — the Pi just needs the values in `/opt/song-history/.env`.

Closes #267

## Test plan

- [x] `test_pushover_called_on_oversized_upload` — 413 body-size rejection sends notification
- [x] `test_pushover_called_on_bad_mime_type` — 400 MIME rejection sends notification
- [x] `test_pushover_called_on_bad_extension` — 400 extension rejection sends notification
- [x] `test_pushover_called_on_content_length_rejection` — 413 Content-Length pre-flight sends notification
- [x] `test_missing_credentials_logs_debug` — missing env vars produce a DEBUG log line
- [x] Full suite: 870 passed, 0 failed
- [x] ruff + mypy: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)