### PR TITLE
fix: close remaining backlog — rate limiter, upload progress, UX, E2E

### DIFF
--- a/src/worship_catalog/cli.py
+++ b/src/worship_catalog/cli.py
@@ -625,6 +625,9 @@ def repair_credits(
             )
             ocr_budget = OcrBudget(max_calls=None if unlimited_ocr else max_ocr_calls)
 
+        # Cache parsed slides per source file to avoid reloading the same PPTX (#293)
+        _slide_cache: dict[str, list[Any]] = {}
+
         updated = 0
         for row in missing:
             title = row["display_title"]
@@ -659,8 +662,11 @@ def repair_credits(
                                     err=True,
                                 )
                                 continue
-                            prs = load_pptx(source_file)
-                            all_slides = parse_all_slides(prs)
+                            # Reuse cached slides for the same source file (#293)
+                            if source_file not in _slide_cache:
+                                prs = load_pptx(source_file)
+                                _slide_cache[source_file] = parse_all_slides(prs)
+                            all_slides = _slide_cache[source_file]
                             song_slides = [
                                 s for s in all_slides[1:]
                                 if any(canonical in line.lower() for line in s.text.text_lines)

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -51,6 +51,13 @@ _log = logging.getLogger("worship_catalog.web")
 
 # Bounded thread pool for background import jobs (#52)
 # Declared here (before lifespan) so the lifespan can shut it down gracefully (#135).
+#
+# Shutdown timeline (#295):
+#   SIGTERM → uvicorn stops accepting connections → lifespan __aexit__ fires
+#   → _shutdown_executor waits up to _EXECUTOR_SHUTDOWN_TIMEOUT seconds
+#   → compose stop_grace_period (35s) > timeout (30s), so SIGKILL comes after
+#   → SQLite WAL mode recovers automatically if SIGKILL hits mid-write
+#   Requires init:true in compose.yml (#289) so SIGTERM reaches uvicorn.
 _MAX_IMPORT_WORKERS: int = 4
 _EXECUTOR_SHUTDOWN_TIMEOUT: int = 30  # seconds to wait for in-flight jobs before giving up
 _import_executor = ThreadPoolExecutor(max_workers=_MAX_IMPORT_WORKERS)
@@ -192,6 +199,20 @@ _PPTX_MIME = (
 # Per-client upload rate limiting (#173)
 _UPLOAD_RATE_LIMIT: int = 10  # max uploads per window
 _UPLOAD_RATE_WINDOW_SECONDS: int = 3600  # 1 hour
+# Env-configurable trusted proxy header (#283).  When TRUSTED_PROXY=1 the rate
+# limiter reads the leftmost X-Forwarded-For value so that clients behind a
+# reverse proxy are identified individually instead of all sharing one bucket.
+_TRUST_PROXY: bool = os.environ.get("TRUSTED_PROXY", "").strip() in ("1", "true", "yes")
+
+
+def _get_client_ip(request: Request) -> str:
+    """Return the real client IP, respecting X-Forwarded-For if trusted (#283)."""
+    if _TRUST_PROXY:
+        xff = request.headers.get("x-forwarded-for", "")
+        if xff:
+            # Leftmost entry is the original client IP
+            return xff.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
 
 
 class _UploadRateLimiter:
@@ -766,14 +787,25 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
     try:
         result = run_import(db, pptx_path)
 
-        db.update_import_job(
-            job_id, status="complete", songs_imported=result.songs_imported
-        )
-        _notify_title = "Import complete"
-        _notify_message = (
-            f"{pptx_path.name} — {result.songs_imported} songs imported"
-        )
-        _notify_priority = 0
+        if result.songs_imported == 0:
+            db.update_import_job(
+                job_id,
+                status="complete",
+                songs_imported=0,
+                error_message="No songs found — file may not be a worship slide deck",
+            )
+            _notify_title = "Import complete (0 songs)"
+            _notify_message = f"{pptx_path.name} — no songs found"
+            _notify_priority = -1
+        else:
+            db.update_import_job(
+                job_id, status="complete", songs_imported=result.songs_imported
+            )
+            _notify_title = "Import complete"
+            _notify_message = (
+                f"{pptx_path.name} — {result.songs_imported} songs imported"
+            )
+            _notify_priority = 0
     except Exception as exc:  # noqa: BLE001
         # update_import_job runs outside the transaction block — commits even on rollback
         db.update_import_job(
@@ -817,8 +849,9 @@ async def upload(
     db: Database = Depends(get_db),  # noqa: B008
 ) -> JSONResponse:
     """Accept a PPTX file, create an import job, and kick off background import."""
-    # Rate limiting (#173) — check before reading the body to save bandwidth
-    client_ip = request.client.host if request.client else "unknown"
+    # Rate limiting (#173) — check before reading the body to save bandwidth.
+    # Prefer X-Forwarded-For when behind a reverse proxy (#283).
+    client_ip = _get_client_ip(request)
     allowed, retry_after = _upload_limiter.is_allowed(client_ip)
     if not allowed:
         _log.warning(

--- a/src/worship_catalog/web/static/upload.js
+++ b/src/worship_catalog/web/static/upload.js
@@ -1,5 +1,6 @@
 /**
  * Upload form handler — reads CSRF cookie and submits via fetch with the token header.
+ * After a successful upload, polls the job status endpoint until complete (#276).
  * This must be an external file (not inline) to comply with CSP script-src 'self'.
  */
 (function () {
@@ -12,6 +13,58 @@
       if (parts[0] === "csrftoken") token = parts[1];
     });
     return token;
+  }
+
+  /** Poll /jobs/{id} until status is complete or failed (#276). */
+  function pollJobStatus(jobId, resultEl) {
+    var pollInterval = 2000; // 2 seconds
+    var maxPolls = 90; // 3 minutes max
+    var polls = 0;
+
+    function check() {
+      polls++;
+      if (polls > maxPolls) {
+        resultEl.innerHTML =
+          '<p style="color:#856404;">Import is still running. ' +
+          'Refresh the page later to check results.</p>';
+        return;
+      }
+      fetch("/jobs/" + jobId)
+        .then(function (resp) {
+          return resp.json();
+        })
+        .then(function (job) {
+          if (job.status === "complete") {
+            if (job.songs_imported === 0) {
+              resultEl.innerHTML =
+                '<p style="color:#856404;">' +
+                "Import complete \u2014 no songs found. " +
+                "The file may not be a worship slide deck.</p>";
+            } else {
+              resultEl.innerHTML =
+                '<p style="color:green;">' +
+                "Import complete \u2014 " +
+                job.songs_imported +
+                " song(s) imported.</p>";
+            }
+          } else if (job.status === "failed") {
+            resultEl.innerHTML =
+              '<p style="color:#c00;">Import failed: ' +
+              (job.error_message || "unknown error") +
+              "</p>";
+          } else {
+            resultEl.innerHTML =
+              '<p style="color:#495057;">Importing\u2026 ' +
+              '<span class="htmx-indicator" style="opacity:1;">processing</span></p>';
+            setTimeout(check, pollInterval);
+          }
+        })
+        .catch(function () {
+          setTimeout(check, pollInterval);
+        });
+    }
+
+    check();
   }
 
   var form = document.getElementById("upload-form");
@@ -39,9 +92,8 @@
       })
       .then(function (j) {
         result.innerHTML =
-          '<p style="color:green;">Accepted &mdash; job ID: <code>' +
-          j.job_id +
-          "</code>. Import is running in the background.</p>";
+          '<p style="color:#495057;">Upload accepted \u2014 importing\u2026</p>';
+        pollJobStatus(j.job_id, result);
       })
       .catch(function (err) {
         result.innerHTML =

--- a/src/worship_catalog/web/templates/base.html
+++ b/src/worship_catalog/web/templates/base.html
@@ -23,7 +23,7 @@
       align-items: center;
       gap: 2rem;
     }
-    nav .brand-logo { height: 2rem; width: auto; border-radius: 4px; }
+    nav .brand-logo { height: 2.5rem; width: auto; border-radius: 6px; background: rgba(255,255,255,0.9); padding: 2px 4px; }
     nav .brand { font-weight: 700; font-size: 1.1rem; letter-spacing: .02em; }
     nav a { color: #ccc; text-decoration: none; font-size: 0.95rem; }
     nav a:hover, nav a.active { color: #fff; }

--- a/src/worship_catalog/web/templates/services.html
+++ b/src/worship_catalog/web/templates/services.html
@@ -15,6 +15,11 @@
 
 {# Filter bar #}
 <div class="card" style="margin-bottom:1rem;">
+  {% if start_date or end_date or q_service or q_leader or q_preacher or q_sermon %}
+  <div style="text-align:right;margin-bottom:0.5rem;">
+    <a href="/services" style="font-size:0.85rem;color:#6c757d;">Clear all filters</a>
+  </div>
+  {% endif %}
   <div class="form-grid">
     <div>
       <label style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Date From</label>

--- a/tests/test_uat_acceptance.py
+++ b/tests/test_uat_acceptance.py
@@ -379,3 +379,71 @@ class TestLeaderPagesE2E:
         browser_page.wait_for_load_state("networkidle")
         assert response.status == 200, f"/leaders returned status {response.status}"
         assert not errors, f"JS errors on /leaders: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# #303 -- CCLI CSV download end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestCcliDownloadE2E:
+    """UAT for #303: CCLI CSV download must work in a real browser."""
+
+    def test_ccli_download_produces_csv(self, browser_page: Any) -> None:
+        """Fill CCLI form, submit, verify CSV download occurs."""
+        browser_page.goto(f"{BASE_URL}/reports")
+        browser_page.wait_for_load_state("networkidle")
+
+        browser_page.fill("#ccli-from", "2020-01-01")
+        browser_page.fill("#ccli-to", "2030-12-31")
+
+        with browser_page.expect_download(timeout=15000) as download_info:
+            browser_page.click('#ccli-form button[type="submit"]')
+
+        download = download_info.value
+        assert download.suggested_filename.startswith("ccli_report_")
+        assert download.suggested_filename.endswith(".csv")
+
+    def test_ccli_download_has_csrf_cookie(self, browser_page: Any) -> None:
+        """CSRF cookie must be set on /reports for the JS to read."""
+        browser_page.goto(f"{BASE_URL}/reports")
+        browser_page.wait_for_load_state("networkidle")
+        cookies = browser_page.context.cookies()
+        assert any(c["name"] == "csrftoken" for c in cookies)
+
+
+# ---------------------------------------------------------------------------
+# #304 -- Upload workflow end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+class TestUploadWorkflowE2E:
+    """UAT for #304: full upload workflow in a real browser."""
+
+    def test_upload_form_loads(self, browser_page: Any) -> None:
+        """Upload page loads with form and CSRF cookie."""
+        browser_page.goto(f"{BASE_URL}/upload")
+        browser_page.wait_for_load_state("networkidle")
+        assert browser_page.locator("#upload-form").is_visible()
+        cookies = browser_page.context.cookies()
+        assert any(c["name"] == "csrftoken" for c in cookies)
+
+    def test_upload_invalid_file_shows_error_in_result(self, browser_page: Any) -> None:
+        """Uploading a non-PPTX file shows an error in the result div."""
+        browser_page.goto(f"{BASE_URL}/upload")
+        browser_page.wait_for_load_state("networkidle")
+
+        browser_page.set_input_files('input[type="file"]', {
+            "name": "bad.txt",
+            "mimeType": "text/plain",
+            "buffer": b"not a pptx",
+        })
+        browser_page.click('button[type="submit"]')
+        browser_page.wait_for_timeout(2000)
+
+        result_text = browser_page.text_content("#upload-result") or ""
+        assert "failed" in result_text.lower() or "pptx" in result_text.lower(), (
+            f"Expected error for non-PPTX file, got: {result_text}"
+        )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3285,3 +3285,81 @@ class TestUploadRateLimiterPersistence:
         assert not allowed
         allowed, _ = limiter.is_allowed("2.2.2.2")
         assert allowed
+
+
+# ---------------------------------------------------------------------------
+# Proxy-aware rate limiter (#283)
+# ---------------------------------------------------------------------------
+
+
+class TestProxyAwareRateLimiter:
+    """Rate limiter should use X-Forwarded-For when TRUSTED_PROXY is set (#283)."""
+
+    def test_get_client_ip_without_proxy(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_PROXY", "")
+        from importlib import reload
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        from unittest.mock import MagicMock
+        req = MagicMock()
+        req.client.host = "1.2.3.4"
+        req.headers = {}
+        assert app_module._get_client_ip(req) == "1.2.3.4"
+
+    def test_get_client_ip_with_proxy(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_PROXY", "1")
+        from importlib import reload
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        from unittest.mock import MagicMock
+        req = MagicMock()
+        req.client.host = "10.0.0.1"
+        req.headers = {"x-forwarded-for": "5.6.7.8, 10.0.0.1"}
+        assert app_module._get_client_ip(req) == "5.6.7.8"
+
+    def test_get_client_ip_proxy_no_xff_header(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_PROXY", "1")
+        from importlib import reload
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        from unittest.mock import MagicMock
+        req = MagicMock()
+        req.client.host = "10.0.0.1"
+        req.headers = {}
+        assert app_module._get_client_ip(req) == "10.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Services clear filters (#302)
+# ---------------------------------------------------------------------------
+
+
+class TestServicesClearFilters:
+    """Services page should show a 'Clear all filters' link when filters active (#302)."""
+
+    def test_clear_link_shown_when_date_filter_active(self, client):
+        resp = client.get("/services?start_date=2026-01-01")
+        assert resp.status_code == 200
+        assert "Clear all filters" in resp.text
+        assert 'href="/services"' in resp.text
+
+    def test_clear_link_hidden_when_no_filters(self, client):
+        resp = client.get("/services")
+        assert resp.status_code == 200
+        assert "Clear all filters" not in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Logo contrast (#249)
+# ---------------------------------------------------------------------------
+
+
+class TestLogoContrast:
+    """Logo should be readable in the dark nav bar (#249)."""
+
+    def test_logo_has_contrast_background(self, client):
+        resp = client.get("/songs")
+        assert resp.status_code == 200
+        # Logo CSS should include background for contrast
+        assert "brand-logo" in resp.text
+        assert "background:" in resp.text or "background-color:" in resp.text


### PR DESCRIPTION
## Summary

Closes all 9 remaining non-deferred issues, bringing the active backlog to zero.

**Security (#283):** Proxy-aware rate limiter reads X-Forwarded-For when `TRUSTED_PROXY=1`

**UX (#276, #301):** Upload page now polls job status and shows real-time progress. Zero-song imports show a clear warning instead of silent "0 songs imported"

**Performance (#293):** repair-credits caches parsed PPTX slides per source file — avoids reloading the same file for each song needing OCR

**DevOps (#295):** Documented shutdown timeline (SIGTERM → lifespan → executor → SIGKILL). init:true from #289 ensures proper signal delivery

**UX (#249, #302):**
- Logo increased to 2.5rem with white background pill for contrast
- Services page shows "Clear all filters" link when any filter is active

**E2E tests (#303, #304):**
- Playwright test for CCLI CSV download end-to-end
- Playwright test for upload form, CSRF cookie, invalid file handling

## Test plan

- [x] 949 tests pass (`python3 -m pytest -m "not e2e"`)
- [x] `ruff check src/` — zero errors
- [x] `mypy src/` — zero errors
- [ ] CI pipeline passes (test + security + e2e)

Closes #249, #276, #283, #293, #295, #301, #302, #303, #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)