### PR TITLE
chore: add ast_serialize to SBOM baseline (mypy 2.x dep)

### DIFF
--- a/sbom-baseline.txt
+++ b/sbom-baseline.txt
@@ -1,6 +1,7 @@
 annotated-doc
 annotated-types
 anthropic
+ast_serialize
 anyio
 bandit
 boolean.py


### PR DESCRIPTION
`ast_serialize` is a new transitive dependency introduced by mypy 2.x. It's needed to unblock dependabot PR #369 (mypy `<2` → `<3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)