### PR TITLE
feat(cli): add cleanup command tests and documentation

### DIFF
--- a/docs/data-cleanup.md
+++ b/docs/data-cleanup.md
@@ -1,0 +1,87 @@
+# Data Cleanup
+
+Commands for fixing bad data in the worship catalog database. Common scenarios:
+
+- **Bad import** -- A file was imported with wrong metadata (e.g. `0000-00-00` date). The service needs to be deleted so the file can be re-imported after the bug is fixed.
+- **Modified file re-import** -- If a PPTX is edited and re-imported, the file hash changes. The old service with stale data remains as a duplicate.
+- **Orphaned songs** -- After deleting services, song rows with 0 performances accumulate in the database.
+
+## Command Reference
+
+### delete-service
+
+Delete one or more services and all related data (service\_songs, copy\_events).
+
+```bash
+# Delete by service ID
+worship-catalog cleanup delete-service --id 30 --db data/worship.db --yes
+
+# Delete all services with a specific date
+worship-catalog cleanup delete-service --date 0000-00-00 --db data/worship.db --yes
+
+# Delete services matching date AND name pattern
+worship-catalog cleanup delete-service --date 2026-02-15 --name "AM" --db data/worship.db --yes
+
+# Preview what would be deleted (no changes made)
+worship-catalog cleanup delete-service --id 30 --db data/worship.db --dry-run
+```
+
+### orphaned-songs
+
+Find and remove songs that have 0 performances (no service\_songs rows). Also removes their song\_editions and copy\_events.
+
+```bash
+# Preview orphaned songs
+worship-catalog cleanup orphaned-songs --db data/worship.db --dry-run
+
+# Remove orphaned songs
+worship-catalog cleanup orphaned-songs --db data/worship.db --yes
+```
+
+### find-duplicates
+
+List services that share the same (service\_date, service\_name) but have different source\_hash values. Helps identify re-import conflicts.
+
+```bash
+worship-catalog cleanup find-duplicates --db data/worship.db
+```
+
+## Docker Usage
+
+On the Pi (production), run commands inside the container:
+
+```bash
+# Using the cli compose service (volumes pre-configured)
+docker compose run --rm cli cleanup find-duplicates
+docker compose run --rm cli cleanup delete-service --date 0000-00-00 --yes
+docker compose run --rm cli cleanup orphaned-songs --dry-run
+docker compose run --rm cli cleanup orphaned-songs --yes
+
+# Or using docker compose exec on the running service
+docker compose exec song-history worship-catalog cleanup find-duplicates --db /data/worship.db
+docker compose exec song-history worship-catalog cleanup delete-service --id 30 --db /data/worship.db --yes
+```
+
+## Re-import Workflow
+
+After fixing a bug that caused bad data, follow this workflow:
+
+```bash
+# 1. ALWAYS backup before cleanup
+/opt/song-history/scripts/backup.sh /opt/song-history/data/worship.db /opt/song-history/backups-usb
+
+# 2. Delete the bad services
+docker compose run --rm cli cleanup delete-service --date 0000-00-00 --yes
+
+# 3. Re-import the affected files
+docker compose run --rm cli import /inbox/"AM Worship 2025.09.28.pptx"
+
+# 4. Clean up orphaned songs left behind
+docker compose run --rm cli cleanup orphaned-songs --yes
+```
+
+## Safety
+
+- All destructive commands require `--yes` or interactive confirmation.
+- Use `--dry-run` to preview changes before committing.
+- Always back up the database before running cleanup commands.

--- a/docs/pi-deploy.md
+++ b/docs/pi-deploy.md
@@ -325,6 +325,29 @@ docker compose pull && docker compose up -d
 
 ---
 
+## Data Maintenance
+
+Use the `cleanup` CLI commands to fix bad data. Always back up first.
+
+```bash
+# Back up the database
+/opt/song-history/scripts/backup.sh /opt/song-history/data/worship.db /opt/song-history/backups-usb
+
+# Find duplicate services (same date+name, different file hash)
+docker compose run --rm cli cleanup find-duplicates
+
+# Delete services with bad date from a buggy import
+docker compose run --rm cli cleanup delete-service --date 0000-00-00 --yes
+
+# Remove orphaned songs left after service deletion
+docker compose run --rm cli cleanup orphaned-songs --dry-run
+docker compose run --rm cli cleanup orphaned-songs --yes
+```
+
+See [docs/data-cleanup.md](data-cleanup.md) for the full command reference and re-import workflow.
+
+---
+
 ## Troubleshooting
 
 | Symptom | Check |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1807,3 +1807,175 @@ class TestReportHelpDiscoverability:
         assert "ccli" in result.output, (
             f"'ccli' not found in report --help output:\n{result.output}"
         )
