### PR TITLE
ci: add re-evaluation note to pip-audit CVE skip (#408)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,9 @@ jobs:
           }
 
       - name: Dependency audit (pip-audit)
-        # CVE-2026-3219 affects pip itself; no fix released yet — ignore until pip patch ships
+        # CVE-2026-3219 affects pip itself; no fix released upstream yet.
+        # Re-evaluate at every Dependabot bump of requirements.lock and remove
+        # this --ignore-vuln once a fixed pip ships. Tracked by #408.
         run: python3 -m pip_audit --skip-editable --ignore-vuln CVE-2026-3219
 
       # --- Static security analysis ----------------------------------------

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -116,6 +116,26 @@ class TestSmokeTestCsrf:
         )
 
 
+@pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
+class TestCveSkipReviewNote:
+    """Every pip-audit CVE ignore must carry a re-evaluation note so suppressed
+    vulnerabilities don't become a permanent ratchet (#408)."""
+
+    def test_cve_skips_have_review_note(self) -> None:
+        import re
+
+        ci = CI_PATH.read_text()
+        skips = re.findall(r"--ignore-vuln\s+(CVE-\d{4}-\d+)", ci)
+        # If there are no skips, there's nothing to review — trivially fine.
+        for cve in skips:
+            idx = ci.index(cve)
+            surrounding = ci[max(0, idx - 300):idx + 100].lower()
+            assert "re-evaluate" in surrounding or "review" in surrounding, (
+                f"CVE skip for {cve} has no re-evaluation note. Add a comment "
+                "stating when to remove it (e.g. 'Re-evaluate when pip >= X.Y ships')."
+            )
+
+
 # Known-good SHA for aquasecurity/trivy-action v0.36.0
 _TRIVY_CURRENT_SHA = "ed142fd0673e97e23eac54620cfb913e5ce36c25"
 


### PR DESCRIPTION
## Summary
- Documents a removal trigger for the `CVE-2026-3219` `--ignore-vuln` (re-evaluate at each lockfile bump, remove when fixed pip ships)
- Adds a `test_ci_config` guard requiring a review note next to every CVE skip

Closes #408

## Test plan
- [x] Guard test fails without the note, passes after (8 ci_config tests green)
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)