### PR TITLE
feat(web): responsive mobile layout for public UI (#394)

### DIFF
--- a/src/worship_catalog/web/templates/_songs_results.html
+++ b/src/worship_catalog/web/templates/_songs_results.html
@@ -20,7 +20,8 @@
   <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
 </div>
 {% else %}
-<div class="card" style="padding:0;overflow:hidden;" aria-live="polite">
+<div class="card" style="padding:0;" aria-live="polite">
+  <div class="table-wrap">
   <table>
     <caption class="sr-only">Song library — sortable by title, credits, or performance count</caption>
     <thead>
@@ -36,6 +37,7 @@
       {% include "songs_rows.html" %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endif %}
 

--- a/src/worship_catalog/web/templates/base.html
+++ b/src/worship_catalog/web/templates/base.html
@@ -22,11 +22,21 @@
       display: flex;
       align-items: center;
       gap: 2rem;
+      flex-wrap: wrap;
     }
     nav .brand-logo { height: 2.5rem; width: auto; border-radius: 6px; background: rgba(255,255,255,0.9); padding: 2px 4px; }
     nav .brand { font-weight: 700; font-size: 1.1rem; letter-spacing: .02em; }
+    nav .nav-links { display: flex; align-items: center; gap: 2rem; }
     nav a { color: #ccc; text-decoration: none; font-size: 0.95rem; }
     nav a:hover, nav a.active { color: #fff; }
+
+    /* CSS-only hamburger: hidden checkbox toggles .nav-links on small screens (no JS, CSP-safe). */
+    #nav-toggle { position: absolute; opacity: 0; width: 1px; height: 1px; }
+    .nav-burger { display: none; cursor: pointer; color: #fff; font-size: 1.5rem; line-height: 1; padding: 0.25rem 0.5rem; margin-left: auto; }
+    #nav-toggle:focus-visible + .nav-burger { outline: 2px solid #fff; outline-offset: 2px; }
+
+    /* Horizontal-scroll container so wide tables don't overflow narrow screens. */
+    .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 
     main { max-width: 1100px; margin: 2rem auto; padding: 0 1rem; }
 
@@ -107,6 +117,29 @@
       z-index: 9999;
     }
     .skip-nav:focus { top: 0; }
+
+    @media (max-width: 640px) {
+      nav { padding: 0.6rem 1rem; gap: 0.75rem; }
+      .nav-burger { display: block; }
+      nav .nav-links {
+        display: none;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.75rem;
+        flex-basis: 100%;
+        padding-top: 0.5rem;
+      }
+      #nav-toggle:checked ~ .nav-links { display: flex; }
+      nav .nav-links a { padding: 0.4rem 0; font-size: 1.05rem; }
+
+      main { margin: 1rem auto; padding: 0 0.75rem; }
+      h1 { font-size: 1.3rem; }
+
+      .tabs { flex-wrap: wrap; }
+      .search-row { flex-wrap: wrap; }
+      .search-row input { max-width: 100%; }
+      button, .btn { padding: 0.6rem 1rem; }
+    }
   </style>
 </head>
 <body>
@@ -115,12 +148,16 @@
 <nav>
   <img src="/static/highland-logo.png" alt="Highland logo" class="brand-logo">
   <span class="brand">Highland Worship Catalog</span>
-  <a href="/songs" {% if request.url.path.startswith('/songs') %}class="active"{% endif %}>Songs</a>
-  <a href="/services" {% if request.url.path.startswith('/services') %}class="active"{% endif %}>Services</a>
-  <a href="/reports" {% if request.url.path == '/reports' %}class="active"{% endif %}>Reports</a>
-  <a href="/leaders" {% if request.url.path.startswith('/leaders') %}class="active"{% endif %}>Leaders</a>
-  <a href="/about" {% if request.url.path == '/about' %}class="active"{% endif %}>About</a>
-  <a href="/upload" {% if request.url.path == '/upload' %}class="active"{% endif %}>Upload</a>
+  <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation menu">
+  <label class="nav-burger" for="nav-toggle"><span aria-hidden="true">&#9776;</span><span class="sr-only">Menu</span></label>
+  <div class="nav-links">
+    <a href="/songs" {% if request.url.path.startswith('/songs') %}class="active"{% endif %}>Songs</a>
+    <a href="/services" {% if request.url.path.startswith('/services') %}class="active"{% endif %}>Services</a>
+    <a href="/reports" {% if request.url.path == '/reports' %}class="active"{% endif %}>Reports</a>
+    <a href="/leaders" {% if request.url.path.startswith('/leaders') %}class="active"{% endif %}>Leaders</a>
+    <a href="/about" {% if request.url.path == '/about' %}class="active"{% endif %}>About</a>
+    <a href="/upload" {% if request.url.path == '/upload' %}class="active"{% endif %}>Upload</a>
+  </div>
 </nav>
 </header>
 <main id="main">

--- a/src/worship_catalog/web/templates/leader_top_songs.html
+++ b/src/worship_catalog/web/templates/leader_top_songs.html
@@ -15,7 +15,8 @@
   <a href="/leaders/{{ leader | urlencode }}/top-songs/csv" class="btn">Download CSV</a>
 </div>
 
-<div class="card" style="padding:0;overflow:hidden;">
+<div class="card" style="padding:0;">
+  <div class="table-wrap">
   <table>
     <thead>
       <tr>
@@ -41,6 +42,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% else %}
 <p style="color:#6c757d;">No songs have been led at {{ min_count }}+ services.</p>

--- a/src/worship_catalog/web/templates/leaders.html
+++ b/src/worship_catalog/web/templates/leaders.html
@@ -4,7 +4,8 @@
 <h1>Song Leaders</h1>
 
 {% if leaders %}
-<div class="card" style="padding:0;overflow:hidden;">
+<div class="card" style="padding:0;">
+  <div class="table-wrap">
   <table>
     <thead>
       <tr>
@@ -25,6 +26,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% else %}
 <p style="color:#6c757d;">No leaders found. Import some services first.</p>

