### PR TITLE
ci: supply CSRF_SECRET to publish smoke test (#406 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,8 +311,11 @@ jobs:
       - name: Smoke test image
         if: steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
+          # CSRF_SECRET is mandatory in production (#406); supply an ephemeral
+          # one so the image boots the same code path a real deployment uses.
           docker run -d --name smoke-test \
             -e DB_PATH=/tmp/test.db \
+            -e CSRF_SECRET=smoke-test-ephemeral-secret \
             -p 8765:8000 \
             local-scan:latest
           # Wait for the server to start (max 15s)

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -93,6 +93,29 @@ class TestMainTestStepFloor:
         )
 
 
+@pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
+class TestSmokeTestCsrf:
+    """The publish smoke test runs the production image, which now hard-requires
+    CSRF_SECRET (#406). The step must supply CSRF_SECRET (or TESTING) or the
+    container exits at startup and the image is never pushed."""
+
+    def _smoke_run_block(self) -> str:
+        workflow = yaml.safe_load(CI_PATH.read_text())
+        for job in workflow["jobs"].values():
+            for step in job.get("steps", []):
+                if step.get("name", "").lower().startswith("smoke test"):
+                    return step.get("run", "")
+        raise AssertionError("Smoke test step not found in ci.yml")
+
+    def test_smoke_test_provides_csrf_config(self) -> None:
+        run_block = self._smoke_run_block()
+        assert "CSRF_SECRET" in run_block or "TESTING" in run_block, (
+            "Smoke test must pass CSRF_SECRET (or TESTING=1) to the container; "
+            "otherwise #406 enforcement makes the image exit at startup and the "
+            "publish push is skipped."
+        )
+
+
 # Known-good SHA for aquasecurity/trivy-action v0.36.0
 _TRIVY_CURRENT_SHA = "ed142fd0673e97e23eac54620cfb913e5ce36c25"
 


### PR DESCRIPTION
## Summary
- #406 made `CSRF_SECRET` mandatory at startup, which broke the publish job's **smoke test** (the container exited before serving `/health`), so the new image was never pushed
- Pass an ephemeral `CSRF_SECRET` to the smoke-test container so it boots the production code path
- Adds a `test_ci_config` guard asserting the smoke step always supplies CSRF config

Follow-up to #406. Unblocks publishing the Sprint 1 image.

## Test plan
- [x] Guard test fails without CSRF config in the smoke step, passes after
- [x] `test_ci_config.py` green (7 passed)
- [ ] CI `test` + `security` + `e2e` + **publish** pass (publish must now push `:latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)