### PR TITLE
test: add upload→songs pipeline E2E (#412)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,64 @@ def synthetic_pptx(tmp_path_factory):
     return out
 
 
+# A song title that does NOT exist in the E2E seed data, so an upload→songs
+# pipeline test can prove the upload actually imported new content (#412).
+# Must be the SHORTEST candidate on its slide: select_best_title() prefers the
+# shortest line, so the lyric lines below are deliberately longer than this.
+UPLOAD_PROBE_SONG_TITLE = "Zzqprobe"
+
+
+@pytest.fixture(scope="session")
+def upload_probe_pptx(tmp_path_factory):
+    """Build a synthetic PPTX whose song title is unique to the upload pipeline
+    test, so asserting it appears in /songs proves the import ran (#412)."""
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    prs = Presentation()
+    blank_layout = prs.slide_layouts[6]
+
+    def add_text_box(slide, lines):
+        box = slide.shapes.add_textbox(Inches(0.5), Inches(0.5), Inches(9), Inches(2))
+        tf = box.text_frame
+        tf.word_wrap = True
+        for i, line in enumerate(lines):
+            if i == 0:
+                tf.paragraphs[0].text = line
+            else:
+                tf.add_paragraph().text = line
+        return tf
+
+    # Slide 0: metadata table (unique date + service so it's a fresh service row).
+    meta = prs.slides.add_slide(blank_layout)
+    table = meta.shapes.add_table(5, 2, Inches(1), Inches(1), Inches(8), Inches(2)).table
+    for r, (k, v) in enumerate([
+        ("Date", "2026-09-09"),
+        ("Service", "E2E Upload Pipeline Test"),
+        ("Song Leader", "Probe"),
+        ("Preacher", "Probe"),
+        ("Sermon Title", "Pipeline"),
+    ]):
+        table.cell(r, 0).text = k
+        table.cell(r, 1).text = v
+
+    # Song slides — publisher marker is required to start a song group. Lyric
+    # lines are intentionally longer than the title so select_best_title() (which
+    # prefers the shortest candidate) chooses the title, not a lyric line.
+    for lines in (
+        [UPLOAD_PROBE_SONG_TITLE,
+         "This is the first sustained lyric line of the probe anthem here",
+         "Words: Test Author", "PaperlessHymnal.com"],
+        [UPLOAD_PROBE_SONG_TITLE,
+         "This is the second sustained lyric line of the probe anthem here"],
+    ):
+        add_text_box(prs.slides.add_slide(blank_layout), lines)
+
+    out = tmp_path_factory.mktemp("probe_pptx") / "E2E Upload 2026.09.09.pptx"
+    prs.save(out)
+    return out
+
+
 @pytest.fixture
 def db_with_songs(tmp_path):
     """Create a minimal test DB with one service, two songs, and copy events."""

--- a/tests/test_uat_acceptance.py
+++ b/tests/test_uat_acceptance.py
@@ -504,3 +504,43 @@ class TestUploadWorkflowE2E:
             or "imported" in result_text.lower()
             or "no songs" in result_text.lower()
         ), f"Expected completion message, got: {result_text}"
+
+    def test_upload_then_song_appears_in_songs_library(
+        self, browser_page: Any, upload_probe_pptx
+    ) -> None:
+        """Full pipeline (#412): upload a PPTX → wait for the background import to
+        complete → confirm its (uniquely-titled) song appears in /songs. Proves the
+        upload→thread-pool→SQLite→render path end-to-end, which TestClient can't."""
+        from tests.conftest import UPLOAD_PROBE_SONG_TITLE
+
+        browser_page.goto(f"{BASE_URL}/upload")
+        browser_page.wait_for_load_state("networkidle")
+
+        # Upload the probe deck from a real local file path.
+        browser_page.set_input_files('input[type="file"]', str(upload_probe_pptx))
+        browser_page.click('button[type="submit"]')
+
+        # Wait for the JS poller to report a terminal job state (import runs async).
+        browser_page.wait_for_function(
+            """() => {
+                const el = document.getElementById('upload-result');
+                if (!el) return false;
+                const t = el.textContent.toLowerCase();
+                return t.includes('imported') || t.includes('complete')
+                    || t.includes('no songs') || t.includes('failed');
+            }""",
+            timeout=40000,
+        )
+        result = (browser_page.text_content("#upload-result") or "").lower()
+        assert "failed" not in result, f"Upload reported failure: {result!r}"
+        # "imported" only appears in the success message; "no songs found" does not,
+        # so this requires the import to have actually stored at least one song.
+        assert "imported" in result, f"Upload did not import any songs: {result!r}"
+
+        # The uniquely-titled song must now be in the library (it was not seeded).
+        browser_page.goto(f"{BASE_URL}/songs?q={UPLOAD_PROBE_SONG_TITLE}")
+        browser_page.wait_for_load_state("networkidle")
+        assert browser_page.locator(f"text={UPLOAD_PROBE_SONG_TITLE}").count() > 0, (
+            f"Uploaded song {UPLOAD_PROBE_SONG_TITLE!r} did not appear in /songs — "
+            "the upload→import→display pipeline is broken."
+        )


### PR DESCRIPTION
## Summary
- Adds a Playwright test that uploads a uniquely-titled probe PPTX, waits for the background import to report "imported", then confirms the song appears in `/songs`
- Exercises the full upload→thread-pool→SQLite→render path (TestClient can't)
- New `upload_probe_pptx` fixture with a short unique title (not in the seed; wins `select_best_title`'s shortest-candidate rule)

Closes #412

## Test plan
- [x] New pipeline test passes against a local server (verified)
- [x] Existing upload E2E classes still pass (8 e2e)
- [x] Full suite (minus e2e): 1142 passed, 2 xfailed
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)