### PR TITLE
fix: render upload status via textContent, not innerHTML (#401)

### DIFF
--- a/src/worship_catalog/web/static/upload.js
+++ b/src/worship_catalog/web/static/upload.js
@@ -2,6 +2,10 @@
  * Upload form handler — reads CSRF cookie and submits via fetch with the token header.
  * After a successful upload, polls the job status endpoint until complete (#276).
  * This must be an external file (not inline) to comply with CSP script-src 'self'.
+ *
+ * All server-provided strings (job.error_message, err.message, counts) are
+ * rendered with textContent — never concatenated into innerHTML — so a crafted
+ * error message cannot inject markup (DOM-XSS defence-in-depth, #401).
  */
 (function () {
   "use strict";
@@ -15,6 +19,17 @@
     return token;
   }
 
+  /**
+   * Replace the contents of `el` with a single styled <p> whose text is set
+   * via textContent, so `text` is never interpreted as HTML.
+   */
+  function showMessage(el, color, text) {
+    var p = document.createElement("p");
+    p.style.color = color;
+    p.textContent = text;
+    el.replaceChildren(p);
+  }
+
   /** Poll /jobs/{id} until status is complete or failed (#276). */
   function pollJobStatus(jobId, resultEl) {
     var pollInterval = 2000; // 2 seconds
@@ -24,9 +39,11 @@
     function check() {
       polls++;
       if (polls > maxPolls) {
-        resultEl.innerHTML =
-          '<p style="color:#856404;">Import is still running. ' +
-          'Refresh the page later to check results.</p>';
+        showMessage(
+          resultEl,
+          "#856404",
+          "Import is still running. Refresh the page later to check results."
+        );
         return;
       }
       fetch("/jobs/" + jobId)
@@ -36,26 +53,29 @@
         .then(function (job) {
           if (job.status === "complete") {
             if (job.songs_imported === 0) {
-              resultEl.innerHTML =
-                '<p style="color:#856404;">' +
-                "Import complete \u2014 no songs found. " +
-                "The file may not be a worship slide deck.</p>";
+              showMessage(
+                resultEl,
+                "#856404",
+                "Import complete — no songs found. " +
+                  "The file may not be a worship slide deck."
+              );
             } else {
-              resultEl.innerHTML =
-                '<p style="color:green;">' +
-                "Import complete \u2014 " +
-                job.songs_imported +
-                " song(s) imported.</p>";
+              showMessage(
+                resultEl,
+                "green",
+                "Import complete — " +
+                  job.songs_imported +
+                  " song(s) imported."
+              );
             }
           } else if (job.status === "failed") {
-            resultEl.innerHTML =
-              '<p style="color:#c00;">Import failed: ' +
-              (job.error_message || "unknown error") +
-              "</p>";
+            showMessage(
+              resultEl,
+              "#c00",
+              "Import failed: " + (job.error_message || "unknown error")
+            );
           } else {
-            resultEl.innerHTML =
-              '<p style="color:#495057;">Importing\u2026 ' +
-              '<span class="htmx-indicator" style="opacity:1;">processing</span></p>';
+            showMessage(resultEl, "#495057", "Importing… processing");
             setTimeout(check, pollInterval);
           }
         })
@@ -75,8 +95,8 @@
     var btn = form.querySelector("button[type=submit]");
     var result = document.getElementById("upload-result");
     btn.disabled = true;
-    btn.textContent = "Uploading\u2026";
-    result.innerHTML = "";
+    btn.textContent = "Uploading…";
+    result.replaceChildren();
 
     var data = new FormData(form);
     fetch("/upload", {
@@ -91,13 +111,11 @@
         });
       })
       .then(function (j) {
-        result.innerHTML =
-          '<p style="color:#495057;">Upload accepted \u2014 importing\u2026</p>';
+        showMessage(result, "#495057", "Upload accepted — importing…");
         pollJobStatus(j.job_id, result);
       })
       .catch(function (err) {
-        result.innerHTML =
-          '<p style="color:#c00;">Upload failed: ' + err.message + "</p>";
+        showMessage(result, "#c00", "Upload failed: " + err.message);
       })
       .finally(function () {
         btn.disabled = false;

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -36,6 +36,50 @@ def client(db_with_songs, tmp_path, monkeypatch):
     return CsrfAwareClient(TestClient(app_module.app))
 
 
+_STATIC_DIR = Path(__file__).parent.parent / "src" / "worship_catalog" / "web" / "static"
+
+
+class TestUploadJsXssSafety:
+    """upload.js must not render server-provided strings via innerHTML (#401).
+
+    job.error_message and err.message originate from the server (DB-stored
+    exception text and JSON `detail`). Concatenating them into innerHTML is a
+    DOM-XSS sink that CSP `script-src 'self'` does not fully close (e.g.
+    `<img onerror=...>`). They must be rendered with textContent.
+    """
+
+    def _upload_js(self) -> str:
+        return (_STATIC_DIR / "upload.js").read_text()
+
+    @staticmethod
+    def _strip_string_literals(js: str) -> str:
+        """Blank out the CONTENTS of string literals so semicolons inside CSS
+        (e.g. 'color:#c00;') don't masquerade as statement terminators."""
+        import re
+
+        js = re.sub(r"'(?:[^'\\]|\\.)*'", "''", js)
+        js = re.sub(r'"(?:[^"\\]|\\.)*"', '""', js)
+        return re.sub(r"\s+", " ", js)
+
+    def test_error_message_not_assigned_via_innerhtml(self) -> None:
+        import re
+
+        collapsed = self._strip_string_literals(self._upload_js())
+        for sink in ("error_message", "err.message"):
+            # After stripping literals, `[^;]*` reliably spans one statement.
+            pattern = re.compile(r"innerHTML\s*=\s*[^;]*" + re.escape(sink))
+            assert not pattern.search(collapsed), (
+                f"upload.js assigns {sink!r} into innerHTML — DOM-XSS risk. "
+                "Render server-provided strings with textContent instead."
+            )
+
+    def test_server_strings_use_textcontent(self) -> None:
+        js = self._upload_js()
+        assert "textContent" in js, (
+            "upload.js should use textContent to render dynamic server values safely"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Issue #107: HTMX SRI integrity attribute
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `upload.js` now renders all dynamic status (`job.error_message`, `err.message`, song counts) via a `showMessage()` helper that uses `textContent` + `replaceChildren()` — never `innerHTML` string concatenation
- Adds a static-analysis security test asserting `error_message`/`err.message` are never fed to `innerHTML`
- Verified in a real Chromium browser: upload form e2e (no JS errors, CSRF cookie, invalid-file error shown) — 4 passed

Closes #401

## Test plan
- [x] Static XSS test fails on the old `innerHTML` concatenation, passes after
- [x] Local Playwright `TestUploadFormE2E` — 4 passed against a live server
- [x] Full suite (minus e2e) green: 1128 passed
- [x] `ruff check src/` + `mypy src/` clean
- [ ] CI `test` + `security` + `e2e` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)