### PR TITLE
fix: commit before PRAGMA in migration v3 so FK toggle actually takes effect

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -50,6 +50,9 @@ _MIGRATIONS: dict[int, list[str]] = {
         # date+name updates the existing row rather than inserting a duplicate.
         # SQLite doesn't support DROP CONSTRAINT, so we dedup then recreate the table.
         #
+        # Guard: if a previous interrupted migration left services_new behind,
+        # drop it so this migration can run cleanly from scratch.
+        "DROP TABLE IF EXISTS services_new",
         # Step 1 — drop child rows for the loser duplicates (keep highest id per group).
         """
         DELETE FROM copy_events
@@ -97,8 +100,10 @@ _MIGRATIONS: dict[int, list[str]] = {
                song_leader, preacher, sermon_title, imported_at
         FROM services
         """,
-        # Disable FK checks while swapping the table so SQLite allows
-        # DROP TABLE on a parent table referenced by child FKs.
+        # Disable FK enforcement so DROP TABLE succeeds even though child
+        # tables (service_songs, copy_events) have rows referencing services.
+        # _apply_migrations issues COMMIT before any PRAGMA so this PRAGMA
+        # takes effect (it is a no-op inside a transaction).
         "PRAGMA foreign_keys=OFF",
         "DROP TABLE services",
         "ALTER TABLE services_new RENAME TO services",
@@ -383,6 +388,11 @@ class Database:
             if version in applied:
                 continue
             for stmt in _MIGRATIONS[version]:
+                # PRAGMA foreign_keys is a no-op inside a transaction (SQLite
+                # rule).  Commit any pending implicit DML transaction first so
+                # the PRAGMA takes effect immediately.
+                if stmt.strip().upper().startswith("PRAGMA"):
+                    self._conn.commit()
                 cursor.execute(stmt)
             cursor.execute(
                 "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",


### PR DESCRIPTION
## Problem

PR #379 attempted to fix the migration v3 FK crash by adding `PRAGMA foreign_keys=OFF` before `DROP TABLE services`, but the container still crash-loops with the same error.

Root cause: **`PRAGMA foreign_keys` is a no-op inside a transaction** (SQLite rule). Python's `sqlite3` module starts an implicit transaction on the first `INSERT` statement and does NOT commit it before the subsequent `PRAGMA` — so the PRAGMA is silently ignored and `foreign_keys` stays ON. The `DROP TABLE` then fails.

Verified with `conn.in_transaction`:
```
in_txn after INSERT: True
FK after PRAGMA OFF (in txn): 1  ← ignored
DROP TABLE FAIL: FOREIGN KEY constraint failed
```

## Fix

Two changes:

1. **`_apply_migrations`**: commit any pending implicit transaction before executing a `PRAGMA` statement, so SQLite honours it.
2. **Migration v3**: add `DROP TABLE IF EXISTS services_new` as the first statement — guard against a partially-completed migration leaving the staging table behind.

The PRAGMA position stays after the `INSERT` (where the ordering makes logical sense); the commit is issued by `_apply_migrations` at the Python layer.

## Verified

```python
# before fix: FK=1 after PRAGMA (no-op), DROP TABLE fails
# after fix:  FK=0 after PRAGMA (honoured), DROP TABLE OK, FK=1 after restore
```

## Impact

Pi-songs is still down. This is the correct fix to unblock it.

## Test plan

- [ ] `python3 -m pytest tests/test_db_integration.py tests/test_cli.py -q` — all pass
- [ ] CI green
- [ ] After merge + publish: `docker compose pull && docker compose up -d` on pi-songs; migration v3 runs without error; health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)