--- a/src/worship_catalog/web/templates/service_detail.html
+++ b/src/worship_catalog/web/templates/service_detail.html
@@ -51,7 +51,8 @@
 {% if not songs %}
 <p style="color:#6c757d;">No songs recorded for this service.</p>
 {% else %}
-<div class="card" style="padding:0;overflow:hidden;">
+<div class="card" style="padding:0;">
+  <div class="table-wrap">
   <table>
     <caption class="sr-only">Setlist for {{ service.service_name }} on {{ service.service_date }}</caption>
     <thead>
@@ -84,6 +85,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endif %}
 

--- a/src/worship_catalog/web/templates/services.html
+++ b/src/worship_catalog/web/templates/services.html
@@ -92,7 +92,8 @@
   <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
 </div>
 {% else %}
-<div class="card" style="padding:0;overflow:hidden;" aria-live="polite">
+<div class="card" style="padding:0;" aria-live="polite">
+  <div class="table-wrap">
   <table>
     <caption class="sr-only">Worship services — sortable and filterable</caption>
     <thead>
@@ -110,6 +111,7 @@
       {% include "services_rows.html" %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endif %}
 

--- a/src/worship_catalog/web/templates/song_detail.html
+++ b/src/worship_catalog/web/templates/song_detail.html
@@ -65,7 +65,8 @@
 {% if not service_history %}
 <p style="color:#6c757d;">No services recorded for this song.</p>
 {% else %}
-<div class="card" style="padding:0;overflow:hidden;">
+<div class="card" style="padding:0;">
+  <div class="table-wrap">
   <table>
     <thead>
       <tr>
@@ -92,6 +93,7 @@
       {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endif %}
 

