### PR TITLE
deploy(pi): promtail sidecar — ship pi-songs container logs to Loki (#388)

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -115,5 +115,25 @@ services:
       traefik:
         condition: service_started
 
+  # ---------------------------------------------------------------------------
+  # promtail — ships this host's container logs to the homelab Loki (#388).
+  # Reads Docker json-file logs read-only; no Docker socket (exposed host).
+  # Requires a DMZ->Loki (10.20.100.249:3100) firewall allow on VLAN 249.
+  # ---------------------------------------------------------------------------
+  promtail:
+    image: grafana/promtail:latest
+    restart: unless-stopped
+    user: root   # needed to read root-owned /var/lib/docker/containers logs
+    command: -config.file=/etc/promtail/config.yml
+    volumes:
+      - /opt/song-history/promtail:/etc/promtail
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    stop_grace_period: 10s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
 # Backups are handled by a host cron job running scripts/backup.sh — not a
 # sidecar container.  See docs/pi-deploy.md § Backup for setup instructions.

--- a/deploy/pi/promtail/config.yml
+++ b/deploy/pi/promtail/config.yml
@@ -1,0 +1,53 @@
+# Promtail config for pi-songs — ships container logs to the homelab Loki.
+#
+# Pushes directly to the Loki host (10.20.100.249:3100), matching the existing
+# promtail convention and the DMZ->Loki:3100 firewall allow. NOTE: loki.tanx95.us
+# resolves to lxc-traefik, a different host/port — do not use it here.
+#
+# Reads the Docker json-file logs read-only; deliberately does NOT mount the
+# Docker socket (this is an internet-exposed host — minimise blast radius).
+server:
+  http_listen_port: 9080   # internal only — not published on the host
+  grpc_listen_port: 0
+
+positions:
+  filename: /etc/promtail/positions.yaml
+
+clients:
+  - url: http://10.20.100.249:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: docker
+          host: pi-songs
+          __path__: /var/lib/docker/containers/*/*.log
+    pipeline_stages:
+      # 1. Unwrap the Docker json-file envelope ({"log","stream","time"}).
+      - json:
+          expressions:
+            log: log
+            stream: stream
+            time: time
+      - timestamp:
+          source: time
+          format: RFC3339Nano
+      - labels:
+          stream:
+      # 2. The song-history app emits structured JSON on stdout. Promote a
+      #    couple of low-cardinality fields to labels (no-op for non-JSON
+      #    lines like Traefik/watcher output).
+      - json:
+          expressions:
+            level: level
+            logger: logger
+          source: log
+      - labels:
+          level:
+          logger:
+      # 3. Emit the unwrapped application line (drop the Docker envelope).
+      - output:
+          source: log


### PR DESCRIPTION
Part of #388 (get logs into Loki before public exposure).

pi-songs ships **no** logs today (json-file driver only). This adds a **promtail sidecar** to the Pi compose that:
- Tails the Docker json-file logs **read-only**; **no Docker socket** mounted (exposed host — minimise blast radius).
- Pushes directly to the homelab Loki at `http://10.20.100.249:3100` — matches the existing promtail convention and the **DMZ→Loki:3100** allow on VLAN 249. (`loki.tanx95.us` points at lxc-traefik, a different host/port — deliberately not used.)
- Promotes the app's structured-JSON `level`/`logger` to low-cardinality labels (`host=pi-songs`, `job=docker`); Traefik/watcher lines pass through unenriched.

Gives queryable visibility into the internet-exposed host (upload-auth 401s, request logs, errors) that IPS can't see inside the encrypted tunnel.

## Files
- `deploy/pi/promtail/config.yml` (new)
- `deploy/pi/docker-compose.yml` (promtail service)

## Notes
- App image unaffected (uses `grafana/promtail:latest`); CI exercises the Python app, not this compose.
- Deploy is manual on the Pi (live compose drifts from repo): create `/opt/song-history/promtail/config.yml`, add the service, `docker compose up -d`. Logs start flowing once the DMZ→Loki:3100 allow is active.
- Verification: `{host="pi-songs"}` in Loki/Grafana after deploy.