### PR TITLE
fix: upload status is a polite live region, not empty role=alert (#414)

### DIFF
--- a/src/worship_catalog/web/templates/upload.html
+++ b/src/worship_catalog/web/templates/upload.html
@@ -17,7 +17,7 @@
     </div>
     <button type="submit">Upload</button>
   </form>
-  <div id="upload-result" style="margin-top:1rem;" role="alert" aria-live="assertive"></div>
+  <div id="upload-result" style="margin-top:1rem;" aria-live="polite" aria-atomic="true"></div>
 </div>
 
 <script src="/static/upload.js"></script>

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -176,7 +176,41 @@ class TestAriaLiveRegions:
 
     def test_upload_result_has_aria_live(self, client: TestClient) -> None:
         resp = client.get("/upload")
-        assert 'aria-live="assertive"' in resp.text or 'role="alert"' in resp.text
+        # Any live region satisfies #306; #414 makes it polite rather than assertive.
+        assert 'aria-live=' in resp.text
+
+
+class TestUploadResultLiveRegion:
+    """Upload result region must be a polite, atomic live region — not an empty
+    role=alert/assertive element that announces on page load (#414)."""
+
+    @pytest.fixture
+    def client(self, db_with_songs, tmp_path, monkeypatch):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        return TestClient(app_module.app)
+
+    def test_upload_result_is_polite_not_assertive(self, client: TestClient) -> None:
+        resp = client.get("/upload")
+        assert 'aria-live="assertive"' not in resp.text, (
+            "Upload status is informational — use polite, not assertive (#414)"
+        )
+        assert 'role="alert"' not in resp.text, (
+            "Empty role=alert announces on page load; use a polite live region"
+        )
+
+    def test_upload_result_region_is_polite_atomic(self, client: TestClient) -> None:
+        resp = client.get("/upload")
+        m = re.search(r'id="upload-result"[^>]*>', resp.text)
+        assert m, "upload-result region missing"
+        tag = m.group(0)
+        assert 'aria-live="polite"' in tag and 'aria-atomic="true"' in tag
 
 
 class TestSongsConciseLiveRegion:


### PR DESCRIPTION
## Summary
- Changes the upload result div from `role="alert" aria-live="assertive"` (announces on load, interrupts) to `aria-live="polite" aria-atomic="true"`
- Updates the #306 generic test; adds focused assertions

Closes #414

## Test plan
- [x] New tests fail before, pass after; a11y suite green (27)
- [x] Full suite (minus e2e): 1153 passed, 2 xfailed
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)