### PR TITLE
fix: disable FK checks during migration v3 services table swap

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -97,8 +97,12 @@ _MIGRATIONS: dict[int, list[str]] = {
                song_leader, preacher, sermon_title, imported_at
         FROM services
         """,
+        # Disable FK checks while swapping the table so SQLite allows
+        # DROP TABLE on a parent table referenced by child FKs.
+        "PRAGMA foreign_keys=OFF",
         "DROP TABLE services",
         "ALTER TABLE services_new RENAME TO services",
+        "PRAGMA foreign_keys=ON",
         "CREATE INDEX IF NOT EXISTS idx_services_date ON services(service_date)",
     ],
 }


### PR DESCRIPTION
## Problem

Migration v3 crashes on startup with `sqlite3.IntegrityError: FOREIGN KEY constraint failed` when trying to `DROP TABLE services`.

Root cause: `connect()` sets `PRAGMA foreign_keys=ON`. SQLite with FK enforcement enabled refuses to drop a parent table (`services`) while child tables (`service_songs`, `copy_events`) have rows with `service_id` FK references pointing to it.

This was not caught by tests because test fixtures use a fresh `Database()` via context manager — the test DB is empty when migrations run, so there are no child rows to trigger the constraint.

## Fix

Bracket the `DROP TABLE services` / `ALTER TABLE services_new RENAME TO services` swap with `PRAGMA foreign_keys=OFF` / `PRAGMA foreign_keys=ON`. FK enforcement is fully restored after — verified by asserting that a bogus INSERT into `service_songs` is rejected post-migration.

## Impact

Pi-songs is currently down (container crash-loops on startup). This unblocks it.

## Test plan

- [ ] `python3 -m pytest tests/test_db_integration.py -x -q` passes
- [ ] CI green
- [ ] After merge + publish: `docker compose pull && docker compose up -d` on pi-songs; migration v3 runs cleanly in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)