### PR TITLE
fix: remove duplicate copyright marker in _is_invalid_line (#416)

### DIFF
--- a/src/worship_catalog/normalize.py
+++ b/src/worship_catalog/normalize.py
@@ -229,7 +229,6 @@ def _is_invalid_line(line: str) -> bool:
     if any(marker in lower for marker in [
         "copyright",
         "all rights reserved",
-        "all rights reserved",
         "used by permission",
         "admin. by",
         "c/o",

--- a/tests/test_title_normalize.py
+++ b/tests/test_title_normalize.py
@@ -368,3 +368,22 @@ class TestSermonOutlineNotStripped:
         """'2. Grace' — even short entries with period should not strip."""
         result = strip_title_prefix("2. Grace")
         assert result.startswith("2.")
+
+
+@pytest.mark.unit
+class TestInvalidLineMarkers:
+    """_is_invalid_line marker lists must not contain duplicates (#416)."""
+
+    def test_copyright_marker_list_has_no_duplicates(self):
+        import inspect
+        import re
+
+        src = inspect.getsource(_is_invalid_line)
+        # Only standalone quoted list items (one per line), e.g. `    "copyright",`.
+        # Avoids matching the docstring or inline regex/code.
+        markers = re.findall(r'^\s*"([^"]+)",?\s*$', src, re.MULTILINE)
+        dupes = sorted({m for m in markers if markers.count(m) > 1})
+        assert not dupes, f"Duplicate markers in _is_invalid_line: {dupes}"
+
+    def test_all_rights_reserved_still_filtered(self):
+        assert _is_invalid_line("All Rights Reserved") is True


### PR DESCRIPTION
## Summary
- Removes the duplicated `"all rights reserved"` entry in `_is_invalid_line`
- Adds a guard test asserting the marker lists have no duplicates

Closes #416

## Test plan
- [x] Guard test fails on the dup, passes after; "all rights reserved" still filtered
- [x] normalize + credits tests green (125)
- [x] ruff + mypy clean
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)