### PR TITLE
feat: tabbed Reports page (#390) + optional upload password (#388 Phase 1)

### DIFF
--- a/deploy/pi/.env.example
+++ b/deploy/pi/.env.example
@@ -20,3 +20,9 @@ ANTHROPIC_API_KEY=
 # Leave blank to disable alerting.
 PUSHOVER_APP_TOKEN=your-app-token-here
 PUSHOVER_USER_KEY=your-user-key-here
+
+# Upload page password (#388). Set this to require HTTP Basic Auth on the
+# /upload page+endpoint before exposing the site publicly. Leave blank to keep
+# uploads open. Username defaults to "highland".
+UPLOAD_PASSWORD=
+UPLOAD_USERNAME=highland

--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -75,6 +75,11 @@ services:
       CSRF_SECRET: "${CSRF_SECRET}"
       PUSHOVER_USER_KEY: "${PUSHOVER_USER_KEY:-}"
       PUSHOVER_APP_TOKEN: "${PUSHOVER_APP_TOKEN:-}"
+      # Set UPLOAD_PASSWORD in .env to require Basic Auth on the upload page
+      # (#388). Leave unset to keep uploads open. Optional UPLOAD_USERNAME
+      # defaults to "highland".
+      UPLOAD_PASSWORD: "${UPLOAD_PASSWORD:-}"
+      UPLOAD_USERNAME: "${UPLOAD_USERNAME:-highland}"
     volumes:
       - /opt/song-history/data:/data
       - /opt/song-history/inbox:/inbox

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import csv
 import importlib.metadata
 import io
@@ -190,7 +191,9 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
             request, "404.html", {"detail": str(exc.detail)}, status_code=404
         )
     return templates.TemplateResponse(
-        request, "500.html", {"detail": str(exc.detail)}, status_code=exc.status_code
+        request, "500.html", {"detail": str(exc.detail)},
+        status_code=exc.status_code,
+        headers=getattr(exc, "headers", None),
     )
 
 
@@ -882,8 +885,49 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
             )
 
 
+# Default username for the upload Basic Auth gate; the password is the secret.
+_UPLOAD_USERNAME_DEFAULT = "highland"
+
+
+def require_upload_auth(request: Request) -> None:
+    """Gate the upload routes behind HTTP Basic Auth (#388).
+
+    Active only when ``UPLOAD_PASSWORD`` is set in the environment; when unset
+    the upload stays open (current behavior). The catalog browsing pages are
+    never gated — only write access (the upload form/endpoint).
+    """
+    password = os.environ.get("UPLOAD_PASSWORD")
+    if not password:
+        return
+
+    expected_user = os.environ.get("UPLOAD_USERNAME", _UPLOAD_USERNAME_DEFAULT)
+    unauthorized = HTTPException(
+        status_code=401,
+        detail="Authentication required to upload.",
+        headers={"WWW-Authenticate": 'Basic realm="Highland Worship Catalog upload"'},
+    )
+
+    header = request.headers.get("Authorization", "")
+    scheme, _, encoded = header.partition(" ")
+    if scheme.lower() != "basic" or not encoded:
+        raise unauthorized
+    try:
+        decoded = base64.b64decode(encoded).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        raise unauthorized from None
+    user, _, supplied = decoded.partition(":")
+
+    user_ok = secrets.compare_digest(user, expected_user)
+    pass_ok = secrets.compare_digest(supplied, password)
+    if not (user_ok and pass_ok):
+        raise unauthorized
+
+
 @app.get("/upload", response_class=HTMLResponse)
-async def upload_page(request: Request) -> HTMLResponse:
+async def upload_page(
+    request: Request,
+    _: None = Depends(require_upload_auth),  # noqa: B008
+) -> HTMLResponse:
     """Render the browser upload form for PPTX files."""
     return templates.TemplateResponse(request, "upload.html")
 
@@ -893,6 +937,7 @@ async def upload(
     request: Request,
     file: UploadFile,
     db: Database = Depends(get_db),  # noqa: B008
+    _: None = Depends(require_upload_auth),  # noqa: B008
 ) -> JSONResponse:
     """Accept a PPTX file, create an import job, and kick off background import."""
     # Rate limiting (#173) — check before reading the body to save bandwidth.

