### PR TITLE
fix: QA sweep — scripture regex, LIKE injection, magic bytes validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev,web,ocr]"
+        run: |
+          pip install -r requirements.lock          # locked runtime deps (#321)
+          pip install -e ".[dev]"                    # dev tools (bandit, pip-audit)
 
       - name: Verify lockfile is up to date (#174)
         run: |

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -54,6 +54,9 @@ _IMPORT_JOB_MUTABLE_FIELDS: frozenset[str] = frozenset(
 )
 
 
+_VALID_SORT_DIRS: frozenset[str] = frozenset({"ASC", "DESC"})
+
+
 def _safe_order_by(col: str, whitelist: frozenset[str]) -> str:
     """Validate *col* against *whitelist* and return it if safe.
 
@@ -65,6 +68,19 @@ def _safe_order_by(col: str, whitelist: frozenset[str]) -> str:
     if not stripped or stripped not in whitelist:
         raise ValueError(f"Invalid sort column: {col!r}")
     return stripped
+
+
+def _safe_sort_dir(direction: str) -> str:
+    """Validate sort direction to prevent SQL injection (#316)."""
+    upper = direction.strip().upper()
+    if upper not in _VALID_SORT_DIRS:
+        raise ValueError(f"Invalid sort direction: {direction!r}")
+    return upper
+
+
+def _escape_like(value: str) -> str:
+    """Escape LIKE special characters (%, _) in user input (#319)."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 class SchemaVersionError(RuntimeError):
@@ -569,10 +585,10 @@ class Database:
                 """
                 SELECT * FROM services
                 WHERE service_date >= ? AND service_date <= ?
-                  AND LOWER(song_leader) LIKE LOWER(?)
+                  AND LOWER(song_leader) LIKE LOWER(?) ESCAPE '\\'
                 ORDER BY service_date
                 """,
-                (start_date, end_date, f"%{song_leader}%"),
+                (start_date, end_date, f"%{_escape_like(song_leader)}%"),
             )
         else:
             cursor.execute(
@@ -731,12 +747,12 @@ class Database:
             JOIN services sv ON ss.service_id = sv.id
             JOIN songs s ON ss.song_id = s.id
             LEFT JOIN song_editions se ON ss.song_edition_id = se.id
-            WHERE LOWER(COALESCE(sv.song_leader, '')) LIKE LOWER(?)
+            WHERE LOWER(COALESCE(sv.song_leader, '')) LIKE LOWER(?) ESCAPE '\\'
             GROUP BY s.id
             HAVING COUNT(DISTINCT ss.service_id) >= ?
             ORDER BY performance_count DESC, s.display_title
             """,
-            (f"%{leader}%", min_count),
+            (f"%{_escape_like(leader)}%", min_count),
         )
         return [dict(row) for row in cursor.fetchall()]
 
@@ -746,9 +762,9 @@ class Database:
         cursor.execute(
             """
             SELECT COUNT(*) FROM services
-            WHERE LOWER(COALESCE(song_leader, '')) LIKE LOWER(?)
+            WHERE LOWER(COALESCE(song_leader, '')) LIKE LOWER(?) ESCAPE '\\'
             """,
-            (f"%{leader}%",),
+            (f"%{_escape_like(leader)}%",),
         )
         row = cursor.fetchone()
         return row[0] if row else 0
@@ -926,7 +942,7 @@ class Database:
     ) -> tuple[list[dict[str, Any]], int]:
         """Return songs with performance count, optionally filtered and sorted."""
         sort = _safe_order_by(sort, self._SONGS_SORT_COLS)
-        order = f"{sort} {sort_dir.upper()}, s.display_title"
+        order = f"{sort} {_safe_sort_dir(sort_dir)}, s.display_title"
         cursor = self._conn.cursor()
         base = """
             SELECT s.id, s.display_title, s.canonical_title,
@@ -944,11 +960,11 @@ class Database:
         """
         offset = (page - 1) * per_page
         if search:
-            like = f"%{search}%"
+            like = f"%{_escape_like(search)}%"
             where = """
-                WHERE LOWER(s.display_title) LIKE LOWER(?)
-                   OR LOWER(COALESCE(se.words_by, '')) LIKE LOWER(?)
-                   OR LOWER(COALESCE(se.music_by, '')) LIKE LOWER(?)
+                WHERE (LOWER(s.display_title) LIKE LOWER(?) ESCAPE '\\'
+                   OR LOWER(COALESCE(se.words_by, '')) LIKE LOWER(?) ESCAPE '\\'
+                   OR LOWER(COALESCE(se.music_by, '')) LIKE LOWER(?) ESCAPE '\\')
             """
             cursor.execute(count_base + where, (like, like, like))
             total: int = cursor.fetchone()[0]
@@ -982,17 +998,17 @@ class Database:
         where_clauses: list[str] = []
         params: list[Any] = []
         if q_service:
-            where_clauses.append("LOWER(sv.service_name) LIKE LOWER(?)")
-            params.append(f"%{q_service}%")
+            where_clauses.append("LOWER(sv.service_name) LIKE LOWER(?) ESCAPE '\\'")
+            params.append(f"%{_escape_like(q_service)}%")
         if q_leader:
-            where_clauses.append("LOWER(COALESCE(sv.song_leader,'')) LIKE LOWER(?)")
-            params.append(f"%{q_leader}%")
+            where_clauses.append("LOWER(COALESCE(sv.song_leader,'')) LIKE LOWER(?) ESCAPE '\\'")
+            params.append(f"%{_escape_like(q_leader)}%")
         if q_preacher:
-            where_clauses.append("LOWER(COALESCE(sv.preacher,'')) LIKE LOWER(?)")
-            params.append(f"%{q_preacher}%")
+            where_clauses.append("LOWER(COALESCE(sv.preacher,'')) LIKE LOWER(?) ESCAPE '\\'")
+            params.append(f"%{_escape_like(q_preacher)}%")
         if q_sermon:
-            where_clauses.append("LOWER(COALESCE(sv.sermon_title,'')) LIKE LOWER(?)")
-            params.append(f"%{q_sermon}%")
+            where_clauses.append("LOWER(COALESCE(sv.sermon_title,'')) LIKE LOWER(?) ESCAPE '\\'")
+            params.append(f"%{_escape_like(q_sermon)}%")
         if start_date:
             where_clauses.append("sv.service_date >= ?")
             params.append(start_date)
@@ -1002,7 +1018,7 @@ class Database:
 
         where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
         sort = _safe_order_by(sort, self._SERVICES_SORT_COLS)