+
+
+class TestCleanupCommand:
+    """Tests for cleanup command group (#266)."""
+
+    @pytest.fixture
+    def runner(self):
+        """Click CLI test runner."""
+        return CliRunner()
+
+    def test_cleanup_help(self, runner):
+        """cleanup --help lists subcommands."""
+        result = runner.invoke(main, ["cleanup", "--help"])
+        assert result.exit_code == 0
+        assert "delete-service" in result.output
+        assert "orphaned-songs" in result.output
+        assert "find-duplicates" in result.output
+
+    def test_delete_service_by_id(self, runner, db_with_songs):
+        """cleanup delete-service --id <N> removes the service and related data."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--id", "1", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_service_by_id(1) is None
+        db.close()
+
+    def test_delete_service_by_id_shows_details(self, runner, db_with_songs):
+        """cleanup delete-service --id <N> shows service details before deleting."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--id", "1", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        assert "2026-02-15" in result.output
+        assert "AM Worship" in result.output
+
+    def test_delete_service_by_id_not_found(self, runner, db_with_songs):
+        """cleanup delete-service --id <N> exits 1 when service not found."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--id", "999", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 1
+
+    def test_delete_service_by_date(self, runner, db_with_songs):
+        """cleanup delete-service --date YYYY-MM-DD removes matching services."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--date", "2026-02-15",
+            "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_service_by_id(1) is None
+        db.close()
+
+    def test_delete_service_by_date_with_name(self, runner, db_with_songs):
+        """cleanup delete-service --date --name filters by name pattern."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--date", "2026-02-15", "--name", "AM",
+            "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_service_by_id(1) is None
+        db.close()
+
+    def test_delete_service_by_date_no_match(self, runner, db_with_songs):
+        """cleanup delete-service --date with no matches exits 1."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--date", "1999-01-01",
+            "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 1
+
+    def test_delete_service_requires_id_or_date(self, runner, db_with_songs):
+        """cleanup delete-service without --id or --date exits with error."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code != 0
+
+    def test_orphaned_songs(self, runner, db_with_songs):
+        """cleanup orphaned-songs removes songs with 0 performances."""
+        # First delete a service to create orphans
+        db = Database(db_with_songs)
+        db.connect()
+        db.delete_service_data(1)
+        db.close()
+
+        result = runner.invoke(main, [
+            "cleanup", "orphaned-songs", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        assert "removed" in result.output.lower() or "deleted" in result.output.lower()
+
+        # Verify songs are gone
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_song_by_id(1) is None
+        assert db.query_song_by_id(2) is None
+        db.close()
+
+    def test_orphaned_songs_none_found(self, runner, db_with_songs):
+        """cleanup orphaned-songs with no orphans reports none found."""
+        result = runner.invoke(main, [
+            "cleanup", "orphaned-songs", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        assert "no orphaned" in result.output.lower() or "0" in result.output
+
+    def test_find_duplicates(self, runner, db_with_songs):
+        """cleanup find-duplicates lists services with same date+name but different hash."""
+        # Insert a duplicate service with different hash
+        db = Database(db_with_songs)
+        db.connect()
+        db.insert_or_update_service(
+            service_date="2026-02-15",
+            service_name="AM Worship",
+            source_file="test2.pptx",
+            source_hash="def456",
+        )
+        db.close()
+
+        result = runner.invoke(main, [
+            "cleanup", "find-duplicates", "--db", str(db_with_songs)
+        ])
+        assert result.exit_code == 0
+        assert "2026-02-15" in result.output
+        assert "AM Worship" in result.output
+
+    def test_find_duplicates_none(self, runner, db_with_songs):
+        """cleanup find-duplicates with no duplicates reports none."""
+        result = runner.invoke(main, [
+            "cleanup", "find-duplicates", "--db", str(db_with_songs)
+        ])
+        assert result.exit_code == 0
+        assert "no duplicate" in result.output.lower()
+
+    def test_dry_run_does_not_delete(self, runner, db_with_songs):
+        """--dry-run shows what would be deleted without actually deleting."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-service", "--id", "1",
+            "--db", str(db_with_songs), "--dry-run"
+        ])
+        assert result.exit_code == 0
+        assert "dry run" in result.output.lower() or "would" in result.output.lower()
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_service_by_id(1) is not None  # NOT deleted
+        db.close()
+
+    def test_dry_run_orphaned_songs(self, runner, db_with_songs):
+        """--dry-run on orphaned-songs does not delete."""
+        db = Database(db_with_songs)
+        db.connect()
+        db.delete_service_data(1)
+        db.close()
+
+        result = runner.invoke(main, [
+            "cleanup", "orphaned-songs", "--db", str(db_with_songs), "--dry-run"
+        ])
+        assert result.exit_code == 0
+        assert "would" in result.output.lower() or "dry run" in result.output.lower()
+
+        # Songs still exist
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_song_by_id(1) is not None
+        db.close()

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2141,3 +2141,92 @@ class TestQueryServiceSongs:
     def test_returns_empty_for_empty_service(self, temp_db):
         sid = temp_db.insert_or_update_service("2026-01-01", "AM", "f.pptx", "h1")
         assert temp_db.query_service_songs(sid) == []
