### PR TITLE
fix: Review 9 backlog — accessibility, OCR tests, CSRF warning, rate limiter

### DIFF
--- a/docs/code-review-history.md
+++ b/docs/code-review-history.md
@@ -7,6 +7,46 @@ Each review produces GitHub issues for every significant finding.
 
 ---
 
+## Review 9 — 2026-03-21
+
+**Branch:** `main`
+**Reviewer:** Claude Code (full-code-review skill)
+**Issues created:** #335–#344
+
+### Findings
+
+| Issue | Persona | Title | Severity |
+|-------|---------|-------|----------|
+| #335 | Accessibility | Report form checkbox and date inputs missing accessible error feedback | MED |
+| #336 | Accessibility | Services table empty action header and missing captions on detail tables | MED |
+| #337 | Accessibility | stat-box label and badge-missing colors have marginal WCAG AA contrast | MED |
+| #338 | Developer | purge_old_import_jobs accepts negative days parameter without validation | LOW |
+| #339 | QA | No dedicated test file for ocr.py Vision API module | MED |
+| #340 | QA | test_report_service.py has minimal assertions — leader filter and date boundaries untested | MED |
+| #341 | Developer | _UploadRateLimiter reopens SQLite connection on every rate-limit check | LOW |
+| #342 | Accessibility | Pagination links missing aria-label for screen reader context | LOW |
+| #343 | Database | query_services uses SELECT * pulling all columns including source_file path | LOW |
+| #344 | DevOps | CSRF_SECRET generated randomly on startup — breaks multi-process deployments | MED |
+
+### Grades
+
+| Persona | Grade | Notes |
+|---------|-------|-------|
+| Senior Architect | A | Excellent module separation; CreditResolver, import_service, report_service abstractions are clean and well-bounded |
+| Senior Developer | A- | Clean code, strong typing, good error handling; minor purge validation and rate limiter efficiency gaps |
+| Senior DevOps | A | Comprehensive CI with E2E, smoke test, lockfile verification, Trivy scanning; CSRF_SECRET startup logging needed |
+| Senior Security Architect | A | CSP, CSRF, parameterized queries, ZIP magic bytes, LIKE escaping all solid; no injection vectors found |
+| Senior DevSecOps | A | SHA-pinned actions, Trivy scan-before-push, SBOM baseline, gitleaks, pip-audit; lockfile used in all jobs |
+| Senior QA Engineer | A- | 1,007 tests with strong markers and fixtures; OCR module and report service need deeper test coverage |
+| Product Manager | A- | Functional features, good reporting, upload progress feedback; only deferred items remain |
+| UAT Analyst | A- | 38+ Playwright tests cover upload, download, CSRF, navigation; good scenario coverage |
+| Accessibility Specialist | B+ | Skip-nav, aria-sort, aria-live, labels, captions present; contrast and form feedback gaps remain |
+| Database / Data Engineer | A- | WAL mode, indexes, migrations, parameterized queries; SELECT * in web queries and rate limiter connection churn are minor |
+
+**Overall: A-**
+
+---
+
 ## Review 8 — 2026-03-21
 
 **Branch:** `fix/qa-sweep`

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -580,10 +580,14 @@ class Database:
     ) -> list[dict]:
         """Query services by date range, with optional case-insensitive song leader filter."""
         cursor = self._conn.cursor()
