### PR TITLE
deploy(pi): cloudflared tunnel sidecar for public access (#388 Phase 2)

### DIFF
--- a/deploy/pi/.env.example
+++ b/deploy/pi/.env.example
@@ -26,3 +26,10 @@ PUSHOVER_USER_KEY=your-user-key-here
 # uploads open. Username defaults to "highland".
 UPLOAD_PASSWORD=
 UPLOAD_USERNAME=highland
+
+# Cloudflare Tunnel token (#388 Phase 2). Create a tunnel in the Cloudflare
+# Zero Trust dashboard (Networks -> Tunnels -> Cloudflared) and paste its token
+# here. The public hostname -> service mapping (songs.highland-coc.com ->
+# http://song-history:8000) is configured in the dashboard. Leave blank to keep
+# the cloudflared container idle/not running.
+TUNNEL_TOKEN=

--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -135,5 +135,28 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # ---------------------------------------------------------------------------
+  # cloudflared — Cloudflare Tunnel for public access to songs.highland-coc.com
+  # (#388 Phase 2). Outbound-only to the Cloudflare edge (no inbound ports);
+  # reaches the app over the internal compose network. Token-managed: the
+  # public-hostname -> service (http://song-history:8000) ingress is configured
+  # in the Cloudflare Zero Trust dashboard. Set TUNNEL_TOKEN in .env.
+  # ---------------------------------------------------------------------------
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+    # If IPS in Prevention mangles the QUIC/UDP edge connection, force HTTP/2:
+    # command: tunnel --no-autoupdate --protocol http2 run --token ${TUNNEL_TOKEN}
+    depends_on:
+      song-history:
+        condition: service_started
+    stop_grace_period: 30s
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
 # Backups are handled by a host cron job running scripts/backup.sh — not a
 # sidecar container.  See docs/pi-deploy.md § Backup for setup instructions.


### PR DESCRIPTION
#388 Phase 2 — public access to `songs.highland-coc.com` via Cloudflare Tunnel, cloudflared running on the Pi.

- **Token-managed** cloudflared sidecar (Cloudflare's recommended model: auto-reconnect, no creds file).
- **Outbound-only** to the Cloudflare edge — no inbound ports, nothing new at the firewall.
- Reaches the app over the internal compose network; the public hostname → `http://song-history:8000` ingress is set in the Zero Trust dashboard (preserves the app's Basic Auth / CSRF / security headers — Traefik bypassed for the public path, still used for internal `pi-songs.tanx95.us`).
- `TUNNEL_TOKEN` from `.env` (not committed); `.env.example` documents it.
- Commented `--protocol http2` fallback if IPS mangles the QUIC/UDP edge link.

## Operator steps (you, in Cloudflare)
1. Zero Trust → Networks → Tunnels → Create a tunnel (Cloudflared) → name it (e.g. `pi-songs`) → copy the **token**.
2. Add a **Public Hostname**: `songs.highland-coc.com` → service `http://song-history:8000` (this also creates the DNS CNAME).
3. Put the token in the Pi's `/opt/song-history/.env` as `TUNNEL_TOKEN=...`.

Then I deploy (`docker compose up -d`), verify the tunnel registers + the public URL serves, confirm upload auth still gates `/upload`, and we close any leftover public 80/443.

## Notes
- App image unaffected; CI exercises the Python app, not this compose.
- Deploy is manual on the Pi (live compose drifts from repo).