### PR TITLE
feat: expose request-duration histogram on /metrics (#395)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -35,7 +35,7 @@ from fastapi import (
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Counter, generate_latest
+from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Counter, Histogram, generate_latest
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette_csrf import CSRFMiddleware  # type: ignore[attr-defined]
@@ -184,16 +184,35 @@ except ValueError:
         "http_requests_total"
     ]
 
+try:
+    # Request-latency histogram so Grafana/Prometheus can compute p50/p95/p99
+    # per route (#395). Default buckets suit sub-second web responses.
+    _HTTP_REQUEST_DURATION_SECONDS: Histogram = Histogram(
+        "http_request_duration_seconds",
+        "HTTP request duration in seconds by method and path",
+        ["method", "path"],
+    )
+except ValueError:
+    _HTTP_REQUEST_DURATION_SECONDS = REGISTRY._names_to_collectors[  # type: ignore[assignment]
+        "http_request_duration_seconds"
+    ]
+
 
 class _PrometheusMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        start = time.perf_counter()
         response = await call_next(request)
         if request.url.path != "/metrics":
+            elapsed = time.perf_counter() - start
             _HTTP_REQUESTS_TOTAL.labels(
                 method=request.method,
                 path=request.url.path,
                 status_code=str(response.status_code),
             ).inc()
+            _HTTP_REQUEST_DURATION_SECONDS.labels(
+                method=request.method,
+                path=request.url.path,
+            ).observe(elapsed)
         return response
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3706,6 +3706,23 @@ class TestPrometheusMetrics:
         response = client.get("/metrics")
         assert "http_requests_total" in response.text
 
+    def test_metrics_contains_request_duration_histogram(self, client):
+        """/metrics must expose a request-duration histogram for latency SLOs (#395)."""
+        client.get("/songs")  # generate at least one observation
+        response = client.get("/metrics")
+        assert "http_request_duration_seconds" in response.text, (
+            "No request-duration histogram exposed — cannot compute latency percentiles"
+        )
+        # A Prometheus Histogram exposes _bucket, _count and _sum series.
+        assert "http_request_duration_seconds_bucket" in response.text
+        assert "http_request_duration_seconds_count" in response.text
+
+    def test_request_duration_histogram_labeled_by_method(self, client):
+        """The duration histogram must be labelled so per-route latency is queryable."""
+        client.get("/songs")
+        response = client.get("/metrics")
+        assert 'method="GET"' in response.text
+
     def test_metrics_exempt_from_csrf(self, raw_client):
         """GET /metrics must work without a CSRF token."""
         response = raw_client.get("/metrics")


### PR DESCRIPTION
## Summary
- Adds `http_request_duration_seconds` Prometheus Histogram (labelled by method+path), observed in the metrics middleware
- Enables per-route latency percentiles (p50/p95/p99) in Grafana
- Reload-safe registration mirrors the existing counter

Closes #395

## Test plan
- [x] New tests assert the histogram (`_bucket`/`_count`) appears on /metrics; pass after
- [x] Full suite (minus e2e): 1153 passed
- [x] ruff + mypy clean
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)