+        _svc_cols = (
+            "id, service_date, service_name, song_leader, preacher,"
+            " sermon_title, source_hash, imported_at"
+        )
         if song_leader:
             cursor.execute(
-                """
-                SELECT * FROM services
+                f"""
+                SELECT {_svc_cols} FROM services
                 WHERE service_date >= ? AND service_date <= ?
                   AND LOWER(song_leader) LIKE LOWER(?) ESCAPE '\\'
                 ORDER BY service_date
@@ -592,8 +596,8 @@ class Database:
             )
         else:
             cursor.execute(
-                """
-                SELECT * FROM services
+                f"""
+                SELECT {_svc_cols} FROM services
                 WHERE service_date >= ? AND service_date <= ?
                 ORDER BY service_date
                 """,
@@ -899,8 +903,9 @@ class Database:
                   many days.
             keep: If specified, keep only this many jobs (newest first).
         """
+        if keep is None and days < 0:
+            raise ValueError(f"days must be >= 0, got {days}")
         if keep is not None:
-            # Delete all jobs except the *keep* newest by started_at.
             # Use a sub-select to identify the IDs to keep, then delete the rest.
             self._conn.execute(
                 """

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -101,6 +101,11 @@ app = FastAPI(title="Worship Catalog", lifespan=_lifespan)
 # responses are logged correctly. Secret is read from env; a random value is
 # generated on first start (sufficient for a single-process deployment).
 _CSRF_SECRET = os.environ.get("CSRF_SECRET") or secrets.token_hex(32)
+if not os.environ.get("CSRF_SECRET"):
+    _log.warning(
+        "CSRF_SECRET not set — using random secret (single-process only). "
+        "Set CSRF_SECRET in .env for multi-process or load-balanced deployments."
+    )
 # cookie_name is set explicitly so the coupling with client-side JS
 # (upload.js, reports.js) and CsrfAwareClient in conftest.py is visible (#239).
 app.add_middleware(
@@ -248,6 +253,7 @@ class _UploadRateLimiter:
     def __init__(self, db_path: Path | None = None) -> None:
         self._lock = threading.Lock()
         self._db_path = db_path
+        self._conn: Any = None  # persistent SQLite connection (#341)
         # In-memory fallback when no db_path is given
         self._timestamps: dict[str, list[float]] = defaultdict(list)
         if db_path is not None:
@@ -258,52 +264,44 @@ class _UploadRateLimiter:
     def _init_db(self) -> None:
         import sqlite3
 
-        conn = sqlite3.connect(self._db_path)  # type: ignore[arg-type]
-        try:
-            conn.execute(self._CREATE_TABLE)
-            conn.execute(self._CREATE_INDEX)
-            conn.commit()
-        finally:
-            conn.close()
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)  # type: ignore[arg-type]
+        self._conn.execute(self._CREATE_TABLE)
+        self._conn.execute(self._CREATE_INDEX)
+        self._conn.commit()
 
     def _db_is_allowed(self, client_ip: str) -> tuple[bool, int]:
-        import sqlite3
-
         now = time.time()
         window_start = now - _UPLOAD_RATE_WINDOW_SECONDS
 
-        conn = sqlite3.connect(self._db_path)  # type: ignore[arg-type]
-        try:
-            # Prune expired entries for this IP
-            conn.execute(
-                "DELETE FROM rate_limit_events WHERE client_ip = ? AND timestamp <= ?",
-                (client_ip, window_start),
-            )
-            row = conn.execute(
-                "SELECT COUNT(*) FROM rate_limit_events WHERE client_ip = ? AND timestamp > ?",
+        conn = self._conn
+        # Prune expired entries for this IP
+        conn.execute(
+            "DELETE FROM rate_limit_events WHERE client_ip = ? AND timestamp <= ?",
+            (client_ip, window_start),
+        )
+        row = conn.execute(
+            "SELECT COUNT(*) FROM rate_limit_events WHERE client_ip = ? AND timestamp > ?",
+            (client_ip, window_start),
+        ).fetchone()
+        count = row[0] if row else 0
+
+        if count >= _UPLOAD_RATE_LIMIT:
+            oldest_row = conn.execute(
+                "SELECT MIN(timestamp) FROM rate_limit_events "
+                "WHERE client_ip = ? AND timestamp > ?",
                 (client_ip, window_start),
             ).fetchone()
-            count = row[0] if row else 0
-
-            if count >= _UPLOAD_RATE_LIMIT:
-                oldest_row = conn.execute(
-                    "SELECT MIN(timestamp) FROM rate_limit_events "
-                    "WHERE client_ip = ? AND timestamp > ?",
-                    (client_ip, window_start),
-                ).fetchone()
-                oldest_ts = oldest_row[0] if oldest_row and oldest_row[0] else now
-                retry_after = int(oldest_ts - window_start) + 1
-                conn.commit()
-                return False, max(retry_after, 1)
-
-            conn.execute(
-                "INSERT INTO rate_limit_events (client_ip, timestamp) VALUES (?, ?)",
-                (client_ip, now),
-            )
+            oldest_ts = oldest_row[0] if oldest_row and oldest_row[0] else now
+            retry_after = int(oldest_ts - window_start) + 1
             conn.commit()
-            return True, 0
-        finally:
-            conn.close()
+            return False, max(retry_after, 1)
+
+        conn.execute(
+            "INSERT INTO rate_limit_events (client_ip, timestamp) VALUES (?, ?)",
+            (client_ip, now),
+        )
+        conn.commit()
+        return True, 0
 
     def _mem_is_allowed(self, client_ip: str) -> tuple[bool, int]:
         now = time.monotonic()

--- a/src/worship_catalog/web/templates/base.html
+++ b/src/worship_catalog/web/templates/base.html
@@ -66,12 +66,12 @@
     .summary-grid { display: flex; gap: 1.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
     .stat-box { background: #f1f3f5; border-radius: 6px; padding: 0.75rem 1.25rem; text-align: center; }
     .stat-box .val { font-size: 1.6rem; font-weight: 700; }
-    .stat-box .lbl { font-size: 0.75rem; color: #6c757d; }
+    .stat-box .lbl { font-size: 0.75rem; color: #495057; }
 
     .htmx-indicator { opacity: 0; transition: opacity 200ms; }
     .htmx-request .htmx-indicator { opacity: 1; }
 
-    .badge-missing { color: #dc3545; font-size: 0.8rem; }
+    .badge-missing { color: #a71d2a; font-size: 0.8rem; }
     .pagination { display:flex; gap:1rem; align-items:center; justify-content:center; padding:1rem 0; }
 
     .sr-only {

--- a/src/worship_catalog/web/templates/reports.html
+++ b/src/worship_catalog/web/templates/reports.html
@@ -46,14 +46,15 @@
     </div>
     <div style="margin-bottom:0.75rem;">
       <label for="stats-leader" style="display:block;font-size:0.8rem;font-weight:600;color:#495057;margin-bottom:0.25rem;">
-        Filter by Song Leader <span style="font-weight:400;color:#6c757d;">(optional — partial match)</span>
+        Filter by Song Leader
       </label>
-      <input type="text" id="stats-leader" name="leader" placeholder="e.g. Matt" style="width:100%;max-width:320px;">
+      <input type="text" id="stats-leader" name="leader" placeholder="e.g. Matt" style="width:100%;max-width:320px;" aria-describedby="leader-help">
+      <span id="leader-help" style="font-size:0.75rem;color:#6c757d;">Optional — partial match</span>
     </div>
     <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;">
       <button type="submit">Generate</button>
-      <label style="font-size:0.85rem;display:flex;align-items:center;gap:0.4rem;">
-        <input type="checkbox" name="all_songs" value="true"> Show all songs (not just top 20)
+      <label for="all-songs" style="font-size:0.85rem;display:flex;align-items:center;gap:0.4rem;">
+        <input type="checkbox" id="all-songs" name="all_songs" value="true"> Show all songs (not just top 20)
       </label>
       <span id="stats-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
     </div>

--- a/src/worship_catalog/web/templates/service_detail.html
+++ b/src/worship_catalog/web/templates/service_detail.html
@@ -53,15 +53,16 @@
 {% else %}
 <div class="card" style="padding:0;overflow:hidden;">
   <table>
+    <caption class="sr-only">Setlist for {{ service.service_name }} on {{ service.service_date }}</caption>
     <thead>
       <tr>
-        <th style="width:2.5rem;">#</th>
-        <th>Song</th>
-        <th>Words By</th>
-        <th>Music By</th>
-        <th>Arranger</th>
-        <th>Publisher</th>
-        <th>Reproductions</th>
+        <th scope="col" style="width:2.5rem;">#</th>
+        <th scope="col">Song</th>
+        <th scope="col">Words By</th>
+        <th scope="col">Music By</th>
+        <th scope="col">Arranger</th>
+        <th scope="col">Publisher</th>
+        <th scope="col">Reproductions</th>
       </tr>
     </thead>
     <tbody>

--- a/src/worship_catalog/web/templates/services.html
+++ b/src/worship_catalog/web/templates/services.html
@@ -93,7 +93,7 @@
         {{ sort_th("Preacher", "preacher") }}
         <th scope="col">Sermon</th>
         {{ sort_th("Songs", "song_count", align="right") }}
-        <th scope="col"></th>
+        <th scope="col"><span class="sr-only">Actions</span></th>
       </tr>
     </thead>
     <tbody id="services-tbody">
@@ -106,11 +106,11 @@
 {% if total_pages > 1 %}
 <div class="pagination">
   {% if page > 1 %}
-    <a href="/services?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}">← Prev</a>
+    <a href="/services?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}" aria-label="Previous page">← Prev</a>
   {% endif %}
   <span>Page {{ page }} of {{ total_pages }}</span>
   {% if page < total_pages %}
-    <a href="/services?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}">Next →</a>
+    <a href="/services?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}" aria-label="Next page">Next →</a>
   {% endif %}
 </div>
 {% endif %}

--- a/src/worship_catalog/web/templates/songs.html
+++ b/src/worship_catalog/web/templates/songs.html
@@ -67,11 +67,11 @@
 {% if total_pages > 1 %}
 <div class="pagination">
   {% if page > 1 %}
-    <a href="/songs?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}">← Prev</a>
+    <a href="/songs?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}" aria-label="Previous page">← Prev</a>
   {% endif %}
   <span>Page {{ page }} of {{ total_pages }}</span>
   {% if page < total_pages %}
-    <a href="/songs?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}">Next →</a>
+    <a href="/songs?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}" aria-label="Next page">Next →</a>
   {% endif %}
 </div>
 {% endif %}

--- a/src/worship_catalog/web/templates/stats_result.html
+++ b/src/worship_catalog/web/templates/stats_result.html
@@ -42,12 +42,13 @@
 
 <h3 style="font-size:1rem;margin:1rem 0 0.5rem;">{% if all_songs %}All Songs{% else %}Top Songs{% endif %}</h3>
 <table>
+  <caption class="sr-only">{% if all_songs %}All songs{% else %}Top songs{% endif %} by performance count</caption>
   <thead>
     <tr>
-      <th>#</th>
-      <th>Song</th>
-      <th>Credits</th>
-      <th style="text-align:right">Count</th>
+      <th scope="col">#</th>
+      <th scope="col">Song</th>
+      <th scope="col">Credits</th>
+      <th scope="col" style="text-align:right">Count</th>
     </tr>
   </thead>
   <tbody>

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2378,3 +2378,40 @@ class TestLikeEscaping:
         rows, total = temp_db.query_songs_paginated(search="test_")
         assert total == 1
         assert rows[0]["canonical_title"] == "test_song"
+
+
+@pytest.mark.integration
+class TestPurgeValidation:
+    """Tests for purge_old_import_jobs parameter validation (#338)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_negative_days_raises(self, temp_db):
+        with pytest.raises(ValueError, match="days must be"):
+            temp_db.purge_old_import_jobs(days=-1)
+
+    def test_zero_days_purges_old(self, temp_db):
+        temp_db.create_import_job("j1", "f.pptx", started_at="2020-01-01T00:00:00Z")
+        temp_db.purge_old_import_jobs(days=0)
+        assert temp_db.list_import_jobs() == []
+
+    def test_positive_days_keeps_recent(self, temp_db):
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).isoformat()
+        temp_db.create_import_job("j1", "f.pptx", started_at=now)
+        temp_db.purge_old_import_jobs(days=1)
+        assert len(temp_db.list_import_jobs()) == 1
+
+    def test_keep_overrides_days_validation(self, temp_db):
+        """keep=N mode should not trigger days validation."""
+        temp_db.create_import_job("j1", "f.pptx", started_at="2020-01-01T00:00:00Z")
+        temp_db.purge_old_import_jobs(days=-999, keep=1)  # no error
+        assert len(temp_db.list_import_jobs()) == 1

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -484,3 +484,69 @@ class TestOcrModelConstant:
 
         assert isinstance(_MAX_OCR_TOKENS, int)
         assert _MAX_OCR_TOKENS > 0
+
+
+class TestValidateOcrOutput:
+    """Tests for _validate_ocr_output (#339)."""
+
+    def test_rejects_long_text(self):
+        from worship_catalog.ocr import _validate_ocr_output
+        assert _validate_ocr_output("Words: " + "A" * 300) is None
+
+    def test_rejects_no_credits_keywords(self):
+        from worship_catalog.ocr import _validate_ocr_output
+        assert _validate_ocr_output("Hello World") is None
+
+    def test_rejects_no_name_pattern(self):
+        from worship_catalog.ocr import _validate_ocr_output
+        assert _validate_ocr_output("Words by the congregation") is None
+
+    def test_accepts_valid_credits(self):
+        from worship_catalog.ocr import _validate_ocr_output
+        result = _validate_ocr_output("Words: John Newton / Music: Traditional Hymn")
+        assert result is not None
+        assert "John Newton" in result
+
+    def test_accepts_arranger_credits(self):
+        from worship_catalog.ocr import _validate_ocr_output
+        result = _validate_ocr_output("Arr. Ken Young")
+        assert result is not None
+
+
+class TestExtractCreditsViaVision:
+    """Tests for the Vision API call with mocked client (#339)."""
+
+    def test_returns_none_when_api_says_none(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        msg = MagicMock()
+        msg.content = [MagicMock(text="none")]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = msg
+        mock_anthropic = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
+        mock_anthropic.APIStatusError = type("APIStatusError", (Exception,), {})
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        # Re-import to pick up the mock
+        result = extract_credits_via_vision(b"\xff\xd8fake-jpeg")
+        assert result is None
+
+    def test_returns_validated_credits(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        msg = MagicMock()
+        msg.content = [MagicMock(text="Words: John Newton / Music: Traditional")]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = msg
+        mock_anthropic = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
+        mock_anthropic.APIStatusError = type("APIStatusError", (Exception,), {})
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+        result = extract_credits_via_vision(b"\xff\xd8fake-jpeg")
+        assert result is not None
+        assert "John Newton" in result
+
+    def test_raises_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        with pytest.raises(OSError, match="ANTHROPIC_API_KEY"):
+            extract_credits_via_vision(b"\xff\xd8fake")

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+from worship_catalog.db import Database
+from worship_catalog.services.report_service import compute_stats_data
+
 
 class TestReportService:
     @pytest.fixture
@@ -102,3 +105,79 @@ class TestReportService:
         assert "James Last" in credits, (
             f"Arranger should appear in credits string, got: {credits!r}"
         )
+
+
+class TestComputeStatsDataExtended:
+    """Extended tests for compute_stats_data (#340)."""
+
+    @pytest.fixture
+    def seeded_db(self, tmp_path):
+        db = Database(tmp_path / "test.db")
+        db.connect()
+        db.init_schema()
+        s1 = db.insert_or_get_song("song a", "Song A")
+        s2 = db.insert_or_get_song("song b", "Song B")
+        svc1 = db.insert_or_update_service(
+            "2026-01-10", "AM", "a.pptx", "h1", song_leader="Matt"
+        )
+        svc2 = db.insert_or_update_service(
+            "2026-01-17", "AM", "b.pptx", "h2", song_leader="John"
+        )
+        db.insert_service_song(svc1, s1, ordinal=1)
+        db.insert_service_song(svc1, s2, ordinal=2)
+        db.insert_service_song(svc2, s1, ordinal=1)
+        db.insert_or_get_copy_event(svc1, s1, "projection")
+        db.insert_or_get_copy_event(svc1, s2, "projection")
+        db.insert_or_get_copy_event(svc2, s1, "projection")
+        yield db
+        db.close()
+
+    def test_leader_filter_returns_only_matching(self, seeded_db):
+        data = compute_stats_data(seeded_db, "2020-01-01", "2030-12-31", "Matt", False)
+        assert len(data["services"]) == 1
+        assert data["services"][0]["song_leader"] == "Matt"
+
+    def test_leader_filter_excludes_others(self, seeded_db):
+        data = compute_stats_data(seeded_db, "2020-01-01", "2030-12-31", "Matt", False)
+        leaders = [s["song_leader"] for s in data["services"]]
+        assert "John" not in leaders
+
+    def test_all_songs_false_limits_to_top_20(self, tmp_path):
+        db = Database(tmp_path / "top20.db")
+        db.connect()
+        db.init_schema()
+        svc = db.insert_or_update_service("2026-01-01", "AM", "a.pptx", "h1")
+        for i in range(25):
+            sid = db.insert_or_get_song(f"song {i}", f"Song {i}")
+            db.insert_service_song(svc, sid, ordinal=i + 1)
+            db.insert_or_get_copy_event(svc, sid, "projection")
+        data = compute_stats_data(db, "2020-01-01", "2030-12-31", None, False)
+        assert len(data["sorted_songs"]) == 20
+        db.close()
+
+    def test_all_songs_true_returns_all(self, tmp_path):
+        db = Database(tmp_path / "all.db")
+        db.connect()
+        db.init_schema()
+        svc = db.insert_or_update_service("2026-01-01", "AM", "a.pptx", "h1")
+        for i in range(25):
+            sid = db.insert_or_get_song(f"song {i}", f"Song {i}")
+            db.insert_service_song(svc, sid, ordinal=i + 1)
+            db.insert_or_get_copy_event(svc, sid, "projection")
+        data = compute_stats_data(db, "2020-01-01", "2030-12-31", None, True)
+        assert len(data["sorted_songs"]) == 25
+        db.close()
+
+    def test_date_boundary_includes_exact_match(self, seeded_db):
+        data = compute_stats_data(seeded_db, "2026-01-10", "2026-01-10", None, False)
+        assert len(data["services"]) == 1
+        assert data["services"][0]["service_date"] == "2026-01-10"
+
+    def test_leader_breakdown_present_when_no_filter(self, seeded_db):
+        data = compute_stats_data(seeded_db, "2020-01-01", "2030-12-31", None, False)
+        assert "Matt" in data["leader_breakdown"]
+        assert "John" in data["leader_breakdown"]
+
+    def test_leader_breakdown_empty_when_filter_set(self, seeded_db):
+        data = compute_stats_data(seeded_db, "2020-01-01", "2030-12-31", "Matt", False)
+        assert data["leader_breakdown"] == {}


### PR DESCRIPTION
## Summary

Closes all 10 active issues from Review 9, bringing the active backlog to zero.

**Accessibility (#335, #336, #337, #342):** Report form checkbox id and aria-describedby, table captions/scope on detail pages, action column sr-only label, pagination aria-labels, contrast fixes for stat labels and missing badges.

**Security (#344):** Startup warning when CSRF_SECRET not set — documents single-process limitation.

**Performance (#341):** Rate limiter keeps a persistent SQLite connection instead of opening/closing per check.

**Code quality (#338, #343):** purge_old_import_jobs validates days >= 0; query_services uses explicit column list.

**Tests (#339, #340):** OCR output validation and Vision API tests with mocked client; report_service tests for leader filter, top-20 limit, date boundaries, leader breakdown.

## Test plan
- [x] 978 tests pass
- [x] ruff + mypy clean
- [ ] CI passes

Closes #335, #336, #337, #338, #339, #340, #341, #342, #343, #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)