### PR TITLE
fix: bump extractor size limit to 200 MB to match upload limit

### DIFF
--- a/src/worship_catalog/extractor.py
+++ b/src/worship_catalog/extractor.py
@@ -28,7 +28,7 @@ from worship_catalog.pptx_reader import (
 _log = logging.getLogger(__name__)
 
 # Pre-flight guards (issue #40 — CWE-400 resource exhaustion)
-_MAX_PPTX_SIZE_BYTES: int = 50 * 1024 * 1024  # 50 MB
+_MAX_PPTX_SIZE_BYTES: int = 200 * 1024 * 1024  # 200 MB — matches web upload limit (#263)
 _MAX_SLIDE_COUNT: int = 500
 
 # Wall-clock timeout for a single file extraction (#73 — prevents runaway on adversarial PPTX)

--- a/tests/test_extractor_unit.py
+++ b/tests/test_extractor_unit.py
@@ -310,11 +310,12 @@ class TestExtractSongsFileHash:
 class TestPptxSizeLimits:
     """Tests for PPTX pre-flight size and slide-count checks — issue #40."""
 
-    def test_file_larger_than_limit_is_rejected(self, tmp_path: Path) -> None:
-        """Files above MAX_PPTX_SIZE_BYTES are rejected before loading."""
+    def test_file_larger_than_limit_is_rejected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Files above _MAX_PPTX_SIZE_BYTES are rejected before loading."""
+        import worship_catalog.extractor as ext_mod
+        monkeypatch.setattr(ext_mod, "_MAX_PPTX_SIZE_BYTES", 1024)  # 1 KB for test
         large_file = tmp_path / "big.pptx"
-        # 60 MB — over any sane limit
-        large_file.write_bytes(b"PK" + b"\x00" * (60 * 1024 * 1024))
+        large_file.write_bytes(b"PK" + b"\x00" * 2048)
         with pytest.raises(ValueError, match="(?i)exceeds maximum"):
             extract_songs(large_file)
 


### PR DESCRIPTION
## Summary
The upload route was bumped to 200 MB in #269, but `extractor.py` still had `_MAX_PPTX_SIZE_BYTES = 50 MB`. The PM Worship Noah file (105 MB) passed the upload but the background worker rejected it with "exceeds maximum allowed size (104 MB > 50 MB)".

## Test plan
- [x] Size limit test updated to use monkeypatch instead of 60 MB file
- [x] Full suite: 916 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)