### PR TITLE
chore: update requirements.lock — anthropic 0.103.0, jiter 0.15.0

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.102.0
+anthropic==0.103.0
     # via worship-catalog (pyproject.toml)
 anyio==4.13.0
     # via
@@ -45,7 +45,7 @@ itsdangerous==2.2.0
     # via starlette-csrf
 jinja2==3.1.6
     # via worship-catalog (pyproject.toml)
-jiter==0.14.0
+jiter==0.15.0
     # via anthropic
 lxml==6.1.1
     # via python-pptx


### PR DESCRIPTION
Routine lockfile refresh. `anthropic` released 0.103.0 and `jiter` 0.15.0 since the last compile, causing the CI lockfile freshness check to fail on dependabot PRs 369 and 373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)