### PR TITLE
fix: require CSRF_SECRET in production, hard-fail if unset (#406)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,9 @@ jobs:
 
       - name: Start server
         run: |
-          DB_PATH=/tmp/e2e-test.db INBOX_DIR=/tmp/e2e-inbox \
+          # TESTING=1 lets the app use an ephemeral CSRF secret instead of
+          # requiring CSRF_SECRET, which is mandatory in production (#406).
+          DB_PATH=/tmp/e2e-test.db INBOX_DIR=/tmp/e2e-inbox TESTING=1 \
             python3 -m uvicorn worship_catalog.web.app:app \
               --host 127.0.0.1 --port 8000 &
           # Wait for server to become healthy (max 15s)

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -100,13 +100,29 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(title="Worship Catalog", lifespan=_lifespan)
 
 # CSRF protection — must be added BEFORE RequestLoggingMiddleware so that 403
-# responses are logged correctly. Secret is read from env; a random value is
-# generated on first start (sufficient for a single-process deployment).
-_CSRF_SECRET = os.environ.get("CSRF_SECRET") or secrets.token_hex(32)
-if not os.environ.get("CSRF_SECRET"):
+# responses are logged correctly. A stable CSRF_SECRET is REQUIRED in
+# production: an ephemeral per-process secret invalidates every outstanding
+# token on restart and fails CSRF validation across workers (#406). Outside
+# TESTING mode a missing secret is a hard error so a misconfigured deploy fails
+# fast instead of silently degrading. TESTING=1 keeps an ephemeral secret for
+# the test suite / local dev.
+_TESTING: bool = os.environ.get("TESTING", "").strip() in ("1", "true", "yes")
+_csrf_secret_env = os.environ.get("CSRF_SECRET")
+if _csrf_secret_env:
+    _CSRF_SECRET = _csrf_secret_env
+elif _TESTING:
+    _CSRF_SECRET = secrets.token_hex(32)
     _log.warning(
-        "CSRF_SECRET not set — using random secret (single-process only). "
-        "Set CSRF_SECRET in .env for multi-process or load-balanced deployments."
+        "CSRF_SECRET not set — using an ephemeral random secret (TESTING mode). "
+        "Set a stable CSRF_SECRET for any real deployment."
+    )
+else:
+    raise RuntimeError(
+        "CSRF_SECRET is not set. Generate a stable secret once with "
+        '`python3 -c "import secrets; print(secrets.token_hex(32))"` and set it '
+        "in the environment so CSRF tokens survive restarts and work across "
+        "workers. For tests or local dev, set TESTING=1 to allow an ephemeral "
+        "random secret."
     )
 # cookie_name is set explicitly so the coupling with client-side JS
 # (upload.js, reports.js) and CsrfAwareClient in conftest.py is visible (#239).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,22 @@
 """Shared pytest fixtures for worship-catalog tests."""
 
 import os
-import socket
-from collections.abc import Generator
-from typing import Any
 
-import pytest
+# Mark the whole test session as TESTING so the web app permits an ephemeral
+# CSRF secret instead of hard-failing on a missing CSRF_SECRET (#406). Set at
+# import time — before any test module imports/reloads worship_catalog.web.app —
+# so module-level enforcement never trips during the test run. Individual tests
+# may still delenv("TESTING") to exercise production startup behavior.
+os.environ.setdefault("TESTING", "1")
 
-from worship_catalog.db import Database
-from worship_catalog.pptx_reader import Slide, SlideImage, SlideText
+import socket  # noqa: E402
+from collections.abc import Generator  # noqa: E402
+from typing import Any  # noqa: E402
+
+import pytest  # noqa: E402
+
+from worship_catalog.db import Database  # noqa: E402
+from worship_catalog.pptx_reader import Slide, SlideImage, SlideText  # noqa: E402
 
 # E2E server URL — configurable via env var for CI (default: local dev server)
 E2E_BASE_URL = os.environ.get("E2E_BASE_URL", "http://localhost:8000")

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -407,6 +407,25 @@ class TestCsrfSecretStartup:
         resp = client.get("/health")
         assert resp.status_code == 200
 
+    def test_app_refuses_to_start_without_csrf_secret_in_production(self, tmp_path, monkeypatch):
+        """Outside TESTING mode, a missing CSRF_SECRET must hard-fail at startup so a
+        production deploy can't silently fall back to an ephemeral secret (#406)."""
+        monkeypatch.delenv("CSRF_SECRET", raising=False)
+        monkeypatch.delenv("TESTING", raising=False)
+        monkeypatch.setenv("DB_PATH", str(tmp_path / "csrf_prod.db"))
+        monkeypatch.setenv("INBOX_DIR", str(tmp_path / "inbox_prod"))
+        (tmp_path / "inbox_prod").mkdir()
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+        try:
+            with pytest.raises(RuntimeError, match="CSRF_SECRET"):
+                reload(app_module)
+        finally:
+            # Leave a healthy module for the rest of the session.
+            monkeypatch.setenv("TESTING", "1")
+            reload(app_module)
+
     def test_csrf_token_persists_across_requests(self, tmp_path, monkeypatch):
         """CSRF token obtained in one request must be valid in the next."""
         monkeypatch.setenv("CSRF_SECRET", "b" * 64)


### PR DESCRIPTION
## Summary
- A missing `CSRF_SECRET` now raises at startup **unless** `TESTING=1`, so a production deploy can't silently use an ephemeral secret (which invalidates tokens on restart and breaks multi-worker setups)
- `conftest.py` sets `TESTING=1` at import so the whole suite is unaffected
- CI e2e server start passes `TESTING=1`
- The Pi `.env` already has `CSRF_SECRET` set, so this is deploy-safe (verified)

Closes #406

## Test plan
- [x] New test: app refuses to start (RuntimeError) without `CSRF_SECRET` when not in TESTING mode
- [x] Existing CSRF startup tests still pass (set + TESTING-fallback paths)
- [x] Full suite (minus e2e): 1138 passed, 2 xfailed
- [x] `ruff check src/` + `mypy src/` clean
- [ ] CI `test` + `security` + `e2e` pass (e2e now exports TESTING=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)