--- a/src/worship_catalog/web/static/reports.js
+++ b/src/worship_catalog/web/static/reports.js
@@ -101,9 +101,58 @@
     interceptDownloadForm("stats-xlsx-form");
   }
 
+  /**
+   * Wire up the Reports tablist: clicking or arrow-keying a tab activates it
+   * and shows its panel, following the ARIA tabs pattern. Keeps the page CSP
+   * compliant (no inline JS).
+   */
+  function setupTabs() {
+    var tablist = document.querySelector('[role="tablist"]');
+    if (!tablist) return;
+    var tabs = Array.prototype.slice.call(
+      tablist.querySelectorAll('[role="tab"]')
+    );
+    if (!tabs.length) return;
+
+    function activate(tab, setFocus) {
+      tabs.forEach(function (t) {
+        var selected = t === tab;
+        t.setAttribute("aria-selected", selected ? "true" : "false");
+        t.setAttribute("tabindex", selected ? "0" : "-1");
+        t.classList.toggle("active", selected);
+        var panel = document.getElementById(t.getAttribute("aria-controls"));
+        if (panel) panel.hidden = !selected;
+      });
+      if (setFocus) tab.focus();
+    }
+
+    tabs.forEach(function (tab, i) {
+      tab.addEventListener("click", function () {
+        activate(tab, false);
+      });
+      tab.addEventListener("keydown", function (e) {
+        var idx = null;
+        if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+          idx = (i + 1) % tabs.length;
+        } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+          idx = (i - 1 + tabs.length) % tabs.length;
+        } else if (e.key === "Home") {
+          idx = 0;
+        } else if (e.key === "End") {
+          idx = tabs.length - 1;
+        }
+        if (idx !== null) {
+          e.preventDefault();
+          activate(tabs[idx], true);
+        }
+      });
+    });
+  }
+
   /* Initialise on DOMContentLoaded (or immediately if already loaded). */
   function init() {
     configureHtmxCsrf();
+    setupTabs();
     interceptDownloadForm("ccli-form");
 
     /* Re-bind download forms after each HTMX swap so dynamically loaded

--- a/src/worship_catalog/web/templates/base.html
+++ b/src/worship_catalog/web/templates/base.html
@@ -74,6 +74,16 @@
     .badge-missing { color: #a71d2a; font-size: 0.8rem; }
     .pagination { display:flex; gap:1rem; align-items:center; justify-content:center; padding:1rem 0; }
 
+    .tabs { display: flex; gap: 0.25rem; border-bottom: 2px solid #dee2e6; margin-bottom: 1.5rem; }
+    .tab {
+      background: transparent; color: #495057; border: none; border-bottom: 2px solid transparent;
+      margin-bottom: -2px; padding: 0.6rem 1.1rem; font-size: 0.95rem; font-weight: 600;
+      cursor: pointer; border-radius: 0;
+    }
+    .tab:hover { background: #f1f3f5; color: #1a1a2e; }
+    .tab.active { color: #1a1a2e; border-bottom-color: #1a1a2e; }
+    .tab[aria-selected="true"] { color: #1a1a2e; border-bottom-color: #1a1a2e; }
+
     .sr-only {
       position: absolute;
       width: 1px;

--- a/src/worship_catalog/web/templates/reports.html
+++ b/src/worship_catalog/web/templates/reports.html
@@ -3,63 +3,74 @@
 {% block content %}
 <h1>Generate Reports</h1>
 
-<!-- CCLI Compliance Report -->
-<div class="card" style="margin-bottom:1.5rem;">
-  <h2>CCLI Compliance Report <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(CSV download)</small></h2>
-  <p style="font-size:0.85rem;color:#495057;margin-bottom:0.75rem;">
-    Generate the CSV report of song reproductions required for CCLI licence compliance.
-  </p>
-  <form method="post" action="/reports/ccli" id="ccli-form">
-    <div class="form-grid" style="margin-bottom:0.75rem;">
-      <div>
-        <label for="ccli-from">From</label>
-        <input type="date" id="ccli-from" name="start_date" required>
-      </div>
-      <div>
-        <label for="ccli-to">To</label>
-        <input type="date" id="ccli-to" name="end_date" required>
-      </div>
-    </div>
-    <button type="submit">Download CSV</button>
-  </form>
+<div class="tabs" role="tablist" aria-label="Report types">
+  <button type="button" class="tab active" role="tab" id="tab-stats"
+          aria-controls="panel-stats" aria-selected="true">Song Statistics</button>
+  <button type="button" class="tab" role="tab" id="tab-ccli"
+          aria-controls="panel-ccli" aria-selected="false" tabindex="-1">CCLI Compliance</button>
 </div>
 
-<!-- Stats Report -->
-<div class="card">
-  <h2>Song Statistics <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(view in browser)</small></h2>
-  <form
-    method="post"
-    action="/reports/stats"
-    hx-post="/reports/stats"
-    hx-target="#stats-result"
-    hx-indicator="#stats-spinner"
-  >
-    <div class="form-grid" style="margin-bottom:0.75rem;">
-      <div>
-        <label for="stats-from">From</label>
-        <input type="date" id="stats-from" name="start_date" required>
+<!-- Song Statistics (default tab) -->
+<section role="tabpanel" id="panel-stats" aria-labelledby="tab-stats" tabindex="0">
+  <div class="card">
+    <h2>Song Statistics <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(view in browser)</small></h2>
+    <form
+      method="post"
+      action="/reports/stats"
+      hx-post="/reports/stats"
+      hx-target="#stats-result"
+      hx-indicator="#stats-spinner"
+    >
+      <div class="form-grid" style="margin-bottom:0.75rem;">
+        <div>
+          <label for="stats-from">From</label>
+          <input type="date" id="stats-from" name="start_date" required>
+        </div>
+        <div>
+          <label for="stats-to">To</label>
+          <input type="date" id="stats-to" name="end_date" required>
+        </div>
       </div>
-      <div>
-        <label for="stats-to">To</label>
-        <input type="date" id="stats-to" name="end_date" required>
+      <div style="margin-bottom:0.75rem;">
+        <label for="stats-leader" style="display:block;font-size:0.8rem;font-weight:600;color:#495057;margin-bottom:0.25rem;">
+          Filter by Song Leader
+        </label>
+        <input type="text" id="stats-leader" name="leader" placeholder="e.g. Matt" style="width:100%;max-width:320px;" aria-describedby="leader-help">
+        <span id="leader-help" style="font-size:0.75rem;color:#6c757d;">Optional — partial match</span>
       </div>
-    </div>
-    <div style="margin-bottom:0.75rem;">
-      <label for="stats-leader" style="display:block;font-size:0.8rem;font-weight:600;color:#495057;margin-bottom:0.25rem;">
-        Filter by Song Leader
-      </label>
-      <input type="text" id="stats-leader" name="leader" placeholder="e.g. Matt" style="width:100%;max-width:320px;" aria-describedby="leader-help">
-      <span id="leader-help" style="font-size:0.75rem;color:#6c757d;">Optional — partial match</span>
-    </div>
-    <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;">
-      <button type="submit">Generate</button>
-      <label for="all-songs" style="font-size:0.85rem;display:flex;align-items:center;gap:0.4rem;">
-        <input type="checkbox" id="all-songs" name="all_songs" value="true"> Show all songs (not just top 20)
-      </label>
-      <span id="stats-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
-    </div>
-  </form>
-  <div id="stats-result" style="margin-top:1.25rem;" aria-live="polite"></div>
-</div>
+      <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;">
+        <button type="submit">Generate</button>
+        <label for="all-songs" style="font-size:0.85rem;display:flex;align-items:center;gap:0.4rem;">
+          <input type="checkbox" id="all-songs" name="all_songs" value="true"> Show all songs (not just top 20)
+        </label>
+        <span id="stats-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
+      </div>
+    </form>
+    <div id="stats-result" style="margin-top:1.25rem;" aria-live="polite"></div>
+  </div>
+</section>
+
+<!-- CCLI Compliance (secondary tab) -->
+<section role="tabpanel" id="panel-ccli" aria-labelledby="tab-ccli" tabindex="0" hidden>
+  <div class="card">
+    <h2>CCLI Compliance Report <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(CSV download)</small></h2>
+    <p style="font-size:0.85rem;color:#495057;margin-bottom:0.75rem;">
+      Generate the CSV report of song reproductions required for CCLI licence compliance.
+    </p>
+    <form method="post" action="/reports/ccli" id="ccli-form">
+      <div class="form-grid" style="margin-bottom:0.75rem;">
+        <div>
+          <label for="ccli-from">From</label>
+          <input type="date" id="ccli-from" name="start_date" required>
+        </div>
+        <div>
+          <label for="ccli-to">To</label>
+          <input type="date" id="ccli-to" name="end_date" required>
+        </div>
+      </div>
+      <button type="submit">Download CSV</button>
+    </form>
+  </div>
+</section>
 <script src="/static/reports.js"></script>
 {% endblock %}

--- a/tests/test_uat_acceptance.py
+++ b/tests/test_uat_acceptance.py
@@ -110,6 +110,10 @@ class TestReportFormsE2E:
         browser_page.goto(f"{BASE_URL}/reports")
         browser_page.wait_for_load_state("networkidle")
 
+        # CCLI is now the secondary tab — open it before interacting (#390).
+        browser_page.click("#tab-ccli")
+        browser_page.wait_for_selector("#ccli-from", state="visible")
+
         browser_page.fill("#ccli-from", "2026-01-01")
         browser_page.fill("#ccli-to", "2026-12-31")
 
@@ -394,6 +398,10 @@ class TestCcliDownloadE2E:
         """Fill CCLI form, submit, verify CSV download occurs."""
         browser_page.goto(f"{BASE_URL}/reports")
         browser_page.wait_for_load_state("networkidle")
+
+        # CCLI is now the secondary tab — open it before interacting (#390).
+        browser_page.click("#tab-ccli")
+        browser_page.wait_for_selector("#ccli-from", state="visible")
 
         browser_page.fill("#ccli-from", "2020-01-01")
         browser_page.fill("#ccli-to", "2030-12-31")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -128,6 +128,44 @@ class TestReportsPage:
         assert "/reports/stats" in response.text
 
 
+class TestReportsTabs:
+    """Reports page is tabbed: Song Statistics primary/default, CCLI secondary (#390)."""
+
+    def test_reports_page_renders_both_reports(self, client):
+        body = client.get("/reports").text
+        assert "Song Statistics" in body
+        assert "CCLI" in body
+
+    def test_song_stats_appears_before_ccli(self, client):
+        body = client.get("/reports").text
+        assert body.index("Song Statistics") < body.index("CCLI Compliance")
+
+    def test_tabs_have_aria_roles(self, client):
+        body = client.get("/reports").text
+        assert 'role="tablist"' in body
+        assert body.count('role="tab"') >= 2
+        assert body.count('role="tabpanel"') >= 2
+
+    def test_stats_tab_is_default_active(self, client):
+        body = client.get("/reports").text
+        # The stats tab is selected and the CCLI panel is hidden on load.
+        stats_tab_idx = body.index('id="tab-stats"')
+        # The active tab carries aria-selected="true".
+        assert 'aria-selected="true"' in body
+        # The CCLI panel must be hidden by default.
+        ccli_panel = body[body.index('id="panel-ccli"'):]
+        assert "hidden" in ccli_panel[:200]
+        assert stats_tab_idx >= 0
+
+    def test_ccli_form_still_posts_to_ccli_endpoint(self, client):
+        assert 'action="/reports/ccli"' in client.get("/reports").text
+
+    def test_stats_form_still_targets_stats_result(self, client):
+        body = client.get("/reports").text
+        assert 'hx-post="/reports/stats"' in body
+        assert 'id="stats-result"' in body
+
+
 class TestStatsReport:
     def test_stats_returns_html(self, client):
         response = client.post(

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -872,3 +872,53 @@ class TestSecurityHeaders:
     def test_csp_still_present(self, client):
         resp = client.get("/health")
         assert "Content-Security-Policy" in resp.headers
+
+
+# ---------------------------------------------------------------------------
+# #388 Phase 1: simple password gate on the upload page
+# ---------------------------------------------------------------------------
+
+
+class TestUploadAuth:
+    """The upload page/endpoint requires a password when UPLOAD_PASSWORD is set;
+    when unset the upload stays open (current behavior). Browsing is always public."""
+
+    @pytest.fixture
+    def auth_client(self, db_with_songs, tmp_path, monkeypatch):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        monkeypatch.setenv("UPLOAD_PASSWORD", "s3cret")
+        from importlib import reload
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        return CsrfAwareClient(TestClient(app_module.app))
+
+    def test_get_upload_requires_auth_when_password_set(self, auth_client):
+        r = auth_client.get("/upload")
+        assert r.status_code == 401
+        assert "basic" in r.headers.get("www-authenticate", "").lower()
+
+    def test_get_upload_succeeds_with_valid_credentials(self, auth_client):
+        r = auth_client.get("/upload", auth=("highland", "s3cret"))
+        assert r.status_code == 200
+
+    def test_get_upload_rejects_wrong_password(self, auth_client):
+        r = auth_client.get("/upload", auth=("highland", "wrong"))
+        assert r.status_code == 401
+
+    def test_post_upload_requires_auth(self, auth_client):
+        r = auth_client.post(
+            "/upload",
+            files={"file": ("x.pptx", io.BytesIO(b"x"), _PPTX_MIME)},
+        )
+        assert r.status_code == 401
+
+    def test_browsing_routes_stay_public(self, auth_client):
+        for path in ("/songs", "/services", "/reports", "/leaders"):
+            assert auth_client.get(path).status_code == 200, path
+
+    def test_upload_open_when_password_unset(self, client):
+        # The default fixture sets no UPLOAD_PASSWORD → upload stays open.
+        assert client.get("/upload").status_code == 200


### PR DESCRIPTION
Closes #390. Implements Phase 1 of #388.

## #390 — Reports tabs
`/reports` is now tabbed, deprioritizing CCLI:
- **Song Statistics** is the default/active tab.
- **CCLI Compliance** is the second tab.

Accessible ARIA tabs (`role="tablist"/"tab"/"tabpanel"`, `aria-selected`, arrow/Home/End keyboard nav). Tab-switch logic lives in `reports.js` (CSP forbids inline JS); tab styling in `base.html`. Both report forms keep their existing endpoints (`/reports/stats` HTMX, `/reports/ccli` CSV). **Browser-verified with Playwright** — default panel, click switching, keyboard nav, ARIA state, no console errors.

## #388 Phase 1 — optional upload password
Adds an HTTP Basic Auth gate (`require_upload_auth`) on `GET`/`POST /upload`:
- Active only when `UPLOAD_PASSWORD` is set; **uploads stay open when unset** (no behavior change for the current deployment).
- Browsing routes (`/songs`, `/services`, `/reports`, `/leaders`) remain public.
- The custom HTTP exception handler now propagates `exc.headers`, so the `WWW-Authenticate` challenge reaches the browser (triggers the login prompt).
- `UPLOAD_PASSWORD` / `UPLOAD_USERNAME` (default `highland`) wired into `deploy/pi` compose + `.env.example` — no secret committed.

This is the prerequisite for exposing the site publicly (#388 Phase 2, Cloudflare Tunnel).

## Test plan
- [x] `pytest` — 1116 passed, 42 skipped
- [x] `ruff` + `mypy` clean
- [x] New tests: `TestReportsTabs` (order, ARIA roles, default-active, forms wired) and `TestUploadAuth` (401 + WWW-Authenticate, valid creds 200, wrong pass 401, POST gated, browsing public, open-when-unset)
- [x] Playwright tab interaction + real-server curl check of the Basic Auth flow
- [ ] CI green

## Activate the upload password (separate, when ready)
Set `UPLOAD_PASSWORD` in the Pi's `~/.env` (and optionally `UPLOAD_USERNAME`) and `docker compose up -d`. Until then uploads remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)