--- a/src/worship_catalog/web/templates/stats_result.html
+++ b/src/worship_catalog/web/templates/stats_result.html
@@ -41,6 +41,7 @@
 {% endif %}
 
 <h3 style="font-size:1rem;margin:1rem 0 0.5rem;">{% if all_songs %}All Songs{% else %}Top Songs{% endif %}</h3>
+<div class="table-wrap">
 <table>
   <caption class="sr-only">{% if all_songs %}All songs{% else %}Top songs{% endif %} by performance count</caption>
   <thead>
@@ -62,6 +63,7 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 
 {% if leader_breakdown %}
 <h3 style="font-size:1rem;margin:1.5rem 0 0.75rem;">By Song Leader</h3>
@@ -88,6 +90,7 @@
 {% endif %}
 
 <h3 style="font-size:1rem;margin:1.5rem 0 0.5rem;">Services</h3>
+<div class="table-wrap">
 <table>
   <thead>
     <tr>
@@ -106,5 +109,6 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 
 {% endif %}

--- a/tests/test_e2e_playwright.py
+++ b/tests/test_e2e_playwright.py
@@ -127,3 +127,60 @@ class TestNavigationHTMX:
 
         skip_link = browser_page.locator("a.skip-nav")
         assert skip_link.count() >= 1, "Skip-to-main-content link must be present"
+
+
+@pytest.mark.e2e
+class TestMobileResponsive:
+    """Issue #394 — UI must not overflow horizontally on a 390px phone viewport."""
+
+    MOBILE = {"width": 390, "height": 800}
+
+    def test_songs_no_horizontal_overflow_mobile(self, browser_page) -> None:
+        """/songs must not cause the page body to scroll sideways on a phone."""
+        browser_page.set_viewport_size(self.MOBILE)
+        browser_page.goto(f"{BASE_URL}/songs")
+        browser_page.wait_for_load_state("networkidle")
+
+        scroll_w = browser_page.evaluate("document.body.scrollWidth")
+        client_w = browser_page.evaluate("document.body.clientWidth")
+        assert scroll_w <= client_w + 1, (
+            f"/songs overflows horizontally: scrollWidth={scroll_w} clientWidth={client_w}"
+        )
+
+    def test_services_no_horizontal_overflow_mobile(self, browser_page) -> None:
+        """/services must not cause the page body to scroll sideways on a phone."""
+        browser_page.set_viewport_size(self.MOBILE)
+        browser_page.goto(f"{BASE_URL}/services")
+        browser_page.wait_for_load_state("networkidle")
+
+        scroll_w = browser_page.evaluate("document.body.scrollWidth")
+        client_w = browser_page.evaluate("document.body.clientWidth")
+        assert scroll_w <= client_w + 1, (
+            f"/services overflows horizontally: scrollWidth={scroll_w} clientWidth={client_w}"
+        )
+
+    def test_song_row_is_tappable_mobile(self, browser_page) -> None:
+        """A song row link must be tappable and navigate on a phone viewport."""
+        browser_page.set_viewport_size(self.MOBILE)
+        browser_page.goto(f"{BASE_URL}/songs")
+        browser_page.wait_for_load_state("networkidle")
+
+        first_row_link = browser_page.locator("tbody tr td a").first
+        if first_row_link.count() == 0:
+            pytest.skip("No song rows in the DB to tap")
+        first_row_link.click()
+        browser_page.wait_for_load_state("networkidle")
+        assert "/songs/" in browser_page.url, "Tapping a song row did not open the detail page"
+
+    def test_nav_toggle_reveals_links_mobile(self, browser_page) -> None:
+        """Nav links are hidden until the CSS-only hamburger is toggled (no JS)."""
+        browser_page.set_viewport_size(self.MOBILE)
+        browser_page.goto(f"{BASE_URL}/songs")
+        browser_page.wait_for_load_state("networkidle")
+
+        services_link = browser_page.locator("nav a[href='/services']")
+        assert services_link.count() >= 1
+        assert not services_link.is_visible(), "Nav links should be collapsed on mobile by default"
+
+        browser_page.click("label[for='nav-toggle']")
+        assert services_link.is_visible(), "Hamburger toggle did not reveal the nav links"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -2929,6 +2929,53 @@ class TestBranding:
         assert b"Highland" in response.content
 
 
