### PR TITLE
feat: emit HSTS header when HTTPS_ONLY is enabled (#405)

### DIFF
--- a/deploy/pi/.env.example
+++ b/deploy/pi/.env.example
@@ -10,6 +10,10 @@ CLOUDFLARE_API_TOKEN=your-cloudflare-api-token-here
 # restarts.  Generate once with: python3 -c "import secrets; print(secrets.token_hex(32))"
 CSRF_SECRET=your-random-secret-here
 
+# Send the Strict-Transport-Security (HSTS) header (#405). Enable on HTTPS-only
+# deployments (behind Cloudflare/Traefik). Leave unset for plain-HTTP/local dev.
+HTTPS_ONLY=1
+
 # Anthropic API key — required only if using --ocr in repair-credits.
 # Leave blank to disable OCR fallback.
 ANTHROPIC_API_KEY=

--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -80,6 +80,8 @@ services:
       # defaults to "highland".
       UPLOAD_PASSWORD: "${UPLOAD_PASSWORD:-}"
       UPLOAD_USERNAME: "${UPLOAD_USERNAME:-highland}"
+      # Emit HSTS when served over HTTPS (behind Cloudflare/Traefik) (#405).
+      HTTPS_ONLY: "${HTTPS_ONLY:-}"
     volumes:
       - /opt/song-history/data:/data
       - /opt/song-history/inbox:/inbox

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -129,8 +129,14 @@ _CSP_POLICY: str = (
 )
 
 
+# HSTS is opt-in via HTTPS_ONLY so that HTTP-only local/CI deployments don't
+# send a policy that would lock a browser into HTTPS for the host (#405).
+_HSTS_ENABLED: bool = os.environ.get("HTTPS_ONLY", "").strip() in ("1", "true", "yes")
+_HSTS_VALUE: str = "max-age=31536000; includeSubDomains"
+
+
 class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    """Attach security headers to every response (#197, #282)."""
+    """Attach security headers to every response (#197, #282, #405)."""
 
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
         response = await call_next(request)
@@ -140,6 +146,10 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Permissions-Policy"] = (
             "camera=(), microphone=(), geolocation=(), payment=()"
         )
+        # Only assert HSTS when the deployment is HTTPS-only (behind Cloudflare/
+        # Traefik). Sending it over plain HTTP would wrongly pin clients to HTTPS.
+        if _HSTS_ENABLED:
+            response.headers["Strict-Transport-Security"] = _HSTS_VALUE
         return response
 
 

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -939,6 +939,47 @@ class TestSecurityHeaders:
         assert "Content-Security-Policy" in resp.headers
 
 
+class TestHstsHeader:
+    """Strict-Transport-Security must be emitted when HTTPS_ONLY is enabled (#405).
+
+    HSTS is gated on HTTPS_ONLY so that local/CI deployments served over plain
+    HTTP do not send an HSTS policy that would lock browsers into HTTPS.
+    """
+
+    def _client(self, tmp_path, monkeypatch, https_only):
+        monkeypatch.setenv("DB_PATH", str(tmp_path / "hsts.db"))
+        inbox = tmp_path / "hsts_inbox"
+        inbox.mkdir(exist_ok=True)
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        if https_only is None:
+            monkeypatch.delenv("HTTPS_ONLY", raising=False)
+        else:
+            monkeypatch.setenv("HTTPS_ONLY", https_only)
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        return TestClient(app_module.app)
+
+    def test_hsts_present_when_https_only_enabled(self, tmp_path, monkeypatch):
+        import re
+
+        client = self._client(tmp_path, monkeypatch, "1")
+        resp = client.get("/health")
+        hsts = resp.headers.get("Strict-Transport-Security", "")
+        assert hsts, "HSTS header missing when HTTPS_ONLY=1"
+        m = re.search(r"max-age=(\d+)", hsts)
+        assert m and int(m.group(1)) >= 31536000, f"HSTS max-age too low: {hsts!r}"
+        assert "includeSubDomains" in hsts
+
+    def test_hsts_absent_by_default(self, tmp_path, monkeypatch):
+        client = self._client(tmp_path, monkeypatch, None)
+        resp = client.get("/health")
+        assert "Strict-Transport-Security" not in resp.headers, (
+            "HSTS must not be sent unless HTTPS_ONLY is enabled (would break HTTP dev)"
+        )
+
+
 # ---------------------------------------------------------------------------
 # #388 Phase 1: simple password gate on the upload page
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `Strict-Transport-Security: max-age=31536000; includeSubDomains` to the security-headers middleware
- Gated on `HTTPS_ONLY` env so plain-HTTP local/CI deployments don't pin browsers to HTTPS
- Wires `HTTPS_ONLY` through the Pi compose file + documents it in `deploy/pi/.env.example`

Closes #405

## Test plan
- [x] `TestHstsHeader`: header present (max-age ≥ 1y, includeSubDomains) when `HTTPS_ONLY=1`, absent by default
- [x] Full suite (minus e2e): 1135 passed, 2 xfailed
- [x] `ruff check src/` + `mypy src/` clean
- [ ] CI `test` + `security` + `e2e` pass

## Deploy note
The Pi `.env` must set `HTTPS_ONLY=1` (added to `.env.example`) for HSTS to take effect — handled at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)