### PR TITLE
fix: metadata separate-line parsing, pagination sync, date normalization (#385 #386 #387)

### DIFF
--- a/src/worship_catalog/cli.py
+++ b/src/worship_catalog/cli.py
@@ -1105,6 +1105,82 @@ def delete_song(song_ids: tuple[int, ...], db: str, dry_run: bool, yes: bool) ->
         sys.exit(1)
 
 
+@cleanup.command(name="normalize-dates")
+@click.option(
+    "--db",
+    type=click.Path(),
+    default="data/worship.db",
+    help="Path to SQLite database",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would change without modifying the database",
+)
+@click.option(
+    "--yes",
+    is_flag=True,
+    help="Skip confirmation prompt",
+)
+def normalize_dates(db: str, dry_run: bool, yes: bool) -> None:
+    """Rewrite non-ISO service dates to canonical YYYY-MM-DD (#387).
+
+    Dates like '2026.05.10' or '2026-05.10' are normalized to '2026-05-10'.
+    Rows that would collide with an existing (date, service_name) are reported
+    and left untouched.
+    """
+    try:
+        db_path = Path(db)
+
+        with Database(db_path) as database:
+            report = database.normalize_service_dates(dry_run=True)
+
+            if not report:
+                click.echo("No non-ISO service dates found.")
+                sys.exit(0)
+
+            changes = [r for r in report if not r["collision"]]
+            collisions = [r for r in report if r["collision"]]
+
+            click.echo(f"Found {len(report)} service(s) with non-ISO dates:")
+            for r in changes:
+                click.echo(
+                    f"  ID={r['service_id']}  {r['old_date']} → {r['new_date']}"
+                    f"  ({r['service_name']})"
+                )
+            for r in collisions:
+                click.echo(
+                    f"  ID={r['service_id']}  {r['old_date']} → {r['new_date']}"
+                    f"  ({r['service_name']})  [SKIPPED — collides with existing service]"
+                )
+
+            if dry_run:
+                click.echo(f"\nDry run — would rewrite {len(changes)} date(s).")
+                sys.exit(0)
+
+            if not changes:
+                click.echo("\nNothing to rewrite (all remaining are collisions).")
+                sys.exit(0)
+
+            if not yes:
+                click.confirm("Proceed?", abort=True)
+
+            database.normalize_service_dates(dry_run=False)
+
+        click.echo(f"Rewrote {len(changes)} service date(s).")
+        sys.exit(0)
+
+    except click.Abort:
+        click.echo("\nAborted.")
+        sys.exit(1)
+    except SystemExit:
+        raise
+    except Exception as e:
+        _log.exception("cleanup normalize-dates error", extra={"error": str(e)})
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+
 @cleanup.command(name="dedup-services")
 @click.option(
     "--db",

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1244,6 +1244,55 @@ class Database:
         self._maybe_commit()
         return losers
 
+    def normalize_service_dates(self, *, dry_run: bool = False) -> list[dict[str, Any]]:
+        """Rewrite non-ISO service dates to canonical ``YYYY-MM-DD`` (#387).
+
+        Returns a report: one dict per row whose stored date differs from its
+        normalized form, with ``service_id``, ``old_date``, ``new_date`` and a
+        ``collision`` flag.  A collision means another service already occupies
+        ``(new_date, service_name)`` — that row is reported but NOT rewritten,
+        to avoid violating ``UNIQUE(service_date, service_name)``.  When
+        *dry_run* is True nothing is written.
+        """
+        from worship_catalog.pptx_reader import normalize_service_date
+
+        cursor = self._conn.cursor()
+        cursor.execute("SELECT id, service_date, service_name FROM services")
+        rows = [dict(r) for r in cursor.fetchall()]
+
+        report: list[dict[str, Any]] = []
+        for row in rows:
+            old_date = row["service_date"]
+            new_date = normalize_service_date(old_date)
+            if new_date == old_date:
+                continue
+            cursor.execute(
+                """SELECT id FROM services
+                   WHERE service_date = ? AND service_name = ? AND id != ?""",
+                (new_date, row["service_name"], row["id"]),
+            )
+            collision = cursor.fetchone() is not None
+            report.append({
+                "service_id": row["id"],
+                "old_date": old_date,
+                "new_date": new_date,
+                "service_name": row["service_name"],
+                "collision": collision,
+            })
+
+        if dry_run:
+            return report
+
+        for item in report:
+            if item["collision"]:
+                continue
+            cursor.execute(
+                "UPDATE services SET service_date = ? WHERE id = ?",
+                (item["new_date"], item["service_id"]),
+            )
+        self._maybe_commit()
+        return report
+
     def delete_song(self, song_id: int) -> None:
         """Delete a song, its editions, and any related copy_events."""
         cursor = self._conn.cursor()

--- a/src/worship_catalog/pptx_reader.py
+++ b/src/worship_catalog/pptx_reader.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -155,11 +156,51 @@ def parse_all_slides(prs: Presentation) -> list[Slide]:  # type: ignore[valid-ty
     return slides
 
 
+# Date components separated by any mix of '.', '-', '/'. Used to canonicalize
+# service dates to ISO YYYY-MM-DD (#387).
+_DATE_PARTS_RE = re.compile(r"^(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})$")
+
+
+def normalize_service_date(raw: str | None) -> str | None:
+    """Canonicalize a service date string to ISO ``YYYY-MM-DD``.
+
+    Accepts any mix of ``.``, ``-`` and ``/`` separators and single-digit
+    month/day (e.g. ``2026.5.10`` → ``2026-05-10``). Returns None for empty
+    input, and the stripped original for anything that isn't a recognizable
+    year-month-day triple (so we never silently drop an unexpected value).
+    """
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    match = _DATE_PARTS_RE.match(stripped)
+    if not match:
+        return stripped
+    year, month, day = match.groups()
+    return f"{year}-{int(month):02d}-{int(day):02d}"
+
+
+# Metadata field keys (lowercased) → ServiceMetadata attribute name.
+_METADATA_FIELD_KEYS: dict[str, str] = {
+    "date": "date",
+    "service": "service_name",
+    "song leader": "song_leader",
+    "preacher": "preacher",
+    "sermon title": "sermon_title",
+}
+# Header/section labels that are never values.
+_METADATA_HEADER_KEYS: frozenset[str] = frozenset({"service data", "metadata", "service info"})
+
+
 def extract_metadata_from_table_slide(slide_text_lines: list[str]) -> ServiceMetadata:
     """
     Extract service metadata from a table slide.
 
-    Expected format: alternating key-value pairs (may have header row like "Service Data").
+    Keys and values live on separate lines. Rather than assume strict
+    even/odd key-value alignment (which a stray header/blank line silently
+    breaks, #385), scan for each recognized key and take the next non-empty
+    line that is not itself a key/header as its value.
     """
     result = ServiceMetadata(
         date=None,
@@ -169,35 +210,22 @@ def extract_metadata_from_table_slide(slide_text_lines: list[str]) -> ServiceMet
         sermon_title=None,
     )
 
-    if not slide_text_lines:
-        return result
-
-    # Skip first line if it's a header
-    start_idx = 0
-    if slide_text_lines[0].lower() in ("service data", "metadata", "service info"):
-        start_idx = 1
-
-    # Convert to dict (assumes alternating key-value pairs)
-    i = start_idx
-    metadata_dict = {}
-    while i < len(slide_text_lines) - 1:
-        key = slide_text_lines[i].lower().strip()
-        value = slide_text_lines[i + 1].strip()
-        if value:  # Only store non-empty values
-            metadata_dict[key] = value
-        i += 2
-
-    # Map to result
-    if "date" in metadata_dict:
-        result.date = metadata_dict["date"]
-    if "service" in metadata_dict:
-        result.service_name = metadata_dict["service"]
-    if "song leader" in metadata_dict:
-        result.song_leader = metadata_dict["song leader"]
-    if "preacher" in metadata_dict:
-        result.preacher = metadata_dict["preacher"]
-    if "sermon title" in metadata_dict:
-        result.sermon_title = metadata_dict["sermon title"]
+    n = len(slide_text_lines)
+    for idx, raw in enumerate(slide_text_lines):
+        key = raw.strip().lower()
+        attr = _METADATA_FIELD_KEYS.get(key)
+        if attr is None or getattr(result, attr) is not None:
+            continue
+        # Value = next non-empty line before the next key/header.
+        for j in range(idx + 1, n):
+            cand = slide_text_lines[j].strip()
+            if not cand:
+                continue
+            cand_lower = cand.lower()
+            if cand_lower in _METADATA_FIELD_KEYS or cand_lower in _METADATA_HEADER_KEYS:
+                break  # next key reached — this field has no value
+            setattr(result, attr, cand)
+            break
 
     return result
 
@@ -210,8 +238,6 @@ def parse_filename_for_metadata(filename: str) -> ServiceMetadata:
     - AM Worship YYYY.MM.DD.pptx → Morning Worship, date
     - PM Worship YYYY.MM.DD.pptx → Evening Worship, date
     """
-    import re
-
     result = ServiceMetadata(
         date=None,
         service_name=None,
@@ -220,12 +246,15 @@ def parse_filename_for_metadata(filename: str) -> ServiceMetadata:
         sermon_title=None,
     )
 
-    # Pattern: (AM|PM) Worship YYYY.MM.DD — accepts underscores and job_id prefixes (#265)
-    match = re.search(r"([AP]M)[\s_]+Worship[\s_]+(\d{4})\.(\d{2})\.(\d{2})", filename)
+    # Pattern: (AM|PM) Worship YYYY.MM.DD — accepts underscores and job_id prefixes
+    # (#265), single-digit month/day, and any of '.', '-', '/' separators (#387).
+    match = re.search(
+        r"([AP]M)[\s_]+Worship[\s_]+(\d{4}[.\-/]\d{1,2}[.\-/]\d{1,2})", filename
+    )
     if match:
-        am_pm, year, month, day = match.groups()
+        am_pm, date_str = match.groups()
         result.service_name = "Morning Worship" if am_pm == "AM" else "Evening Worship"
-        result.date = f"{year}-{month}-{day}"
+        result.date = normalize_service_date(date_str)
 
     return result
 
@@ -255,5 +284,8 @@ def extract_service_metadata(
             metadata.date = fallback.date
         if metadata.service_name is None:
             metadata.service_name = fallback.service_name
+
+    # Canonicalize the date to ISO YYYY-MM-DD regardless of source (#387).
+    metadata.date = normalize_service_date(metadata.date)
 
     return metadata

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -476,17 +476,15 @@ async def songs(
 
     total_pages = math.ceil(total / per_page) if total > 0 else 1
 
-    if request.headers.get("HX-Request"):
-        return templates.TemplateResponse(
-            request, "songs_rows.html", {"songs": rows}
-        )
-    return templates.TemplateResponse(
-        request, "songs.html", {
-            "songs": rows, "q": q or "", "sort": sort, "sort_dir": sort_dir,
-            "page": page, "per_page": per_page, "total_pages": total_pages, "total": total,
-            "library_size": library_size,
-        }
-    )
+    context = {
+        "songs": rows, "q": q or "", "sort": sort, "sort_dir": sort_dir,
+        "page": page, "per_page": per_page, "total_pages": total_pages, "total": total,
+        "library_size": library_size,
+    }
+    # HTMX search/sort swaps the whole #songs-results region (table + footer)
+    # so the pagination footer never drifts from the rows shown (#386).
+    template = "_songs_results.html" if request.headers.get("HX-Request") else "songs.html"
+    return templates.TemplateResponse(request, template, context)
 
 
 @app.get("/reports", response_class=HTMLResponse)

--- a/src/worship_catalog/web/templates/_pagination_inner.html
+++ b/src/worship_catalog/web/templates/_pagination_inner.html
@@ -1,0 +1,11 @@
+{# Inner pagination controls — shared by the full page and the HTMX partial.
+   Wrapped by a stable #pagination container so HTMX can swap it out-of-band. #}
+{% if total_pages > 1 %}
+  {% if page > 1 %}
+    <a href="/songs?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}" aria-label="Previous page">← Prev</a>
+  {% endif %}
+  <span>Page {{ page }} of {{ total_pages }}</span>
+  {% if page < total_pages %}
+    <a href="/songs?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}" aria-label="Next page">Next →</a>
+  {% endif %}
+{% endif %}

--- a/src/worship_catalog/web/templates/_songs_results.html
+++ b/src/worship_catalog/web/templates/_songs_results.html
@@ -1,0 +1,44 @@
+{# Song library results region: table + pagination footer. Rendered both in
+   the full page (inside #songs-results) and as the HTMX search/sort response,
+   so the footer always stays in sync with the rows shown (#386). #}
+{% macro sort_th(label, col, align="left") %}
+{% set next_dir = "asc" if (sort == col and sort_dir == "desc") else "desc" %}
+{% set aria_sort_val = ("ascending" if sort_dir == "asc" else "descending") if sort == col else "none" %}
+<th scope="col" style="text-align:{{ align }};white-space:nowrap;user-select:none;cursor:pointer;" aria-sort="{{ aria_sort_val }}">
+  <a href="/songs?sort={{ col }}&sort_dir={{ next_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}"
+     style="color:inherit;text-decoration:none;">
+    {{ label }}{% if sort == col %}&nbsp;{{ '▲' if sort_dir == 'asc' else '▼' }}{% endif %}
+  </a>
+</th>
+{% endmacro %}
+
+{% if total == 0 and not q %}
+<div class="card" style="text-align:center;padding:2rem;">
+  <h2>No songs yet</h2>
+  <p>Import your first worship service to get started.</p>
+  <p>Upload a PPTX file on the <a href="/upload">Upload</a> page, or run:</p>
+  <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
+</div>
+{% else %}
+<div class="card" style="padding:0;overflow:hidden;" aria-live="polite">
+  <table>
+    <caption class="sr-only">Song library — sortable by title, credits, or performance count</caption>
+    <thead>
+      <tr>
+        {{ sort_th("Title", "display_title") }}
+        {{ sort_th("Words By", "words_by") }}
+        {{ sort_th("Music By", "music_by") }}
+        {{ sort_th("Arranger", "arranger") }}
+        {{ sort_th("Performances", "performance_count", align="right") }}
+      </tr>
+    </thead>
+    <tbody id="song-tbody">
+      {% include "songs_rows.html" %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+<nav class="pagination" aria-label="Pagination">
+{% include "_pagination_inner.html" %}
+</nav>

--- a/src/worship_catalog/web/templates/songs.html
+++ b/src/worship_catalog/web/templates/songs.html
@@ -21,7 +21,8 @@
     aria-label="Search songs"
     hx-get="/songs"
     hx-trigger="input changed delay:300ms, search"
-    hx-target="#song-tbody"
+    hx-target="#songs-results"
+    hx-swap="innerHTML"
     hx-include="[name='q'],[name='sort'],[name='sort_dir']"
     hx-indicator="#spinner"
     autofocus
@@ -29,53 +30,9 @@
   <span id="spinner" class="htmx-indicator" style="align-self:center;color:#6c757d;font-size:0.85rem;">searching…</span>
 </div>
 
-{% macro sort_th(label, col, align="left") %}
-{% set next_dir = "asc" if (sort == col and sort_dir == "desc") else "desc" %}
-{% set aria_sort_val = ("ascending" if sort_dir == "asc" else "descending") if sort == col else "none" %}
-<th scope="col" style="text-align:{{ align }};white-space:nowrap;user-select:none;cursor:pointer;" aria-sort="{{ aria_sort_val }}">
-  <a href="/songs?sort={{ col }}&sort_dir={{ next_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}"
-     style="color:inherit;text-decoration:none;">
-    {{ label }}{% if sort == col %}&nbsp;{{ '▲' if sort_dir == 'asc' else '▼' }}{% endif %}
-  </a>
-</th>
-{% endmacro %}
-
-{% if total == 0 and not q %}
-<div class="card" style="text-align:center;padding:2rem;">
-  <h2>No songs yet</h2>
-  <p>Import your first worship service to get started.</p>
-  <p>Upload a PPTX file on the <a href="/upload">Upload</a> page, or run:</p>
-  <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
+{# Search/sort swaps this whole region (table + footer) so pagination never
+   drifts from the rows shown (#386). #}
+<div id="songs-results">
+{% include "_songs_results.html" %}
 </div>
-{% else %}
-<div class="card" style="padding:0;overflow:hidden;" aria-live="polite">
-  <table>
-    <caption class="sr-only">Song library — sortable by title, credits, or performance count</caption>
-    <thead>
-      <tr>
-        {{ sort_th("Title", "display_title") }}
-        {{ sort_th("Words By", "words_by") }}
-        {{ sort_th("Music By", "music_by") }}
-        {{ sort_th("Arranger", "arranger") }}
-        {{ sort_th("Performances", "performance_count", align="right") }}
-      </tr>
-    </thead>
-    <tbody id="song-tbody">
-      {% include "songs_rows.html" %}
-    </tbody>
-  </table>
-</div>
-{% endif %}
-
-{% if total_pages > 1 %}
-<div class="pagination">
-  {% if page > 1 %}
-    <a href="/songs?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}" aria-label="Previous page">← Prev</a>
-  {% endif %}
-  <span>Page {{ page }} of {{ total_pages }}</span>
-  {% if page < total_pages %}
-    <a href="/songs?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}{% if q %}&q={{ q | urlencode }}{% endif %}" aria-label="Next page">Next →</a>
-  {% endif %}
-</div>
-{% endif %}
 {% endblock %}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2212,3 +2212,58 @@ class TestDeleteSongCommand:
             "cleanup", "delete-song", "--db", str(db_with_songs), "--yes"
         ])
         assert result.exit_code != 0
+
+
+class TestNormalizeDatesCommand:
+    """Tests for `cleanup normalize-dates` (#387)."""
+
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture
+    def mixed_dates_db(self, tmp_path):
+        db_path = tmp_path / "dates.db"
+        db = Database(db_path)
+        db.connect()
+        db.init_schema()
+        db.insert_or_update_service("2026.05.10", "Evening Worship", "f1.pptx", "h1")
+        db.insert_or_update_service("2026-05-17", "Morning Worship", "f2.pptx", "h2")
+        db.close()
+        return db_path
+
+    def test_listed_in_cleanup_help(self, runner):
+        result = runner.invoke(main, ["cleanup", "--help"])
+        assert result.exit_code == 0
+        assert "normalize-dates" in result.output
+
+    def test_normalize_dates_rewrites(self, runner, mixed_dates_db):
+        result = runner.invoke(main, [
+            "cleanup", "normalize-dates", "--db", str(mixed_dates_db), "--yes"
+        ])
+        assert result.exit_code == 0
+        db = Database(mixed_dates_db)
+        db.connect()
+        dates = {r[0] for r in db.cursor().execute("SELECT service_date FROM services").fetchall()}
+        db.close()
+        assert "2026-05-10" in dates
+        assert "2026.05.10" not in dates
+
+    def test_normalize_dates_dry_run(self, runner, mixed_dates_db):
+        result = runner.invoke(main, [
+            "cleanup", "normalize-dates", "--db", str(mixed_dates_db), "--dry-run"
+        ])
+        assert result.exit_code == 0
+        assert "2026-05-10" in result.output
+        db = Database(mixed_dates_db)
+        db.connect()
+        dates = {r[0] for r in db.cursor().execute("SELECT service_date FROM services").fetchall()}
+        db.close()
+        assert "2026.05.10" in dates  # unchanged
+
+    def test_normalize_dates_none_needed(self, runner, db_with_songs):
+        result = runner.invoke(main, [
+            "cleanup", "normalize-dates", "--db", str(db_with_songs), "--yes"
+        ])
+        assert result.exit_code == 0
+        assert "no" in result.output.lower()

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2770,3 +2770,49 @@ def _create_pre_v3_db_with_duplicates(
     conn.execute("PRAGMA user_version = 2")
     conn.commit()
     conn.close()
+
+
+@pytest.mark.integration
+class TestNormalizeServiceDates:
+    """Database.normalize_service_dates() rewrites non-ISO dates to ISO (#387)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            db = Database(db_path)
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_normalize_rewrites_non_iso_dates(self, temp_db):
+        a = temp_db.insert_or_update_service("2026.05.10", "Evening Worship", "f1.pptx", "h1")
+        b = temp_db.insert_or_update_service("2026-05.10", "Morning Worship", "f2.pptx", "h2")
+        temp_db.normalize_service_dates()
+        assert temp_db.query_service_by_id(a)["service_date"] == "2026-05-10"
+        assert temp_db.query_service_by_id(b)["service_date"] == "2026-05-10"
+
+    def test_normalize_leaves_iso_dates_untouched(self, temp_db):
+        a = temp_db.insert_or_update_service("2026-05-17", "Morning Worship", "f1.pptx", "h1")
+        report = temp_db.normalize_service_dates(dry_run=True)
+        assert report == []
+        assert temp_db.query_service_by_id(a)["service_date"] == "2026-05-17"
+
+    def test_dry_run_does_not_modify(self, temp_db):
+        a = temp_db.insert_or_update_service("2026.05.10", "Evening Worship", "f1.pptx", "h1")
+        report = temp_db.normalize_service_dates(dry_run=True)
+        assert any(r["service_id"] == a and r["new_date"] == "2026-05-10" for r in report)
+        # unchanged on dry run
+        assert temp_db.query_service_by_id(a)["service_date"] == "2026.05.10"
+
+    def test_normalize_skips_when_target_would_collide(self, temp_db):
+        # An ISO row already occupies (2026-05-10, Evening Worship); a dotted
+        # row for the same service must be flagged as a collision, not applied.
+        temp_db.insert_or_update_service("2026-05-10", "Evening Worship", "f1.pptx", "h1")
+        b = temp_db.insert_or_update_service("2026.05.10", "Evening Worship", "f2.pptx", "h2")
+        report = temp_db.normalize_service_dates(dry_run=True)
+        assert any(r["service_id"] == b and r.get("collision") for r in report)
+        # Applying must not raise and must not change the colliding row.
+        temp_db.normalize_service_dates()
+        assert temp_db.query_service_by_id(b)["service_date"] == "2026.05.10"

--- a/tests/test_pptx_reader_unit.py
+++ b/tests/test_pptx_reader_unit.py
@@ -120,6 +120,127 @@ class TestExtractMetadataFromTableSlide:
         assert result.service_name is None
 
 
+class TestSeparateLineMetadataSlide:
+    """Metadata slides where keys/values are on separate lines and a stray
+    line breaks strict even/odd pairing must still resolve (#385)."""
+
+    def test_key_value_on_separate_lines_parses_date(self):
+        lines = [
+            "Service Data",
+            "Date", "2026-04-05",
+            "Service", "Evening Worship",
+            "Song Leader", "Noah Whatever",
+        ]
+        meta = extract_metadata_from_table_slide(lines)
+        assert meta.date == "2026-04-05"
+        assert meta.service_name == "Evening Worship"
+        assert meta.song_leader == "Noah Whatever"
+
+    def test_misaligned_metadata_slide_still_resolves_keys(self):
+        # Extra/blank lines push key/value off even-odd alignment;
+        # parser must still associate each key with its following value.
+        lines = [
+            "Service Data",
+            "",
+            "Date", "2026-04-05",
+            "Service", "Evening Worship",
+        ]
+        meta = extract_metadata_from_table_slide(lines)
+        assert meta.date == "2026-04-05"
+        assert meta.service_name == "Evening Worship"
+
+    def test_stray_quote_line_does_not_break_pairing(self):
+        # Exact shape of PM Worship 2026.4.5.pptx slide 0: a stray curly-quote
+        # line after the header shifted every key onto the wrong parity.
+        lines = [
+            "Service Data",
+            "“",  # stray curly open-quote
+            "Date", "2026-04-05",
+            "Service", "Evening Worship",
+            "Song Leader", "Jeremy Farmer",
+            "Preacher", "David Morris",
+            "Sermon Title", "The Lord Is My Shepherd",
+        ]
+        meta = extract_metadata_from_table_slide(lines)
+        assert meta.date == "2026-04-05"
+        assert meta.service_name == "Evening Worship"
+        assert meta.song_leader == "Jeremy Farmer"
+        assert meta.preacher == "David Morris"
+        assert meta.sermon_title == "The Lord Is My Shepherd"
+
+    def test_missing_value_leaves_field_none(self):
+        # A key immediately followed by another key has no value.
+        lines = ["Date", "Service", "Evening Worship"]
+        meta = extract_metadata_from_table_slide(lines)
+        assert meta.date is None
+        assert meta.service_name == "Evening Worship"
+
+    def test_extract_service_metadata_uses_slide_over_filename(self):
+        from worship_catalog.pptx_reader import Slide, extract_service_metadata
+
+        slide = Slide(
+            index=0,
+            hidden=False,
+            text=SlideText(text_lines=[
+                "Service Data",
+                "“",
+                "Date", "2026-04-05",
+                "Service", "Evening Worship",
+            ]),
+            images=[],
+        )
+        # Filename has single-digit month/day and should NOT be needed.
+        meta = extract_service_metadata(slide, "PM Worship 2026.4.5.pptx")
+        assert meta.date == "2026-04-05"
+        assert meta.service_name == "Evening Worship"
+
+
+class TestNormalizeServiceDate:
+    """Service dates must canonicalize to ISO YYYY-MM-DD (#387)."""
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("2026-05-10", "2026-05-10"),
+        ("2026.05.10", "2026-05-10"),
+        ("2026-05.10", "2026-05-10"),
+        ("2026.05-10", "2026-05-10"),
+        ("2026/05/10", "2026-05-10"),
+        ("2026.5.10", "2026-05-10"),   # single-digit month/day
+        ("2026-5-1", "2026-05-01"),
+        ("  2026.5.1  ", "2026-05-01"),
+    ])
+    def test_normalizes_to_iso(self, raw, expected):
+        from worship_catalog.pptx_reader import normalize_service_date
+
+        assert normalize_service_date(raw) == expected
+
+    def test_unparseable_returned_stripped(self):
+        from worship_catalog.pptx_reader import normalize_service_date
+
+        assert normalize_service_date("Easter Sunday") == "Easter Sunday"
+
+    def test_none_and_empty(self):
+        from worship_catalog.pptx_reader import normalize_service_date
+
+        assert normalize_service_date(None) is None
+        assert normalize_service_date("  ") is None
+
+    def test_extract_service_metadata_normalizes_date(self):
+        from worship_catalog.pptx_reader import Slide, extract_service_metadata
+
+        slide = Slide(index=0, hidden=False, text=SlideText(text_lines=[
+            "Service Data", "Date", "2026.05.10", "Service", "Evening Worship",
+        ]), images=[])
+        meta = extract_service_metadata(slide, "PM Worship 2026.5.10.pptx")
+        assert meta.date == "2026-05-10"
+
+    def test_filename_fallback_single_digit_normalizes(self):
+        from worship_catalog.pptx_reader import parse_filename_for_metadata
+
+        meta = parse_filename_for_metadata("PM Worship 2026.4.5.pptx")
+        assert meta.date == "2026-04-05"
+        assert meta.service_name == "Evening Worship"
+
+
 class TestExtractImagesLogsOnError:
     """Issue #101 — blob extraction errors must be logged at WARNING."""
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -69,12 +69,17 @@ class TestSongsPage:
         assert "How Great Thou Art" not in response.text
 
     def test_songs_htmx_request_returns_partial(self, client):
-        """HTMX requests return table rows only (no full page nav)."""
+        """HTMX requests return the results region only (no full-page chrome)."""
         response = client.get("/songs?q=Amazing", headers={"HX-Request": "true"})
         assert response.status_code == 200
         assert "Amazing Grace" in response.text
-        # Partial should NOT include the full <nav> chrome
-        assert "<nav" not in response.text
+        # Partial must not include the base layout chrome.
+        lowered = response.text.lower()
+        assert "<!doctype" not in lowered
+        assert "<html" not in lowered
+        # ...but it now carries the table + pagination footer so the footer
+        # stays in sync with the rows (#386).
+        assert "<tbody" in response.text
 
     def test_songs_empty_search_returns_all(self, client):
         response = client.get("/songs?q=")
@@ -740,6 +745,52 @@ class TestPagination:
         assert response.status_code == 200
         row_count = response.text.count("<tr>")
         assert row_count <= 11  # 10 data rows + 1 header row
+
+    # --- #386: pagination footer must stay in sync with HTMX search results ---
+
+    def test_htmx_search_response_includes_pagination(self, paginated_client):
+        """An HTMX /songs request must carry pagination state, not just rows."""
+        resp = paginated_client.get(
+            "/songs",
+            params={"q": "", "page": "1", "per_page": "10"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        body = resp.text
+        assert "Page 1 of" in body
+        # The response must include both the rows and the pagination footer.
+        assert "<tbody" in body
+        assert 'class="pagination"' in body
+
+    def test_htmx_search_clear_resets_to_page_one(self, paginated_client):
+        """Clearing search (page defaults to 1) must report page 1, no Prev link."""
+        resp = paginated_client.get(
+            "/songs",
+            params={"q": ""},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        assert "Page 1 of" in resp.text
+        assert "Previous page" not in resp.text
+
+    def test_htmx_narrow_search_pagination_not_stale(self, paginated_client):
+        """A search narrowing to one page must not advertise a higher page count."""
+        resp = paginated_client.get(
+            "/songs",
+            params={"q": "Song Number 042", "page": "1", "per_page": "10"},
+            headers={"HX-Request": "true"},
+        )
+        assert resp.status_code == 200
+        # Single match → one page; never a stale multi-page indicator.
+        assert "Page 2 of" not in resp.text
+        assert "Next" not in resp.text
+
+    def test_full_page_has_results_swap_container(self, paginated_client):
+        """The full page must render a stable #songs-results region for HTMX swaps."""
+        resp = paginated_client.get("/songs?page=1&per_page=10")
+        assert resp.status_code == 200
+        assert 'id="songs-results"' in resp.text
+        assert 'hx-target="#songs-results"' in resp.text
 
 
 class TestErrorPages:


### PR DESCRIPTION
Fixes #385, #386, #387.

## #385 — metadata key/value on separate lines
`extract_metadata_from_table_slide` assumed strict even/odd key-value pairing and advanced `i += 2`. A stray header/blank line (PM 4.5's deck has a lone curly-quote after "Service Data") shifted every key onto the wrong parity, so the date/service/leader never resolved and the service was stored as `0000-00-00 / Unknown`. Rewritten to scan for known keys and take the next non-empty non-key line as the value. The filename fallback regex now also accepts single-digit month/day.

## #386 — pagination footer desync on HTMX search
The `/songs` HTMX response swapped only `#song-tbody`; the pagination footer lived outside the target and went stale (showed "Page 3 of 10" while rows reset to page 1). Now the search/sort response swaps a single `#songs-results` region (table + footer) as well-formed HTML. **Browser-verified with Playwright** — footer tracks the rows. (An out-of-band `<nav>` approach was tried and rejected: mixing bare `<tr>` rows with an OOB element broke HTMX's table-fragment parsing — caught only in the browser, not server-side tests.)

## #387 — service date normalization
Dates were stored verbatim from the slide, producing a mix of `2026-05-17`, `2026.05.10`, `2026-05.10`. Added `normalize_service_date()` (ISO `YYYY-MM-DD`, any `.`/`-`/`/` mix, single-digit month/day), applied on extraction; `Database.normalize_service_dates()` (collision-aware) and a `cleanup normalize-dates` CLI command to fix existing rows.

## Test plan
- [x] `pytest` — 1104 passed, 42 skipped
- [x] `ruff check src/` + `mypy src/` clean
- [x] New unit tests (separate-line metadata, date normalization), DB integration tests (normalize + collision safety), CLI tests (`normalize-dates`), web pagination-sync tests
- [x] Playwright browser check of the search→clear pagination flow
- [ ] CI green

## Post-merge
- Run `cleanup normalize-dates` on pi-songs (ids 55 `2026-05.10`, 57 `2026.05.10` → `2026-05-10`, no collisions).
- Re-importing the affected decks now yields correct dates (PM 4.5 → `2026-04-05`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)