-        order = f"{sort} {sort_dir.upper()}, sv.service_name"
+        order = f"{sort} {_safe_sort_dir(sort_dir)}, sv.service_name"
         offset = (page - 1) * per_page
         cursor = self._conn.cursor()
         cursor.execute(
@@ -1035,10 +1051,10 @@ class Database:
             cursor.execute(
                 """
                 SELECT * FROM services
-                WHERE service_date = ? AND LOWER(service_name) LIKE LOWER(?)
+                WHERE service_date = ? AND LOWER(service_name) LIKE LOWER(?) ESCAPE '\\'
                 ORDER BY id
                 """,
-                (date, f"%{name_pattern}%"),
+                (date, f"%{_escape_like(name_pattern)}%"),
             )
         else:
             cursor.execute(

--- a/src/worship_catalog/normalize.py
+++ b/src/worship_catalog/normalize.py
@@ -42,8 +42,16 @@ def strip_title_prefix(line: str) -> str:
         prefix_match = re.match(r'^\s*([\dA-Za-z][\dA-Za-z-]{0,3})', stripped)
         if prefix_match:
             prefix = prefix_match.group(1)
-            # Accept if: has dash, starts with digit, or is letter+digits (like V1, C2, V1a)
-            if '-' in prefix or prefix[0].isdigit() or re.match(r'^[A-Za-z]\d', prefix):
+            # Accept if: has dash, starts with digit (but NOT "N. Text" patterns
+            # which are sermon outlines #314), or is letter+digits (like V1, C2, V1a)
+            is_sermon_outline = (
+                prefix[0].isdigit()
+                and re.match(r'^\s*\d+\.\s', stripped) is not None
+            )
+            if not is_sermon_outline and (
+                '-' in prefix or prefix[0].isdigit()
+                or re.match(r'^[A-Za-z]\d', prefix)
+            ):
                 stripped = match.group(1).strip()
                 return _normalize_whitespace(stripped)
 
@@ -125,10 +133,11 @@ def select_best_title(candidates: list[str]) -> str | None:
     return min(normalized, key=len)
 
 
-# Scripture reference pattern: "John 3:16", "1 Peter 1:3-4", "2 Corinthians 4:7", "Psalm 23:1-3"
-# Matches: optional numeric book prefix + book name + chapter:verse[-verse]
+# Scripture reference pattern: "John 3:16", "1 Peter 1:3-4", "MICAH 6:6 – 8"
+# Matches: optional numeric book prefix + book name + chapter:verse[(-|–|—) verse]
+# Accepts hyphens, en-dashes, em-dashes, and optional spaces around the separator (#313).
 _SCRIPTURE_RE = re.compile(
-    r"^(1|2|3)?\s*[A-Za-z][a-z]+(\s[A-Za-z][a-z]+)?\s+\d{1,3}:\d{1,3}(-\d{1,3})?$",
+    r"^(1|2|3)?\s*[A-Za-z][a-z]+(\s[A-Za-z][a-z]+)?\s+\d{1,3}:\d{1,3}(\s*[-–—]\s*\d{1,3})?$",
     re.IGNORECASE,
 )
 

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -926,6 +926,17 @@ async def upload(
             break
         chunks.append(chunk)
     content = b"".join(chunks)
+    # Validate ZIP magic bytes — PPTX is a ZIP archive (PK\x03\x04) (#320)
+    if len(content) < 4 or content[:4] != b"PK\x03\x04":
+        send_pushover(
+            title="Upload rejected",
+            message=f"{filename} — not a valid PPTX (bad magic bytes)",
+            priority=-1,
+        )
+        return JSONResponse(
+            content={"detail": "File is not a valid PPTX archive"},
+            status_code=400,
+        )
     if total_read > MAX_UPLOAD_BYTES:
         limit_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
         send_pushover(

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2319,3 +2319,62 @@ class TestDatabaseIndexes:
         cursor = temp_db.cursor()
         cursor.execute("PRAGMA user_version")
         assert cursor.fetchone()[0] == 2
+
+
+@pytest.mark.integration
+class TestSortDirValidation:
+    """Tests for _safe_sort_dir validation (#316)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_valid_asc(self, temp_db):
+        from worship_catalog.db import _safe_sort_dir
+        assert _safe_sort_dir("asc") == "ASC"
+
+    def test_valid_desc(self, temp_db):
+        from worship_catalog.db import _safe_sort_dir
+        assert _safe_sort_dir("DESC") == "DESC"
+
+    def test_invalid_sort_dir_raises(self, temp_db):
+        from worship_catalog.db import _safe_sort_dir
+        with pytest.raises(ValueError, match="Invalid sort direction"):
+            _safe_sort_dir("DROP TABLE songs;")
+
+
+@pytest.mark.integration
+class TestLikeEscaping:
+    """Tests for LIKE pattern escaping (#319)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_search_percent_in_query_does_not_match_all(self, temp_db):
+        """A search containing '%' should not match everything."""
+        temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        temp_db.insert_or_get_song("how great", "How Great Thou Art")
+        rows, total = temp_db.query_songs_paginated(search="%")
+        # '%' should not match any real titles (it's escaped)
+        assert total == 0
+
+    def test_search_underscore_in_query_literal(self, temp_db):
+        """A search containing '_' should match literally, not as wildcard."""
+        temp_db.insert_or_get_song("test_song", "Test_Song")
+        temp_db.insert_or_get_song("testing", "Testing")
+        rows, total = temp_db.query_songs_paginated(search="test_")
+        assert total == 1
+        assert rows[0]["canonical_title"] == "test_song"

--- a/tests/test_title_normalize.py
+++ b/tests/test_title_normalize.py
@@ -267,3 +267,36 @@ class TestScriptureGuard:
     def test_partial_reference_not_flagged(self):
         # No chapter:verse pattern → not a scripture ref
         assert _is_invalid_line("John") is False
+
+    def test_scripture_with_en_dash(self):
+        """Scripture with en-dash verse range should be flagged (#313)."""
+        assert _is_invalid_line("MICAH 6:6 – 8") is True
+
+    def test_scripture_with_em_dash(self):
+        """Scripture with em-dash verse range should be flagged (#313)."""
+        assert _is_invalid_line("Psalm 23:1—6") is True
+
+    def test_scripture_with_spaced_range(self):
+        """Scripture with spaces around hyphen should be flagged (#313)."""
+        assert _is_invalid_line("Romans 8:28 - 30") is True
+
+
+@pytest.mark.unit
+class TestSermonOutlineNotStripped:
+    """Sermon outline numbered points should not be stripped (#314)."""
+
+    def test_numbered_period_not_stripped(self):
+        """'1. SALVATION' should NOT have '1.' stripped."""
+        result = strip_title_prefix("1. SALVATION THEN SANCTIFICATION")
+        assert "SALVATION" in result
+        # Should not strip the number — it's a sermon outline, not a verse prefix
+        assert result.startswith("1.")
+
+    def test_regular_verse_prefix_still_stripped(self):
+        """'1 - Amazing Grace' should still be stripped normally."""
+        assert strip_title_prefix("1 - Amazing Grace") == "Amazing Grace"
+
+    def test_numbered_period_short(self):
+        """'2. Grace' — even short entries with period should not strip."""
+        result = strip_title_prefix("2. Grace")
+        assert result.startswith("2.")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2092,10 +2092,15 @@ class TestUploadInboxCleanup:
         reload(app_module)
         client = CsrfAwareClient(TestClient(app_module.app))
 
-        # Upload a garbage PPTX that will fail extraction
+        # Upload a valid ZIP (passes magic bytes check) but not a real PPTX (fails extraction)
+        import zipfile
+        bad_zip = io.BytesIO()
+        with zipfile.ZipFile(bad_zip, "w") as zf:
+            zf.writestr("dummy.txt", "not a pptx")
+        bad_zip.seek(0)
         resp = client.post(
             "/upload",
-            files={"file": ("bad.pptx", io.BytesIO(b"not a real pptx"), VALID_PPTX_MIME)},
+            files={"file": ("bad.pptx", bad_zip, VALID_PPTX_MIME)},
         )
         assert resp.status_code == 202
         job_id = resp.json()["job_id"]
@@ -3363,3 +3368,26 @@ class TestLogoContrast:
         # Logo CSS should include background for contrast
         assert "brand-logo" in resp.text
         assert "background:" in resp.text or "background-color:" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Upload magic bytes validation (#320)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadMagicBytes:
+    """Upload endpoint should reject files that aren't ZIP archives (#320)."""
+
+    def test_upload_rejects_non_zip_content(self, client):
+        """A file with correct MIME and extension but wrong content should be rejected."""
+        fake_content = b"This is not a ZIP file at all"
+        resp = client.post(
+            "/upload",
+            files={"file": (
+                "fake.pptx",
+                io.BytesIO(fake_content),
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            )},
+        )
+        assert resp.status_code == 400
+        assert "not a valid PPTX" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Fixes bugs and security issues found during QA agent sweep.

**Bugs (#313, #314):**
- Scripture regex now accepts en-dash (`–`), em-dash (`—`), and spaced verse ranges (`6:6 – 8`)
- Sermon outline numbered points (`1. SALVATION...`) no longer misidentified as song section prefixes

**Security (#316, #319, #320, #321):**
- `_safe_sort_dir()` validates sort direction in DB query methods (defence-in-depth)
- `_escape_like()` escapes `%` and `_` in all LIKE queries to prevent pattern injection
- Upload validates ZIP magic bytes (`PK\x03\x04`) — rejects spoofed Content-Type
- CI security job installs from lockfile before dev extras

## Test plan

- [x] 961 tests pass (`python3 -m pytest -m "not e2e"`)
- [x] `ruff check src/` — zero errors
- [x] `mypy src/` — zero errors
- [ ] CI pipeline passes

Closes #313, #314, #316, #319, #320, #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)