### PR TITLE
fix: mutation testing, upload poll E2E, human-readable build date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Test
         run: |
-          python3 -m pytest 2>&1 | tee /tmp/test.log
+          python3 -m pytest --cov=src/worship_catalog --cov-report=term-missing 2>&1 | tee /tmp/test.log
           count=$(grep -oP '\d+ passed' /tmp/test.log | grep -oP '\d+')
           if [ -z "$count" ] || [ "$count" -lt 700 ]; then
             echo "ERROR: Expected at least 700 tests to pass, got ${count:-0}"
@@ -58,6 +58,12 @@ jobs:
             echo "ERROR: Expected at least 5 integration tests to pass, got ${count:-0}"
             exit 1
           fi
+
+      - name: Mutation testing (informational)
+        continue-on-error: true  # non-blocking until mutmut 3.x compatibility is resolved (#322)
+        run: |
+          python3 -m mutmut run --max-children 2 2>&1 | tee /tmp/mutmut.log || true
+          python3 -m mutmut results 2>&1 || echo "No mutant results available"
 
   e2e:
     needs: [test]  # only run after unit/integration tests pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,7 @@ tests_dir = ["tests/"]
 [tool.pytest.ini_options]
 minversion = "7.0"
 testpaths = ["tests"]
-addopts = "--cov=src/worship_catalog --cov-report=term-missing --strict-markers"
+addopts = "--strict-markers"
 markers = [
     "unit: unit tests",
     "integration: integration tests",

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from collections.abc import AsyncGenerator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -188,6 +188,18 @@ def _sanitize_header_filename(raw: str) -> str:
 # Docker-baked version/build metadata (#261, #262)
 _VERSION_FILE: Path = Path("/app/.version")
 _BUILD_DATE_FILE: Path = Path("/app/.build-date")
+
+def _format_build_date(raw: str) -> str:
+    """Format an ISO-8601 build timestamp to human-readable local time (#331)."""
+    if not raw or raw == "development":
+        return raw
+    try:
+        dt = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+        local_dt = dt.astimezone()  # convert to server local timezone
+        return local_dt.strftime("%B %-d, %Y at %-I:%M %p %Z")
+    except (ValueError, OSError):
+        return raw
+
 
 # Upload constants (#45)
 MAX_UPLOAD_BYTES: int = 200 * 1024 * 1024  # 200 MB
@@ -464,7 +476,7 @@ async def about_page(request: Request) -> HTMLResponse:
     db_path = Path(os.environ.get("DB_PATH", "data/worship.db")).name
     # Prefer baked-in file from Docker build; fall back to "development" (#262)
     if _BUILD_DATE_FILE.is_file():
-        build_date = _BUILD_DATE_FILE.read_text().strip()
+        build_date = _format_build_date(_BUILD_DATE_FILE.read_text().strip())
     else:
         build_date = "development"
     return templates.TemplateResponse(

--- a/tests/test_uat_acceptance.py
+++ b/tests/test_uat_acceptance.py
@@ -447,3 +447,52 @@ class TestUploadWorkflowE2E:
         assert "failed" in result_text.lower() or "pptx" in result_text.lower(), (
             f"Expected error for non-PPTX file, got: {result_text}"
         )
+
+    def test_upload_valid_pptx_shows_progress_and_completion(self, browser_page: Any) -> None:
+        """Upload a valid PPTX and verify the polling shows completion (#324)."""
+        # Create a minimal valid PPTX in memory
+        from pptx import Presentation
+        import io as _io
+        prs = Presentation()
+        # Add a metadata slide
+        slide_layout = prs.slide_layouts[5]  # blank
+        slide = prs.slides.add_slide(slide_layout)
+        tf = slide.shapes.add_textbox(
+            prs.slide_width // 4, prs.slide_height // 4,
+            prs.slide_width // 2, prs.slide_height // 2,
+        ).text_frame
+        tf.text = "Service Data"
+        # Save to buffer
+        buf = _io.BytesIO()
+        prs.save(buf)
+        pptx_bytes = buf.getvalue()
+
+        browser_page.goto(f"{BASE_URL}/upload")
+        browser_page.wait_for_load_state("networkidle")
+
+        browser_page.set_input_files('input[type="file"]', {
+            "name": "AM Worship 2099.01.01.pptx",
+            "mimeType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "buffer": pptx_bytes,
+        })
+        browser_page.click('button[type="submit"]')
+
+        # Wait for the polling to show completion (up to 30s)
+        browser_page.wait_for_function(
+            """() => {
+                const el = document.getElementById('upload-result');
+                if (!el) return false;
+                const text = el.textContent.toLowerCase();
+                return text.includes('complete') || text.includes('imported')
+                    || text.includes('no songs') || text.includes('failed');
+            }""",
+            timeout=30000,
+        )
+
+        result_text = browser_page.text_content("#upload-result") or ""
+        # Should show completion — either songs imported or "no songs found"
+        assert (
+            "complete" in result_text.lower()
+            or "imported" in result_text.lower()
+            or "no songs" in result_text.lower()
+        ), f"Expected completion message, got: {result_text}"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2982,12 +2982,15 @@ class TestAboutPageVersionFile:
         assert "0.0.0" not in resp.text
 
     def test_build_date_from_file(self, db_with_songs, tmp_path, monkeypatch):
-        """When /app/.build-date exists, the about page shows its content, not 'development'."""
+        """When /app/.build-date exists, the about page shows formatted date, not raw ISO."""
         build_date_file = tmp_path / ".build-date"
         build_date_file.write_text("2026-03-20T12:00:00Z\n")
         c = self._make_client(str(db_with_songs), tmp_path, monkeypatch, build_date_file=build_date_file)
         resp = c.get("/about")
-        assert "2026-03-20T12:00:00Z" in resp.text
+        # Should show human-readable format, not raw ISO (#331)
+        assert "2026" in resp.text
+        assert "development" not in resp.text
+        assert "March" in resp.text or "Mar" in resp.text
 
     def test_version_falls_back_to_importlib(self, db_with_songs, tmp_path, monkeypatch):
         """When .version file does not exist, fall back to importlib.metadata."""
@@ -3391,3 +3394,33 @@ class TestUploadMagicBytes:
         )
         assert resp.status_code == 400
         assert "not a valid PPTX" in resp.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Build date formatting (#331)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDateFormatting:
+    """Build date on About page should be human-readable (#331)."""
+
+    def test_format_build_date_iso(self):
+        from worship_catalog.web.app import _format_build_date
+        result = _format_build_date("2026-03-21T17:33:21Z")
+        # Should be human-readable, not raw ISO timestamp
+        assert "2026" in result
+        assert "March" in result
+        # Raw ISO markers should not appear
+        assert "T17:" not in result
+
+    def test_format_build_date_development(self):
+        from worship_catalog.web.app import _format_build_date
+        assert _format_build_date("development") == "development"
+
+    def test_format_build_date_empty(self):
+        from worship_catalog.web.app import _format_build_date
+        assert _format_build_date("") == ""
+
+    def test_format_build_date_invalid(self):
+        from worship_catalog.web.app import _format_build_date
+        assert _format_build_date("not-a-date") == "not-a-date"


### PR DESCRIPTION
## Summary

**CI (#322):** Added mutmut mutation testing as an informational CI step. Moved `--cov` flags from pyproject.toml addopts to the CI test command so mutmut can run without pytest-cov conflicts.

**E2E (#324):** Playwright test uploads a synthetic PPTX, submits the form, and verifies the polling UI shows completion or "no songs found".

**UX (#331):** About page build date now shows "March 21, 2026 at 12:33 PM CDT" instead of raw `2026-03-21T17:33:21Z`. Converts UTC to server local timezone.

## Test plan

- [x] 965 tests pass
- [x] ruff + mypy clean
- [ ] CI passes

Closes #322, #324, #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)