### PR TITLE
fix: announce concise song count, not whole table, to screen readers (#413)

### DIFF
--- a/src/worship_catalog/web/templates/_songs_results.html
+++ b/src/worship_catalog/web/templates/_songs_results.html
@@ -12,6 +12,13 @@
 </th>
 {% endmacro %}
 
+{# Concise screen-reader announcement of the result count. Replaces the old
+   table-wide aria-live region, which read every row aloud on each search
+   keystroke (#413). aria-atomic ensures the whole short sentence is announced. #}
+<p id="songs-count" class="sr-only" aria-live="polite" aria-atomic="true">
+  {{ total }} song{{ "s" if total != 1 else "" }} found{% if q %} for “{{ q }}”{% endif %}.
+</p>
+
 {% if total == 0 and not q %}
 <div class="card" style="text-align:center;padding:2rem;">
   <h2>No songs yet</h2>
@@ -20,7 +27,7 @@
   <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
 </div>
 {% else %}
-<div class="card" style="padding:0;" aria-live="polite">
+<div class="card" style="padding:0;">
   <div class="table-wrap">
   <table>
     <caption class="sr-only">Song library — sortable by title, credits, or performance count</caption>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -179,6 +179,35 @@ class TestAriaLiveRegions:
         assert 'aria-live="assertive"' in resp.text or 'role="alert"' in resp.text
 
 
+class TestSongsConciseLiveRegion:
+    """Songs search must announce a concise result count, not the whole table (#413)."""
+
+    def test_songs_table_card_is_not_the_live_region(self, client: TestClient) -> None:
+        """The table-wrapping card must no longer carry aria-live — otherwise every
+        HTMX search keystroke re-announces all rows to screen readers."""
+        resp = client.get("/songs")
+        assert 'style="padding:0;" aria-live="polite"' not in resp.text, (
+            "Songs table card is still an aria-live region — it announces the entire "
+            "table on every search keystroke. Move aria-live to a concise count region."
+        )
+
+    def test_songs_has_concise_count_live_region(self, client: TestClient) -> None:
+        resp = client.get("/songs")
+        import re
+
+        m = re.search(r'id="songs-count"[^>]*>', resp.text)
+        assert m, "Expected a concise #songs-count live region"
+        tag = m.group(0)
+        assert 'aria-live="polite"' in tag and 'aria-atomic="true"' in tag, (
+            "The count region must be a polite, atomic live region"
+        )
+
+    def test_songs_htmx_partial_includes_count(self, client: TestClient) -> None:
+        """The HTMX search response must re-render the count so it updates on search."""
+        resp = client.get("/songs?q=Amazing", headers={"HX-Request": "true"})
+        assert 'id="songs-count"' in resp.text
+
+
 class TestErrorPageContrast:
     """Tests for error page text contrast (#307)."""
 


### PR DESCRIPTION
## Summary
- Removes `aria-live` from the songs table card (which re-announced every row on each search keystroke) and adds a concise sr-only `#songs-count` live region ("N songs found")
- The count lives inside the swapped `#songs-results` region, so it updates correctly on HTMX search (verified: "3 songs found." → "1 song found for "Amazing"."), with proper singular/plural
- Services page has the same issue but needs a results-region refactor → split to **#431**

Closes #413

## Test plan
- [x] New `TestSongsConciseLiveRegion` (3 tests) + existing #306 aria-live tests pass (25 a11y total)
- [x] Local Playwright `TestSongsPageHTMX` (search/sort/clear) — 4 passed
- [x] Full suite (minus e2e): 1142 passed, 2 xfailed
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)