### PR TITLE
fix: revert Dockerfile base image to GA Python 3.12 (#403)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Pin base image to exact digest to prevent supply-chain drift (#26)
-# python:3.14-slim — Dependabot bumped from 3.12; CVE scan passing at this digest
-FROM python:3.14-slim@sha256:fb83750094b46fd6b8adaa80f66e2302ecbe45d513f6cece637a841e1025b4ca
+# python:3.12-slim — GA release matching CI (3.12) and the pyproject target (#403).
+# Reverted from a Dependabot bump to 3.14 (pre-release). Dependabot must be
+# restricted to GA Python minors so it cannot re-introduce a pre-release runtime.
+FROM python:3.12-slim@sha256:090ba77e2958f6af52a5341f788b50b032dd4ca28377d2893dcf1ecbdfdfe203
 
 WORKDIR /app
 

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -29,6 +29,28 @@ class TestDependencyReproducibility:
         ), "Dockerfile does not reference any lockfile — builds are non-reproducible"
 
 
+class TestDockerfilePythonVersion:
+    """The base image must use a GA (non-pre-release) Python version (#403)."""
+
+    def test_dockerfile_uses_stable_python(self):
+        """Dockerfile base image must use a GA (non-pre-release) Python version.
+
+        Python 3.14 was pre-release as of 2026-05-25; GA versions are <= 3.13.
+        pyproject.toml targets 3.10 and CI runs on 3.12, so production must not
+        run an untested pre-release interpreter.
+        """
+        import re
+
+        dockerfile = (_PROJECT_ROOT / "Dockerfile").read_text()
+        m = re.search(r"FROM python:(\d+)\.(\d+)", dockerfile)
+        assert m, "Could not find a 'FROM python:X.Y' line in the Dockerfile"
+        major, minor = int(m.group(1)), int(m.group(2))
+        assert (major, minor) <= (3, 13), (
+            f"Dockerfile uses Python {major}.{minor} which is pre-release. "
+            "Use a GA Python version (e.g., 3.12 or 3.13)."
+        )
+
+
 class TestDockerfileCMD:
     """Verify the Dockerfile CMD is safe and meaningful."""
 


### PR DESCRIPTION
## Summary
- Reverts the Dependabot bump to `python:3.14-slim` (pre-release) back to GA `python:3.12-slim`, matching CI (3.12) and the pyproject target (3.10)
- Pins to the current `python:3.12-slim` index digest
- Adds a regression test asserting the base image is a GA version (≤ 3.13)

Closes #403

## Test plan
- [x] `test_dockerfile.py::TestDockerfilePythonVersion` fails on 3.14, passes on 3.12
- [x] Full suite (minus e2e) green: 1125 passed
- [x] ruff + mypy clean
- [ ] CI `test` + `security` + `e2e` jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)