### PR TITLE
fix: resolve client IP via CF-Connecting-IP, not spoofable XFF (#404)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -252,19 +252,33 @@ _PPTX_MIME = (
 # Per-client upload rate limiting (#173)
 _UPLOAD_RATE_LIMIT: int = 10  # max uploads per window
 _UPLOAD_RATE_WINDOW_SECONDS: int = 3600  # 1 hour
-# Env-configurable trusted proxy header (#283).  When TRUSTED_PROXY=1 the rate
-# limiter reads the leftmost X-Forwarded-For value so that clients behind a
-# reverse proxy are identified individually instead of all sharing one bucket.
+# Env-configurable trusted proxy support (#283, #404).  When TRUSTED_PROXY=1 the
+# rate limiter identifies clients via Cloudflare's unspoofable CF-Connecting-IP
+# (or, failing that, the proxy-appended rightmost X-Forwarded-For entry) instead
+# of the socket peer, so clients behind the proxy are bucketed individually.
 _TRUST_PROXY: bool = os.environ.get("TRUSTED_PROXY", "").strip() in ("1", "true", "yes")
 
 
 def _get_client_ip(request: Request) -> str:
-    """Return the real client IP, respecting X-Forwarded-For if trusted (#283)."""
+    """Return the real client IP, respecting trusted-proxy headers (#283, #404).
+
+    The leftmost ``X-Forwarded-For`` entry is supplied by the client and is
+    therefore spoofable — trusting it lets an attacker mint a fresh rate-limit
+    bucket per request. This deployment sits behind Cloudflare, which sets the
+    unspoofable ``CF-Connecting-IP`` header (and strips any client-supplied
+    copy), so prefer it. If it is absent, fall back to the *rightmost*
+    ``X-Forwarded-For`` entry — the address appended by our own proxy — rather
+    than the client-controlled leftmost one.
+    """
     if _TRUST_PROXY:
+        cf_ip = request.headers.get("cf-connecting-ip", "").strip()
+        if cf_ip:
+            return cf_ip
         xff = request.headers.get("x-forwarded-for", "")
         if xff:
-            # Leftmost entry is the original client IP
-            return xff.split(",")[0].strip()
+            parts = [p.strip() for p in xff.split(",") if p.strip()]
+            if parts:
+                return parts[-1]
     return request.client.host if request.client else "unknown"
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3516,7 +3516,7 @@ class TestUploadRateLimiterPersistence:
 
 
 class TestProxyAwareRateLimiter:
-    """Rate limiter should use X-Forwarded-For when TRUSTED_PROXY is set (#283)."""
+    """Rate limiter client-IP resolution behind a trusted proxy (#283, #404)."""
 
     def test_get_client_ip_without_proxy(self, monkeypatch):
         monkeypatch.setenv("TRUSTED_PROXY", "")
@@ -3529,7 +3529,9 @@ class TestProxyAwareRateLimiter:
         req.headers = {}
         assert app_module._get_client_ip(req) == "1.2.3.4"
 
-    def test_get_client_ip_with_proxy(self, monkeypatch):
+    def test_get_client_ip_with_proxy_uses_rightmost_xff(self, monkeypatch):
+        # The leftmost X-Forwarded-For entry is client-controlled and spoofable;
+        # the proxy-appended rightmost entry is the trustworthy one (#404).
         monkeypatch.setenv("TRUSTED_PROXY", "1")
         from importlib import reload
         import worship_catalog.web.app as app_module
@@ -3537,8 +3539,23 @@ class TestProxyAwareRateLimiter:
         from unittest.mock import MagicMock
         req = MagicMock()
         req.client.host = "10.0.0.1"
-        req.headers = {"x-forwarded-for": "5.6.7.8, 10.0.0.1"}
-        assert app_module._get_client_ip(req) == "5.6.7.8"
+        req.headers = {"x-forwarded-for": "5.6.7.8, 198.51.100.2"}
+        assert app_module._get_client_ip(req) == "198.51.100.2"
+
+    def test_get_client_ip_prefers_cf_connecting_ip(self, monkeypatch):
+        # Cloudflare sets CF-Connecting-IP to the unspoofable real client IP (#404).
+        monkeypatch.setenv("TRUSTED_PROXY", "1")
+        from importlib import reload
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        from unittest.mock import MagicMock
+        req = MagicMock()
+        req.client.host = "10.0.0.1"
+        req.headers = {
+            "cf-connecting-ip": "203.0.113.7",
+            "x-forwarded-for": "5.6.7.8",
+        }
+        assert app_module._get_client_ip(req) == "203.0.113.7"
 
     def test_get_client_ip_proxy_no_xff_header(self, monkeypatch):
         monkeypatch.setenv("TRUSTED_PROXY", "1")

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -401,6 +401,71 @@ class TestCsrfSecretStartup:
 
 
 # ---------------------------------------------------------------------------
+# Issue #404 — client IP resolution must not trust spoofable X-Forwarded-For
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self, host: str) -> None:
+        self.host = host
+
+
+class _FakeRequest:
+    """Minimal stand-in exposing the .headers.get() and .client.host that
+    _get_client_ip relies on (headers are matched case-insensitively)."""
+
+    def __init__(self, headers: dict[str, str], client_host: str = "10.0.0.9") -> None:
+        self.headers = {k.lower(): v for k, v in headers.items()}
+        self.client = _FakeClient(client_host)
+
+
+class TestClientIpResolution:
+    """_get_client_ip must prefer Cloudflare's unspoofable CF-Connecting-IP and
+    never trust the client-controlled leftmost X-Forwarded-For entry (#404)."""
+
+    def _app(self):
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        return app_module
+
+    def test_cf_connecting_ip_preferred_over_xff(self, monkeypatch) -> None:
+        app_module = self._app()
+        monkeypatch.setattr(app_module, "_TRUST_PROXY", True)
+        req = _FakeRequest({
+            "CF-Connecting-IP": "203.0.113.7",
+            "X-Forwarded-For": "1.2.3.4",  # attacker-supplied leftmost
+        })
+        assert app_module._get_client_ip(req) == "203.0.113.7"
+
+    def test_spoofed_leftmost_xff_ignored(self, monkeypatch) -> None:
+        """Without CF header, the leftmost (client-set) XFF entry must NOT be used;
+        the proxy-appended rightmost entry is the trustworthy one."""
+        app_module = self._app()
+        monkeypatch.setattr(app_module, "_TRUST_PROXY", True)
+        req = _FakeRequest({"X-Forwarded-For": "1.2.3.4, 198.51.100.2"})
+        ip = app_module._get_client_ip(req)
+        assert ip != "1.2.3.4", "Leftmost X-Forwarded-For is client-controlled and spoofable"
+        assert ip == "198.51.100.2"
+
+    def test_proxy_disabled_uses_socket_peer(self, monkeypatch) -> None:
+        app_module = self._app()
+        monkeypatch.setattr(app_module, "_TRUST_PROXY", False)
+        req = _FakeRequest(
+            {"CF-Connecting-IP": "203.0.113.7", "X-Forwarded-For": "1.2.3.4"},
+            client_host="10.0.0.9",
+        )
+        assert app_module._get_client_ip(req) == "10.0.0.9"
+
+    def test_no_proxy_headers_falls_back_to_peer(self, monkeypatch) -> None:
+        app_module = self._app()
+        monkeypatch.setattr(app_module, "_TRUST_PROXY", True)
+        req = _FakeRequest({}, client_host="172.16.0.5")
+        assert app_module._get_client_ip(req) == "172.16.0.5"
+
+
+# ---------------------------------------------------------------------------
 # Issue #173 — Upload rate limiting
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `_get_client_ip` now prefers Cloudflare's unspoofable `CF-Connecting-IP`; falls back to the proxy-appended **rightmost** `X-Forwarded-For` entry instead of the client-controlled leftmost one
- Closes the rate-limiter bypass where an attacker rotated `X-Forwarded-For` to get a fresh bucket per request
- Updates the existing proxy test that encoded the old leftmost behavior

Closes #404

## Test plan
- [x] New `TestClientIpResolution` + updated `TestProxyAwareRateLimiter` (8 tests) green
- [x] Full suite (minus e2e): 1132 passed
- [x] `ruff check src/` + `mypy src/` clean
- [ ] CI `test` + `security` + `e2e` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)