+
+
+class TestCleanupQueries:
+    """Tests for cleanup-related database methods (#266)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_query_services_by_date(self, temp_db):
+        """query_services_by_date returns services matching the date."""
+        temp_db.insert_or_update_service("2026-02-15", "AM Worship", "f.pptx", "h1")
+        temp_db.insert_or_update_service("2026-02-16", "PM Worship", "g.pptx", "h2")
+        results = temp_db.query_services_by_date("2026-02-15")
+        assert len(results) == 1
+        assert results[0]["service_name"] == "AM Worship"
+
+    def test_query_services_by_date_with_name_pattern(self, temp_db):
+        """query_services_by_date with name_pattern filters by name."""
+        temp_db.insert_or_update_service("2026-02-15", "AM Worship", "f.pptx", "h1")
+        temp_db.insert_or_update_service("2026-02-15", "PM Worship", "g.pptx", "h2")
+        results = temp_db.query_services_by_date("2026-02-15", name_pattern="AM")
+        assert len(results) == 1
+        assert results[0]["service_name"] == "AM Worship"
+
+    def test_query_services_by_date_no_match(self, temp_db):
+        """query_services_by_date returns empty list for no matches."""
+        temp_db.insert_or_update_service("2026-02-15", "AM Worship", "f.pptx", "h1")
+        assert temp_db.query_services_by_date("1999-01-01") == []
+
+    def test_query_orphaned_songs(self, temp_db):
+        """query_orphaned_songs returns songs with no service_songs rows."""
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        temp_db.insert_or_get_song_edition(song_id, words_by="John Newton")
+        results = temp_db.query_orphaned_songs()
+        assert len(results) == 1
+        assert results[0]["canonical_title"] == "amazing grace"
+
+    def test_query_orphaned_songs_excludes_performed(self, temp_db):
+        """query_orphaned_songs excludes songs with service_songs rows."""
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        service_id = temp_db.insert_or_update_service("2026-02-15", "AM", "f.pptx", "h1")
+        temp_db.insert_service_song(service_id, song_id, ordinal=1)
+        results = temp_db.query_orphaned_songs()
+        assert len(results) == 0
+
+    def test_query_duplicate_services(self, temp_db):
+        """query_duplicate_services returns groups with same date+name, different hash."""
+        temp_db.insert_or_update_service("2026-02-15", "AM Worship", "f.pptx", "h1")
+        temp_db.insert_or_update_service("2026-02-15", "AM Worship", "g.pptx", "h2")
+        results = temp_db.query_duplicate_services()
+        assert len(results) >= 2
+        dates = [r["service_date"] for r in results]
+        assert "2026-02-15" in dates
+
+    def test_query_duplicate_services_none(self, temp_db):
+        """query_duplicate_services returns empty list when no duplicates."""
+        temp_db.insert_or_update_service("2026-02-15", "AM Worship", "f.pptx", "h1")
+        results = temp_db.query_duplicate_services()
+        assert len(results) == 0
+
+    def test_delete_song(self, temp_db):
+        """delete_song removes the song, its editions, and related copy_events."""
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        edition_id = temp_db.insert_or_get_song_edition(song_id, words_by="John Newton")
+
+        temp_db.delete_song(song_id)
+
+        assert temp_db.query_song_by_id(song_id) is None
+        assert temp_db.query_song_editions(song_id) == []
+
+    def test_delete_song_removes_copy_events(self, temp_db):
+        """delete_song removes copy_events referencing the song."""
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        edition_id = temp_db.insert_or_get_song_edition(song_id, words_by="John Newton")
+        service_id = temp_db.insert_or_update_service("2026-02-15", "AM", "f.pptx", "h1")
+        temp_db.insert_or_get_copy_event(service_id, song_id, "projection", song_edition_id=edition_id)
+
+        temp_db.delete_song(song_id)
+
+        cursor = temp_db.cursor()
+        cursor.execute("SELECT COUNT(*) FROM copy_events WHERE song_id = ?", (song_id,))
+        assert cursor.fetchone()[0] == 0


### PR DESCRIPTION
## Summary
- Add 14 CLI tests for `cleanup delete-service`, `cleanup orphaned-songs`, and `cleanup find-duplicates` commands
- Add 9 DB integration tests for `query_services_by_date`, `query_orphaned_songs`, `query_duplicate_services`, and `delete_song` methods
- Add `docs/data-cleanup.md` with full command reference, Docker usage examples, and re-import workflow
- Add Data Maintenance section to `docs/pi-deploy.md`

Closes #266

## Test plan
- [x] All 23 new tests pass (`pytest tests/test_cli.py::TestCleanupCommand` and `pytest tests/test_db_integration.py::TestCleanupQueries`)
- [x] Full suite passes: 916 passed, 0 failed
- [x] `ruff check src/` passes
- [x] `mypy src/` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)