### PR TITLE
fix: disable inherited healthcheck on watcher service (#402 follow-up)

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -45,6 +45,11 @@ services:
     image: ghcr.io/mshirel/song-history:latest
     restart: unless-stopped
     init: true
+    # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
+    # runs an import loop and serves no HTTP, so disable the inherited check to
+    # avoid a permanently "unhealthy" container and false monitoring alerts.
+    healthcheck:
+      disable: true
     entrypoint: /bin/sh
     command: >
       -c "while true; do /app/scripts/import-new.sh; sleep 300; done"

--- a/tests/test_pi_compose.py
+++ b/tests/test_pi_compose.py
@@ -1,0 +1,36 @@
+"""Tests for the Pi deployment compose file (deploy/pi/docker-compose.yml)."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+COMPOSE_PATH = Path("deploy/pi/docker-compose.yml")
+
+
+@pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
+class TestWatcherHealthcheck:
+    """The watcher reuses the app image, which ships a HEALTHCHECK probing
+    http://localhost:8000/health (#402). The watcher runs an import loop and does
+    NOT serve HTTP, so it must disable the inherited healthcheck — otherwise Docker
+    marks the watcher 'unhealthy' and triggers false monitoring alerts."""
+
+    def _services(self) -> dict:
+        return yaml.safe_load(COMPOSE_PATH.read_text())["services"]
+
+    def test_watcher_disables_inherited_healthcheck(self) -> None:
+        watcher = self._services()["watcher"]
+        hc = watcher.get("healthcheck")
+        assert hc is not None and hc.get("disable") is True, (
+            "watcher must set 'healthcheck: {disable: true}' — it reuses the app "
+            "image's HEALTHCHECK (probing :8000) but serves no HTTP, so it would "
+            "otherwise be marked unhealthy (#402)."
+        )
+
+    def test_song_history_keeps_its_healthcheck(self) -> None:
+        """The web service must NOT disable its healthcheck (regression guard)."""
+        svc = self._services()["song-history"]
+        hc = svc.get("healthcheck") or {}
+        assert hc.get("disable") is not True, (
+            "song-history must keep a working healthcheck"
+        )


### PR DESCRIPTION
## Summary
- #402 baked a HEALTHCHECK (probes `:8000`) into the image; the `watcher` service reuses that image for the import loop and serves no HTTP, so it was marked **unhealthy** after deploy
- Disable the inherited healthcheck on the watcher in the Pi compose; add a `test_pi_compose` guard
- Already applied surgically to the live Pi (watcher no longer unhealthy); this fixes the repo for future deploys

Follow-up to #402.

## Test plan
- [x] Guard test fails without the disable, passes after
- [x] Verified on the Pi: watcher recreated, no longer unhealthy; song-history still healthy
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)