### PR TITLE
feat: add HEALTHCHECK to Dockerfile (#402)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,5 +65,11 @@ ENV INBOX_DIR=/inbox
 # Drop privileges before running anything
 USER appuser
 
+# Liveness probe baked into the image so standalone `docker run` (and any
+# orchestrator that doesn't use the compose healthcheck) can detect a dead
+# uvicorn process (#402). Mirrors the compose healthcheck.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD ["python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+
 ENTRYPOINT ["uvicorn"]
 CMD ["worship_catalog.web.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -29,6 +29,31 @@ class TestDependencyReproducibility:
         ), "Dockerfile does not reference any lockfile — builds are non-reproducible"
 
 
+class TestDockerfileHealthcheck:
+    """The image must define a HEALTHCHECK so non-compose deploys have a probe (#402)."""
+
+    def test_dockerfile_has_healthcheck(self):
+        dockerfile = (_PROJECT_ROOT / "Dockerfile").read_text()
+        assert "HEALTHCHECK" in dockerfile, (
+            "Dockerfile must define a HEALTHCHECK so standalone 'docker run' "
+            "invocations (not using the compose healthcheck) detect a dead process."
+        )
+
+    def test_healthcheck_targets_health_endpoint(self):
+        dockerfile = (_PROJECT_ROOT / "Dockerfile").read_text()
+        idx = dockerfile.find("HEALTHCHECK")
+        assert idx != -1
+        assert "/health" in dockerfile[idx:], "HEALTHCHECK must probe the /health endpoint"
+
+    def test_healthcheck_interval_reasonable(self):
+        import re
+
+        dockerfile = (_PROJECT_ROOT / "Dockerfile").read_text()
+        m = re.search(r"--interval=(\d+)s", dockerfile)
+        assert m, "HEALTHCHECK must set an explicit --interval"
+        assert int(m.group(1)) <= 60, "HEALTHCHECK interval should be <= 60s"
+
+
 class TestDockerfilePythonVersion:
     """The base image must use a GA (non-pre-release) Python version (#403)."""
 


### PR DESCRIPTION
## Summary
- Bakes a `HEALTHCHECK` (probes `/health`, 30s interval) into the image so non-compose deployments have a liveness probe
- Adds `TestDockerfileHealthcheck` regression tests

Closes #402

## Test plan
- [x] HEALTHCHECK tests fail before, pass after (9 dockerfile tests green)
- [x] `ruff check src/` clean
- [ ] CI test + security + e2e + publish (smoke test confirms the image still boots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)