+class TestResponsiveLayout:
+    """Issue #394 — the public UI must be usable on phones."""
+
+    def test_viewport_meta_present(self, client):
+        """base.html must set a device-width viewport (guard against regression)."""
+        resp = client.get("/songs")
+        assert resp.status_code == 200
+        assert 'name="viewport"' in resp.text
+        assert "width=device-width" in resp.text
+
+    def test_base_has_media_query(self, client):
+        """Responsive rules require at least one @media breakpoint in the stylesheet."""
+        resp = client.get("/songs")
+        assert resp.status_code == 200
+        assert "@media" in resp.text, "base.html has no media query — UI is not responsive"
+
+    def test_songs_table_in_scroll_container(self, client):
+        """Songs table must sit inside a horizontal-scroll container for narrow screens."""
+        resp = client.get("/songs")
+        assert resp.status_code == 200
+        assert "table-wrap" in resp.text, (
+            "Songs table is not wrapped in a .table-wrap scroll container"
+        )
+
+    def test_services_table_in_scroll_container(self, client):
+        """Services table must sit inside a horizontal-scroll container."""
+        resp = client.get("/services")
+        assert resp.status_code == 200
+        assert "table-wrap" in resp.text, (
+            "Services table is not wrapped in a .table-wrap scroll container"
+        )
+
+    def test_nav_has_css_only_toggle(self, client):
+        """Mobile nav must collapse via a CSS-only checkbox toggle (no JS, CSP-safe)."""
+        resp = client.get("/songs")
+        assert resp.status_code == 200
+        html = resp.text
+        assert 'id="nav-toggle"' in html, "No #nav-toggle checkbox for the hamburger menu"
+        assert 'for="nav-toggle"' in html, "No <label for=nav-toggle> hamburger control"
+        # The toggle must not introduce any new inline script (CSP blocks inline JS).
+        import re
+        inline_scripts = re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", html)
+        assert not inline_scripts, (
+            f"Nav added {len(inline_scripts)} inline <script> tag(s) blocked by CSP"
+        )
+
+
 class TestHtmxSelfHosted:
     """htmx must be served from our own static files, not a CDN."""
 


### PR DESCRIPTION
## Summary
- Adds a 640px breakpoint so the now-public catalog (Cloudflare Tunnel, #388) is usable on phones.
- Wide tables (Songs, Services, song/service detail, leaders, stats report) scroll horizontally inside a `.table-wrap` container instead of breaking the page.
- The six-link nav collapses behind a **CSS-only hamburger** (hidden checkbox + label) — no JS, so it stays within the `script-src 'self'` CSP.
- Forms, tabs, search bar, and tap targets reflow on small widths.

## Changes
- `base.html`: `@media (max-width: 640px)` block, `.table-wrap`, CSS-only `#nav-toggle` hamburger + `.nav-links` wrapper.
- 7 templates: tables wrapped in `.table-wrap` (HTMX tbody-only partials unchanged — wrapper lives in parent).

Closes #394.

## Test plan
- [x] `pytest tests/test_web.py -k Responsive` — viewport guard, media-query, `.table-wrap`, CSS-only toggle (5 pass)
- [x] `pytest -m "not e2e"` — full suite, no regressions (1121 pass)
- [x] `ruff check src/` + `mypy src/` — clean (no Python changes)
- [x] Playwright e2e at 390px viewport: no horizontal overflow on /songs & /services, song row tappable, hamburger reveals nav (12 e2e pass)
- [ ] CI `test` + `security` jobs green

🤖 Generated with [Claude Code](https://claude.com/claude-code)