### PR TITLE
import: print song list + service header summary on success (#398)

### DIFF
--- a/src/worship_catalog/cli.py
+++ b/src/worship_catalog/cli.py
@@ -12,7 +12,7 @@ import click
 
 from worship_catalog.db import Database
 from worship_catalog.extractor import extract_songs
-from worship_catalog.import_service import run_import
+from worship_catalog.import_service import ImportResult, run_import
 from worship_catalog.log_config import setup as _setup_logging
 from worship_catalog.services.report_service import _STATS_TOP_SONGS as _STATS_TOP_SONGS
 from worship_catalog.services.report_service import compute_stats_data
@@ -134,6 +134,32 @@ def validate(pptx: str, format: str) -> None:
         _log.exception("validate error", extra={"error": str(e)})
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
+
+
+def _echo_import_summary(result: ImportResult) -> None:
+    """Print a brief service-header summary + numbered song list after import."""
+    header = []
+    if result.service_date:
+        header.append(f"Date: {result.service_date}")
+    if result.service_name:
+        header.append(f"Service: {result.service_name}")
+    if header:
+        click.echo(f"    {'  |  '.join(header)}")
+
+    people = []
+    if result.song_leader:
+        people.append(f"Song Leader: {result.song_leader}")
+    if result.preacher:
+        people.append(f"Preacher: {result.preacher}")
+    if result.sermon_title:
+        people.append(f"Sermon: {result.sermon_title}")
+    if people:
+        click.echo(f"    {'  |  '.join(people)}")
+
+    if result.songs:
+        click.echo("    Songs:")
+        for song in result.songs:
+            click.echo(f"      {song.ordinal}. {song.display_title}")
 
 
 @main.command(name="import")
@@ -262,6 +288,7 @@ def import_cmd(
                         f"  ✓ Imported {import_result.songs_imported} songs",
                         err=False,
                     )
+                    _echo_import_summary(import_result)
 
                 except Exception as e:
                     _log.error(

--- a/src/worship_catalog/import_service.py
+++ b/src/worship_catalog/import_service.py
@@ -18,6 +18,14 @@ _log = logging.getLogger(__name__)
 
 
 @dataclass
+class ImportedSong:
+    """A single song surfaced in an import summary."""
+
+    ordinal: int
+    display_title: str
+
+
+@dataclass
 class ImportResult:
     """Summary of a completed import run."""
 
@@ -25,6 +33,10 @@ class ImportResult:
     service_name: str | None
     songs_imported: int
     anomalies: list[dict[str, Any]] = field(default_factory=list)
+    song_leader: str | None = None
+    preacher: str | None = None
+    sermon_title: str | None = None
+    songs: list[ImportedSong] = field(default_factory=list)
 
 
 def run_import(
@@ -157,4 +169,8 @@ def run_import(
         service_name=result.service_name,
         songs_imported=len(result.songs),
         anomalies=result.anomalies,
+        song_leader=result.song_leader,
+        preacher=result.preacher,
+        sermon_title=result.sermon_title,
+        songs=[ImportedSong(s.ordinal, s.display_title) for s in result.songs],
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -273,6 +273,85 @@ class TestImportCommand:
 
             db.close()
 
+    def test_import_prints_header_summary_and_song_list(self, runner, monkeypatch):
+        """Successful import echoes a service header summary + numbered song list."""
+        from worship_catalog import cli as cli_mod
+        from worship_catalog.import_service import ImportResult, ImportedSong
+
+        fake = ImportResult(
+            service_date="2026-02-15",
+            service_name="AM Worship",
+            songs_imported=2,
+            song_leader="John Smith",
+            preacher="Pastor Dave",
+            sermon_title="Grace Abounds",
+            songs=[ImportedSong(1, "Amazing Grace"), ImportedSong(2, "How Great Thou Art")],
+        )
+        monkeypatch.setattr(cli_mod, "run_import", lambda *a, **k: fake)
+
+        with TemporaryDirectory() as tmpdir:
+            pptx = Path(tmpdir) / "AM Worship 2026.02.15.pptx"
+            pptx.write_bytes(b"PK")  # only needs to exist; run_import is mocked
+            db_path = Path(tmpdir) / "t.db"
+            result = runner.invoke(
+                main, ["import", str(pptx), "--db", str(db_path), "--non-interactive"]
+            )
+
+        assert result.exit_code == 0
+        assert "2026-02-15" in result.output
+        assert "AM Worship" in result.output
+        assert "John Smith" in result.output
+        assert "Pastor Dave" in result.output
+        assert "Grace Abounds" in result.output
+        assert "Songs:" in result.output
+        assert "1. Amazing Grace" in result.output
+        assert "2. How Great Thou Art" in result.output
+
+    def test_import_summary_omits_absent_header_fields(self, runner, monkeypatch):
+        """Empty leader/preacher/sermon are not printed."""
+        from worship_catalog import cli as cli_mod
+        from worship_catalog.import_service import ImportResult, ImportedSong
+
+        fake = ImportResult(
+            service_date="2026-03-01",
+            service_name="PM Worship",
+            songs_imported=1,
+            song_leader=None,
+            preacher=None,
+            sermon_title=None,
+            songs=[ImportedSong(1, "Be Thou My Vision")],
+        )
+        monkeypatch.setattr(cli_mod, "run_import", lambda *a, **k: fake)
+
+        with TemporaryDirectory() as tmpdir:
+            pptx = Path(tmpdir) / "PM Worship 2026.03.01.pptx"
+            pptx.write_bytes(b"PK")
+            db_path = Path(tmpdir) / "t.db"
+            result = runner.invoke(
+                main, ["import", str(pptx), "--db", str(db_path), "--non-interactive"]
+            )
+
+        assert result.exit_code == 0
+        assert "Be Thou My Vision" in result.output
+        assert "Song Leader:" not in result.output
+        assert "Preacher:" not in result.output
+        assert "Sermon:" not in result.output
+
+    @pytest.mark.slow
+    def test_import_real_pptx_lists_songs_and_date(self, runner, pptx_file):
+        """End-to-end: real import surfaces the new summary (Date label + Songs list)."""
+        if not pptx_file.exists():
+            pytest.skip(f"Test PPTX not found: {pptx_file}")
+        with TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "test.db"
+            result = runner.invoke(
+                main, ["import", str(pptx_file), "--db", str(db_path), "--non-interactive"]
+            )
+        assert result.exit_code == 0
+        assert "Date:" in result.output
+        assert "Songs:" in result.output
+        assert "1. " in result.output
+
 
 @pytest.mark.integration
 class TestReportCCLICommand:


### PR DESCRIPTION
## Summary
On a successful `import`, print a brief service-header summary + numbered song list (mirrors `validate`), so the result is reviewable inline and visible in the Pi watcher's logs (now shipped to Loki). Closes #398.

```
Processing AM Worship 2026.02.15.pptx...
  ✓ Imported 8 songs
    Date: 2026-02-15  |  Service: AM Worship
    Song Leader: ...  |  Preacher: ...  |  Sermon: ...
    Songs:
      1. ...
      2. ...
```
- Header lines show only present fields.
- Per-file in folder imports; no new flags; import has no JSON mode (unaffected).

## Changes
- `import_service.py`: add `ImportedSong`; extend `ImportResult` with `song_leader`, `preacher`, `sermon_title`, `songs`; populate in `run_import`.
- `cli.py`: `_echo_import_summary()` after the per-file success line.

## Test plan (TDD, #398)
- [x] `test_import_prints_header_summary_and_song_list` (mock run_import)
- [x] `test_import_summary_omits_absent_header_fields`
- [x] `test_import_real_pptx_lists_songs_and_date` (`slow`, real fixture)
- [x] Full suite: 1124 passed, 46 skipped
- [x] `ruff check src/` clean, `mypy src/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)