### PR TITLE
feat: filter non-song titles from extraction + cleanup delete-song

### DIFF
--- a/src/worship_catalog/cli.py
+++ b/src/worship_catalog/cli.py
@@ -1028,6 +1028,83 @@ def find_duplicates(db: str) -> None:
         sys.exit(1)
 
 
+@cleanup.command(name="delete-song")
+@click.option(
+    "--id",
+    "song_ids",
+    type=int,
+    multiple=True,
+    required=True,
+    help="Song ID to delete (repeatable).",
+)
+@click.option(
+    "--db",
+    type=click.Path(),
+    default="data/worship.db",
+    help="Path to SQLite database",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be deleted without modifying the database",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+def delete_song(song_ids: tuple[int, ...], db: str, dry_run: bool, yes: bool) -> None:
+    """Delete specific songs by ID, with their editions and copy_events.
+
+    Use this to remove non-song entries (sermon points, scripture quotes,
+    lyric fragments) that were mistakenly recorded. Unlike orphaned-songs,
+    this targets exact IDs even when they still have performance links.
+    """
+    try:
+        db_path = Path(db)
+
+        with Database(db_path) as database:
+            found = []
+            for song_id in song_ids:
+                song = database.query_song_by_id(song_id)
+                if song is None:
+                    click.echo(f"Song ID {song_id} not found.", err=True)
+                    sys.exit(1)
+                perf = len(database.query_song_services(song_id))
+                found.append((song_id, song["display_title"], perf))
+
+            click.echo(f"Found {len(found)} song(s) to delete:")
+            for song_id, title, perf in found:
+                click.echo(f"  ID={song_id}  {title}  ({perf} performance(s))")
+
+            if dry_run:
+                click.echo(f"\nDry run — would delete {len(found)} song(s).")
+                sys.exit(0)
+
+            if not yes:
+                click.confirm("Proceed?", abort=True)
+
+            for song_id, title, _ in found:
+                database.delete_song(song_id)
+                _log.info(
+                    "Deleted song",
+                    extra={"song_id": song_id, "title": title},
+                )
+
+        click.echo(f"Deleted {len(found)} song(s).")
+        sys.exit(0)
+
+    except click.Abort:
+        click.echo("\nAborted.")
+        sys.exit(1)
+    except SystemExit:
+        raise
+    except Exception as e:
+        _log.exception("cleanup delete-song error", extra={"error": str(e)})
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
 @cleanup.command(name="dedup-services")
 @click.option(
     "--db",

--- a/src/worship_catalog/extractor.py
+++ b/src/worship_catalog/extractor.py
@@ -12,6 +12,7 @@ from worship_catalog.normalize import (
     _TITLE_MAX_LENGTH,
     canonicalize_title,
     detect_publisher,
+    is_non_song_title,
     parse_credits,
     select_best_title,
     strip_title_prefix,
@@ -351,12 +352,22 @@ def _extract_songs_impl(
     # Step 4: Convert groups to song occurrences
     # Create a single CreditResolver for the entire run so that the
     # shared ocr_budget is explicitly passed once, not recreated per-song (#291).
+    # Drop occurrences whose final title is not a real song — sermon points,
+    # scripture quotes, verse/stanza markers, and lyric fragments that the
+    # grouping step mistakenly split out. Filtering on the FINAL title (rather
+    # than during candidate selection) avoids perturbing slide grouping.
     resolver = CreditResolver(library_index=library_index, ocr_budget=ocr_budget, use_ocr=use_ocr)
-    songs = []
-    for ordinal, (canonical, group) in enumerate(song_groups, 1):
+    songs: list[SongOccurrence] = []
+    for canonical, group in song_groups:
         song = _create_song_occurrence(
-            ordinal, canonical, group, resolver=resolver,
+            len(songs) + 1, canonical, group, resolver=resolver,
         )
+        if is_non_song_title(song.display_title):
+            _log.debug(
+                "Dropped non-song title %r from %s", song.display_title, file_path.name
+            )
+            continue
+        song.ordinal = len(songs) + 1
         songs.append(song)
 
     _log.debug(

--- a/src/worship_catalog/normalize.py
+++ b/src/worship_catalog/normalize.py
@@ -141,6 +141,85 @@ _SCRIPTURE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Paperless Hymnal "Songs For Praise" catalog numbers (e.g. "SFP 373") — reference
+# IDs, never song titles (#264).
+_SFP_CATALOG_RE = re.compile(r"^SFP\s+\d{3,4}$", re.IGNORECASE)
+
+# Opening / closing quotation marks (straight + curly). A line wrapped in these
+# is a quoted sentence (e.g. scripture), not a title.
+_OPEN_QUOTES = ('"', "“", "‘")  # " “ ‘
+_CLOSE_QUOTES = ('"', "”", "’")  # " ” ’
+_TERMINAL_PUNCT = (".", "?", "!")
+
+# A line counts as "sentence-like" prose (not a title) when it ends in terminal
+# punctuation AND is long enough to be a real sentence. Short titles that happen
+# to end in "?" or "!" ("Does Jesus Care?", "Praise Him! Praise Him!") are spared.
+_SENTENCE_MIN_WORDS = 7
+_SENTENCE_MIN_COMMAS = 2
+
+
+def _starts_with_lowercase(stripped: str) -> bool:
+    """True if the first alphabetic character is lowercase (a lyric fragment)."""
+    for ch in stripped:
+        if ch.isalpha():
+            return ch.islower()
+    return False
+
+
+def _looks_like_non_title(stripped: str) -> bool:
+    """Heuristics that reject sermon points, scripture quotes, verse/stanza
+    markers, and lyric fragments mistakenly captured as song titles.
+
+    Validated against the full production catalog: no real title starts with a
+    lowercase letter, ends in a comma, contains a colon, or ends in terminal
+    punctuation while being sentence-length.
+    """
+    if not stripped:
+        return False
+
+    # Only punctuation and digits (e.g. ":7", ".") — a stray fragment.
+    if re.fullmatch(r"[\s\d.:;,()–—-]+", stripped):
+        return True
+
+    # SFP catalog numbers.
+    if _SFP_CATALOG_RE.match(stripped):
+        return True
+
+    # Leading verse / stanza markers: "(6) ...", "St. 2 ...", leading ". "/": ".
+    if re.match(r"^\(\d+\)", stripped):
+        return True
+    if re.match(r"^St\.\s*\d", stripped, re.IGNORECASE):
+        return True
+    if re.match(r"^[.:]\s", stripped):
+        return True
+    if "(vv." in stripped.lower() or "(v." in stripped.lower():
+        return True
+
+    # Lyric fragments: lowercase start or trailing comma (continuation).
+    if _starts_with_lowercase(stripped):
+        return True
+    if stripped.endswith(","):
+        return True
+
+    # Quote-wrapped sentences (scripture quotes).
+    if stripped.startswith(_OPEN_QUOTES) and stripped.endswith(_CLOSE_QUOTES):
+        return True
+
+    # Sermon-point label: "Label: text" — no real title contains a colon+space.
+    if ": " in stripped:
+        return True
+
+    # Sentence-like prose: ends in terminal punctuation (ignoring a trailing
+    # closing quote) and is long enough to be a sentence rather than a title.
+    core = stripped.rstrip("".join(_CLOSE_QUOTES) + " ")
+    if core and core[-1] in _TERMINAL_PUNCT:
+        long_enough = len(stripped.split()) >= _SENTENCE_MIN_WORDS
+        comma_heavy = stripped.count(",") >= _SENTENCE_MIN_COMMAS
+        if long_enough or comma_heavy:
+            return True
+
+    return False
+
 
 def _is_invalid_line(line: str) -> bool:
     """Check if a line is a footer/copyright/invalid marker."""
@@ -182,6 +261,24 @@ def _is_invalid_line(line: str) -> bool:
         return True
 
     return False
+
+
+def is_non_song_title(title: str) -> bool:
+    """Return True if *title* is not a real song title.
+
+    Combines the scripture/SFP/sentence/lyric-fragment heuristics. Used as a
+    post-extraction filter to drop sermon points, scripture quotes, verse/stanza
+    markers, and lyric fragments that were mistakenly grouped as songs.
+
+    This is applied to the FINAL chosen title rather than to candidate
+    selection, so it does not perturb slide grouping.
+    """
+    stripped = title.strip()
+    if not stripped:
+        return True
+    if _SCRIPTURE_RE.match(stripped):
+        return True
+    return _looks_like_non_title(stripped)
 
 
 def canonicalize_title(title: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2139,3 +2139,76 @@ class TestDedupServicesCommand:
         db.connect()
         assert db.query_duplicate_services() == []
         db.close()
+
+
+class TestDeleteSongCommand:
+    """Tests for `cleanup delete-song --id` (targeted song removal)."""
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    def test_delete_song_listed_in_cleanup_help(self, runner):
+        result = runner.invoke(main, ["cleanup", "--help"])
+        assert result.exit_code == 0
+        assert "delete-song" in result.output
+
+    def test_delete_song_by_id(self, runner, db_with_songs):
+        """delete-song --id <N> removes the song, its editions, and copy_events."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-song", "--id", "1", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_song_by_id(1) is None
+        assert db.query_song_by_id(2) is not None  # untouched
+        db.close()
+
+    def test_delete_song_shows_title(self, runner, db_with_songs):
+        """delete-song shows the title (and performance count) before deleting."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-song", "--id", "1", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        assert "Amazing Grace" in result.output
+
+    def test_delete_song_multiple_ids(self, runner, db_with_songs):
+        """delete-song accepts multiple --id options."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-song", "--id", "1", "--id", "2",
+            "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_song_by_id(1) is None
+        assert db.query_song_by_id(2) is None
+        db.close()
+
+    def test_delete_song_dry_run_does_not_delete(self, runner, db_with_songs):
+        """--dry-run reports the target but leaves the song in place."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-song", "--id", "1",
+            "--db", str(db_with_songs), "--dry-run"
+        ])
+        assert result.exit_code == 0
+        assert "Amazing Grace" in result.output
+        db = Database(db_with_songs)
+        db.connect()
+        assert db.query_song_by_id(1) is not None
+        db.close()
+
+    def test_delete_song_not_found(self, runner, db_with_songs):
+        """delete-song with an unknown id exits non-zero."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-song", "--id", "999", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 1
+
+    def test_delete_song_requires_id(self, runner, db_with_songs):
+        """delete-song with no --id errors out."""
+        result = runner.invoke(main, [
+            "cleanup", "delete-song", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code != 0

--- a/tests/test_extraction_integration.py
+++ b/tests/test_extraction_integration.py
@@ -183,3 +183,81 @@ class TestExtractionAccuracy:
             assert actual_song.canonical_title == expected_song["canonical_title"]
             assert actual_song.display_title == expected_song["display_title"]
             assert actual_song.publisher == expected_song.get("publisher")
+
+
+# Real worship decks (dev machines only — never committed; these are real service
+# files). Each previously produced spurious "songs" from sermon/scripture/lyric
+# slides. Regression guard for the non-song output filter.
+_HIGHLAND_DIR = Path.home() / "Dropbox" / "Highland"
+
+_NON_SONG_REGRESSION = {
+    "PM Worship 2026.4.5.pptx": {
+        "must_contain": [
+            "Alleluia, Alleluia! Hearts to Heaven",
+            "We Saw Thee Not",
+            "The Lord's My Shepherd",
+            "Jesus, the Loving Shepherd",
+            "He Lives",
+            "Our God, He Is Alive",
+        ],
+        "must_not_contain": [
+            "us Christ, the King of Glory,",
+            "they comfort me.",
+            "St. 2 The Lord as Host (vv. 5–6)",
+            "The Simplest Truth: The Lord is My Deliverer",
+            ":7",
+        ],
+    },
+    "AM Worship 2026.4.12.pptx": {
+        "must_contain": [
+            "Angels Are Singing",
+            "Nailed To The Cross",
+            "All Things Are Ready",
+            "Paradise Valley",
+        ],
+        "must_not_contain": [
+            "(6) Humble yourselves, therefore, under the mighty hand of God "
+            "so that at the proper time he may exalt you",
+        ],
+    },
+    "PM Worship 2026.5.10 Jeremy.pptx": {
+        "must_contain": [
+            "Christ for the World We Sing",
+            "Jesus Paid It All",
+            "Nothing But the Blood",
+            "Stand Up, Stand Up for Jesus",
+        ],
+        "must_not_contain": [
+            "sick and sorrowworn,",
+        ],
+    },
+}
+
+
+@pytest.mark.integration
+class TestNonSongFilterRegression:
+    """Real decks must no longer yield sermon/scripture/lyric-fragment songs.
+
+    Skips in CI (files are dev-only and intentionally uncommitted).
+    """
+
+    @pytest.mark.parametrize("filename", list(_NON_SONG_REGRESSION))
+    def test_no_non_song_titles(self, filename):
+        from worship_catalog.normalize import is_non_song_title
+
+        path = _HIGHLAND_DIR / filename
+        if not path.exists():
+            pytest.skip(f"Real worship deck not found: {path}")
+
+        result = extract_songs(path)
+        titles = [s.display_title for s in result.songs]
+
+        # No extracted title may look like a non-song.
+        offenders = [t for t in titles if is_non_song_title(t)]
+        assert offenders == [], f"{filename}: non-song titles leaked: {offenders}"
+
+        spec = _NON_SONG_REGRESSION[filename]
+        for junk in spec["must_not_contain"]:
+            assert junk not in titles, f"{filename}: should not contain {junk!r}"
+        for real in spec["must_contain"]:
+            assert real in titles, f"{filename}: missing real song {real!r}"

--- a/tests/test_title_normalize.py
+++ b/tests/test_title_normalize.py
@@ -282,6 +282,74 @@ class TestScriptureGuard:
 
 
 @pytest.mark.unit
+class TestNonSongTitleFilter:
+    """is_non_song_title() drops sermon points, scripture quotes, verse/stanza
+    markers, and lyric fragments that the grouping step mistakenly split out.
+
+    Applied to the FINAL chosen title (post-extraction) so it does not perturb
+    slide grouping. These are the real false positives observed in production.
+    """
+
+    # Titles that must be rejected (NOT real songs).
+    NON_TITLES = [
+        ":7",  # bare verse fragment
+        "And when he has found it, he lays it on his shoulders, rejoicing.",  # scripture prose
+        "(6) Humble yourselves, therefore, under the mighty hand of God "
+        "so that at the proper time he may exalt you",  # leading (N) + prose
+        "St. 2 The Lord as Host (vv. 5–6)",  # stanza + verse markers
+        'The Simplest Promise: “You are with me”',  # sermon point w/ quote
+        "The Simplest Truth: The Lord is My Deliverer",  # sermon point (colon)
+        'Many of them said, “He has a demon, and is insane; '
+        'why listen to him?”',  # scripture quote ending ?"
+        "“Ah, shepherds of Israel who have been feeding yourselves! "
+        "Should not shepherds feed the sheep?”",  # quote-wrapped
+        ". SALVATION IS COMPLETELY THE WORK OF GOD, THE MOST HIGH.",  # leading . + caps
+        "MICAH 6:6 – 8",  # scripture reference
+        "us Christ, the King of Glory,",  # lyric: lowercase start + trailing comma
+        "sick and sorrowworn,",  # lyric: lowercase start + trailing comma
+        "they comfort me.",  # lyric: lowercase start
+        "SFP 373",  # Paperless Hymnal catalog number
+        "SFP 878",
+        "",  # empty
+        "   ",  # whitespace only
+    ]
+
+    # Real titles from production that must NOT be rejected.
+    REAL_TITLES = [
+        "Amazing Grace",
+        "Are You Washed in the Blood?",
+        "Does Jesus Care?",
+        "Praise Him! Praise Him!",
+        "Lovest Thou Me More Than These?",
+        "He arose! He arose!",
+        "Where Could I Go?",
+        "Alleluia, Alleluia! Hearts to Heaven",
+        "‘Tis So Sweet to Trust in Jesus",
+        "The Lord's My Shepherd",
+        "Praise to the Lord, the Almighty, the King of Creation",
+        "Come, We That Love the Lord",
+        "Stand Up, Stand Up for Jesus",
+        "I Love You, Lord",
+        "God’s Family",
+        "How Deep the Father’s Love",
+        "10,000 Reasons",
+        "We Saw Thee Not",
+    ]
+
+    @pytest.mark.parametrize("title", NON_TITLES)
+    def test_non_titles_are_dropped(self, title):
+        from worship_catalog.normalize import is_non_song_title
+
+        assert is_non_song_title(title) is True
+
+    @pytest.mark.parametrize("title", REAL_TITLES)
+    def test_real_titles_are_kept(self, title):
+        from worship_catalog.normalize import is_non_song_title
+
+        assert is_non_song_title(title) is False
+
+
+@pytest.mark.unit
 class TestSermonOutlineNotStripped:
     """Sermon outline numbered points should not be stripped (#314)."""
 


### PR DESCRIPTION
## Summary

Sermon points, scripture quotes, verse/stanza markers, and lyric fragments were being recorded as songs in the library. Examples found in production: `us Christ, the King of Glory,`, `The Simplest Truth: The Lord is My Deliverer`, `(6) Humble yourselves, therefore…`, `:7`, `"Ah, shepherds of Israel…?"`.

Root cause: on messy decks (sermon slides interleaved with songs, or a lyric slide appearing before its title slide), the grouping step splits out spurious "songs" and `select_best_title` picks a lyric/prose line. Tightening title *selection* only shifts which junk line wins and perturbs grouping — so instead this filters on the **final chosen title** post-extraction.

### Changes
- **`normalize.is_non_song_title()`** — heuristics validated against the entire production catalog (zero false positives): lowercase start, trailing comma, quote-wrapped, colon label, leading `(N)`/`St. N`/`vv.` markers, punctuation-only fragments, SFP catalog numbers, scripture refs, and sentence-like prose (terminal punctuation with ≥7 words or ≥2 commas).
- **`extractor`** — drop occurrences whose final title is a non-song, then renumber ordinals. Grouping is untouched.
- **`cleanup delete-song --id N (repeatable) [--dry-run] [--yes]`** — targeted removal of specific song rows that still have performance links (`orphaned-songs` only reaches songs with zero links).

### Verified on the three real decks that produced the junk
- PM 4.5: 15 entries → 6 real songs (Alleluia/We Saw Thee Not/Lord's My Shepherd/Jesus the Loving Shepherd/He Lives/Our God He Is Alive)
- AM 4.12: drops `(6) Humble yourselves…`
- PM 5.10: drops `sick and sorrowworn,` (a fragment of "Christ for the World We Sing", already captured)

## Test plan
- [x] `pytest` — 1075 passed, 42 skipped
- [x] `ruff check src/` clean
- [x] `mypy src/` clean
- [x] New unit tests (`is_non_song_title` junk vs. real), integration regression guard over the 3 real decks (skips in CI — files dev-only), CLI tests for `delete-song`
- [ ] CI green

## Notes / follow-ups
- The data cleanup of the 15 existing junk rows in production will be run via `cleanup delete-song` after this deploys.
- Separately discovered: `PM Worship 2026.4.5.pptx` yields `date=None` (stored as `0000-00-00`) because that deck puts metadata keys/values on separate lines — filing as its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)