### PR TITLE
fix: make insert_or_get_* retry-safe on UNIQUE conflict (#400)

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -416,13 +416,27 @@ class Database:
         if row:
             return row[0]
 
-        # Insert new
-        cursor.execute(
-            "INSERT INTO songs (canonical_title, display_title) VALUES (?, ?)",
-            (canonical_title, display_title),
-        )
-        self._maybe_commit()
-        return cursor.lastrowid
+        # Insert new — retry-safe under concurrent writers (#400).  A second
+        # importer can insert the same canonical_title between our SELECT and
+        # INSERT; the UNIQUE(canonical_title) constraint then raises
+        # IntegrityError.  Re-read and return the row the other writer created.
+        try:
+            cursor.execute(
+                "INSERT INTO songs (canonical_title, display_title) VALUES (?, ?)",
+                (canonical_title, display_title),
+            )
+            self._maybe_commit()
+            return cursor.lastrowid
+        except sqlite3.IntegrityError:
+            if not self._in_transaction:
+                self._conn.rollback()
+            cursor.execute(
+                "SELECT id FROM songs WHERE canonical_title = ?", (canonical_title,)
+            )
+            row = cursor.fetchone()
+            if row:
+                return row[0]
+            raise
 
     def insert_or_get_song_edition(
         self,
@@ -436,43 +450,55 @@ class Database:
         """Insert or get song edition. Returns edition_id."""
         cursor = self._conn.cursor()
 
-        # Try to get existing - handle NULL comparisons explicitly
-        cursor.execute(
-            """
+        # Try to get existing - handle NULL comparisons explicitly.
+        select_sql = """
             SELECT id FROM song_editions
             WHERE song_id = ?
             AND (publisher = ? OR (publisher IS NULL AND ? IS NULL))
             AND (words_by = ? OR (words_by IS NULL AND ? IS NULL))
             AND (music_by = ? OR (music_by IS NULL AND ? IS NULL))
             AND (arranger = ? OR (arranger IS NULL AND ? IS NULL))
-            """,
-            (
-                song_id,
-                publisher,
-                publisher,
-                words_by,
-                words_by,
-                music_by,
-                music_by,
-                arranger,
-                arranger,
-            ),
+            """
+        select_params = (
+            song_id,
+            publisher,
+            publisher,
+            words_by,
+            words_by,
+            music_by,
+            music_by,
+            arranger,
+            arranger,
         )
+        cursor.execute(select_sql, select_params)
         row = cursor.fetchone()
         if row:
             return row[0]
 
-        # Insert new
-        cursor.execute(
-            """
-            INSERT INTO song_editions
-            (song_id, publisher, words_by, music_by, arranger, copyright_notice)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (song_id, publisher, words_by, music_by, arranger, copyright_notice),
-        )
-        self._maybe_commit()
-        return cursor.lastrowid
+        # Insert new — retry-safe under concurrent writers when the identity
+        # columns are non-NULL (#400).  NOTE: when publisher/words_by/music_by/
+        # arranger are NULL, SQLite treats each NULL as distinct in the UNIQUE
+        # index, so no IntegrityError fires and concurrent duplicates are still
+        # possible — that NULL-distinct weakness is tracked in #420.
+        try:
+            cursor.execute(
+                """
+                INSERT INTO song_editions
+                (song_id, publisher, words_by, music_by, arranger, copyright_notice)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (song_id, publisher, words_by, music_by, arranger, copyright_notice),
+            )
+            self._maybe_commit()
+            return cursor.lastrowid
+        except sqlite3.IntegrityError:
+            if not self._in_transaction:
+                self._conn.rollback()
+            cursor.execute(select_sql, select_params)
+            row = cursor.fetchone()
+            if row:
+                return row[0]
+            raise
 
     # --- Services ---
 
@@ -624,29 +650,42 @@ class Database:
         cursor = self._conn.cursor()
 
         # Try to get existing - handle NULL comparisons explicitly
-        cursor.execute(
-            """
+        select_sql = """
             SELECT id FROM copy_events
             WHERE service_id = ? AND song_id = ? AND reproduction_type = ?
             AND (song_edition_id = ? OR (song_edition_id IS NULL AND ? IS NULL))
-            """,
-            (service_id, song_id, reproduction_type, song_edition_id, song_edition_id),
+            """
+        select_params = (
+            service_id, song_id, reproduction_type, song_edition_id, song_edition_id,
         )
+        cursor.execute(select_sql, select_params)
         row = cursor.fetchone()
         if row:
             return row[0]
 
-        # Insert new
-        cursor.execute(
-            """
-            INSERT INTO copy_events
-            (service_id, song_id, song_edition_id, reproduction_type, count, reportable)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (service_id, song_id, song_edition_id, reproduction_type, count, int(reportable)),
-        )
-        self._maybe_commit()
-        return cursor.lastrowid
+        # Insert new — retry-safe under concurrent writers when song_edition_id
+        # is non-NULL (#400).  When song_edition_id is NULL, SQLite's UNIQUE index
+        # treats each NULL as distinct, so no IntegrityError fires and concurrent
+        # duplicates remain possible — tracked in #420.
+        try:
+            cursor.execute(
+                """
+                INSERT INTO copy_events
+                (service_id, song_id, song_edition_id, reproduction_type, count, reportable)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (service_id, song_id, song_edition_id, reproduction_type, count, int(reportable)),
+            )
+            self._maybe_commit()
+            return cursor.lastrowid
+        except sqlite3.IntegrityError:
+            if not self._in_transaction:
+                self._conn.rollback()
+            cursor.execute(select_sql, select_params)
+            row = cursor.fetchone()
+            if row:
+                return row[0]
+            raise
 
     # --- Queries ---
 

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2,6 +2,7 @@
 
 import logging
 import sqlite3
+import threading
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -2816,3 +2817,159 @@ class TestNormalizeServiceDates:
         # Applying must not raise and must not change the colliding row.
         temp_db.normalize_service_dates()
         assert temp_db.query_service_by_id(b)["service_date"] == "2026.05.10"
+
+
+@pytest.mark.integration
+class TestConcurrentInsertOrGet:
+    """insert_or_get_* must be safe under concurrent writers (#400).
+
+    The web app runs background imports in a ThreadPoolExecutor (up to 4
+    workers), each with its own Database/connection on the same file. Two
+    threads importing files that share a song can both SELECT (find nothing)
+    then both INSERT — the second INSERT hits the UNIQUE constraint. The
+    methods must absorb that IntegrityError and return the existing row.
+
+    A per-connection busy_timeout lets SQLite wait out write-lock contention,
+    so the only failure these tests surface is the UNIQUE-constraint TOCTOU.
+    """
+
+    _THREADS = 4
+    _ITERATIONS = 25
+
+    @staticmethod
+    def _connect(db_path):
+        db = Database(db_path)
+        db.connect()
+        db.conn.execute("PRAGMA busy_timeout=5000")
+        return db
+
+    def test_concurrent_insert_or_get_song_no_error(self, tmp_path):
+        db_path = tmp_path / "race_song.db"
+        init = self._connect(db_path)
+        init.init_schema()
+        init.close()
+
+        errors: list[Exception] = []
+        barrier = threading.Barrier(self._THREADS)
+
+        def worker() -> None:
+            db = self._connect(db_path)
+            try:
+                barrier.wait()
+                for _ in range(self._ITERATIONS):
+                    db.insert_or_get_song("amazing grace", "Amazing Grace")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                db.close()
+
+        threads = [threading.Thread(target=worker) for _ in range(self._THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Concurrent insert_or_get_song raised: {errors!r}"
+
+        # Exactly one canonical row must exist despite the stampede.
+        check = self._connect(db_path)
+        try:
+            cur = check.conn.cursor()
+            cur.execute("SELECT COUNT(*) FROM songs WHERE canonical_title = ?", ("amazing grace",))
+            assert cur.fetchone()[0] == 1
+        finally:
+            check.close()
+
+    @pytest.mark.xfail(
+        reason="#420: NULL columns in song_editions UNIQUE are distinct in SQLite, "
+        "so concurrent NULL-credit inserts still duplicate (retry can't catch — no error)",
+        strict=False,
+    )
+    def test_concurrent_insert_or_get_song_edition_no_error(self, tmp_path):
+        db_path = tmp_path / "race_edition.db"
+        init = self._connect(db_path)
+        init.init_schema()
+        song_id = init.insert_or_get_song("how great thou art", "How Great Thou Art")
+        init.close()
+
+        errors: list[Exception] = []
+        barrier = threading.Barrier(self._THREADS)
+
+        def worker() -> None:
+            db = self._connect(db_path)
+            try:
+                barrier.wait()
+                for _ in range(self._ITERATIONS):
+                    db.insert_or_get_song_edition(song_id, words_by="Stuart K. Hine")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                db.close()
+
+        threads = [threading.Thread(target=worker) for _ in range(self._THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Concurrent insert_or_get_song_edition raised: {errors!r}"
+
+        check = self._connect(db_path)
+        try:
+            cur = check.conn.cursor()
+            cur.execute(
+                "SELECT COUNT(*) FROM song_editions WHERE song_id = ? AND words_by = ?",
+                (song_id, "Stuart K. Hine"),
+            )
+            assert cur.fetchone()[0] == 1
+        finally:
+            check.close()
+
+    @pytest.mark.xfail(
+        reason="#420: NULL song_edition_id in copy_events UNIQUE is distinct in SQLite, "
+        "so concurrent NULL-edition inserts still duplicate (retry can't catch — no error)",
+        strict=False,
+    )
+    def test_concurrent_insert_or_get_copy_event_no_error(self, tmp_path):
+        db_path = tmp_path / "race_copy.db"
+        init = self._connect(db_path)
+        init.init_schema()
+        song_id = init.insert_or_get_song("blessed assurance", "Blessed Assurance")
+        service_id = init.insert_or_update_service(
+            "2026-02-15", "AM Worship", "f.pptx", "hash1"
+        )
+        init.close()
+
+        errors: list[Exception] = []
+        barrier = threading.Barrier(self._THREADS)
+
+        def worker() -> None:
+            db = self._connect(db_path)
+            try:
+                barrier.wait()
+                for _ in range(self._ITERATIONS):
+                    db.insert_or_get_copy_event(service_id, song_id, "projection")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                db.close()
+
+        threads = [threading.Thread(target=worker) for _ in range(self._THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Concurrent insert_or_get_copy_event raised: {errors!r}"
+
+        check = self._connect(db_path)
+        try:
+            cur = check.conn.cursor()
+            cur.execute(
+                "SELECT COUNT(*) FROM copy_events WHERE service_id = ? AND song_id = ? "
+                "AND reproduction_type = ?",
+                (service_id, song_id, "projection"),
+            )
+            assert cur.fetchone()[0] == 1
+        finally:
+            check.close()


### PR DESCRIPTION
## Summary
- `insert_or_get_song/edition/copy_event` now absorb a UNIQUE `IntegrityError` from a competing concurrent writer: re-SELECT and return the existing row instead of crashing the import
- Conditional rollback (only outside an explicit `transaction()`) lets the re-SELECT see the latest committed row without disturbing `run_import`'s transaction
- Adds `TestConcurrentInsertOrGet` (4 threads × 25 iterations). The **songs** test passes; **editions/copy_events** are `xfail` pending the deeper NULL-distinct UNIQUE fix

## Scope note
Investigation found two root causes. This PR fixes the **songs** `IntegrityError` race (the common case: same song across different services imported concurrently). The **NULL-distinct UNIQUE** weakness in `song_editions`/`copy_events` (no error raised → silent duplicates) needs a schema migration and is filed separately as **#420**.

Closes #400

## Test plan
- [x] Concurrency tests fail before the fix (`IntegrityError`), songs test passes after
- [x] Full suite (minus e2e) green: 1125 passed, 2 xfailed
- [x] `ruff check src/` + `mypy src/` clean
- [ ] CI `test` + `security` + `e2e` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)