### PR TITLE
refactor: move normalize_service_date to normalize.py (#399)

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1293,7 +1293,7 @@ class Database:
         to avoid violating ``UNIQUE(service_date, service_name)``.  When
         *dry_run* is True nothing is written.
         """
-        from worship_catalog.pptx_reader import normalize_service_date
+        from worship_catalog.normalize import normalize_service_date
 
         cursor = self._conn.cursor()
         cursor.execute("SELECT id, service_date, service_name FROM services")

--- a/src/worship_catalog/normalize.py
+++ b/src/worship_catalog/normalize.py
@@ -81,6 +81,33 @@ def _normalize_whitespace(text: str) -> str:
     return ' '.join(text.split()).strip()
 
 
+# Year-month-day with ., - or / separators and single-or-double-digit month/day.
+_DATE_PARTS_RE = re.compile(r"^(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})$")
+
+
+def normalize_service_date(raw: str | None) -> str | None:
+    """Canonicalize a service date string to ISO ``YYYY-MM-DD``.
+
+    Accepts any mix of ``.``, ``-`` and ``/`` separators and single-digit
+    month/day (e.g. ``2026.5.10`` → ``2026-05-10``). Returns None for empty
+    input, and the stripped original for anything that isn't a recognizable
+    year-month-day triple (so we never silently drop an unexpected value).
+
+    Lives here (not in pptx_reader) so the data layer can normalize stored dates
+    without importing the PPTX-parsing layer (#399).
+    """
+    if raw is None:
+        return None
+    stripped = raw.strip()
+    if not stripped:
+        return None
+    match = _DATE_PARTS_RE.match(stripped)
+    if not match:
+        return stripped
+    year, month, day = match.groups()
+    return f"{year}-{int(month):02d}-{int(day):02d}"
+
+
 def select_best_title(candidates: list[str]) -> str | None:
     """
     Select the best title candidate from a list of lines.

--- a/src/worship_catalog/pptx_reader.py
+++ b/src/worship_catalog/pptx_reader.py
@@ -9,6 +9,11 @@ from typing import Any
 
 from pptx import Presentation
 
+# normalize_service_date moved to normalize.py so the data layer can use it
+# without importing this PPTX-parsing module (#399); re-imported here because
+# this module still uses it and tests reference pptx_reader.normalize_service_date.
+from worship_catalog.normalize import normalize_service_date
+
 logger = logging.getLogger(__name__)
 
 _HASH_CHUNK_SIZE: int = 4096
@@ -155,30 +160,6 @@ def parse_all_slides(prs: Presentation) -> list[Slide]:  # type: ignore[valid-ty
         slides.append(parse_slide(slide, i))
     return slides
 
-
-# Date components separated by any mix of '.', '-', '/'. Used to canonicalize
-# service dates to ISO YYYY-MM-DD (#387).
-_DATE_PARTS_RE = re.compile(r"^(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})$")
-
-
-def normalize_service_date(raw: str | None) -> str | None:
-    """Canonicalize a service date string to ISO ``YYYY-MM-DD``.
-
-    Accepts any mix of ``.``, ``-`` and ``/`` separators and single-digit
-    month/day (e.g. ``2026.5.10`` → ``2026-05-10``). Returns None for empty
-    input, and the stripped original for anything that isn't a recognizable
-    year-month-day triple (so we never silently drop an unexpected value).
-    """
-    if raw is None:
-        return None
-    stripped = raw.strip()
-    if not stripped:
-        return None
-    match = _DATE_PARTS_RE.match(stripped)
-    if not match:
-        return stripped
-    year, month, day = match.groups()
-    return f"{year}-{int(month):02d}-{int(day):02d}"
 
 
 # Metadata field keys (lowercased) → ServiceMetadata attribute name.

--- a/tests/test_title_normalize.py
+++ b/tests/test_title_normalize.py
@@ -387,3 +387,27 @@ class TestInvalidLineMarkers:
 
     def test_all_rights_reserved_still_filtered(self):
         assert _is_invalid_line("All Rights Reserved") is True
+
+
+@pytest.mark.unit
+class TestNormalizeServiceDateLayering:
+    """normalize_service_date belongs in normalize.py, not pptx_reader, so the
+    data layer (db.py) doesn't import the parsing layer (#399)."""
+
+    def test_importable_from_normalize(self):
+        from worship_catalog.normalize import normalize_service_date
+
+        assert normalize_service_date("2026.1.11") == "2026-01-11"
+        assert normalize_service_date(None) is None
+        assert normalize_service_date("Easter") == "Easter"
+
+    def test_db_does_not_import_pptx_reader_for_dates(self):
+        import inspect
+
+        from worship_catalog.db import Database
+
+        src = inspect.getsource(Database.normalize_service_dates)
+        assert "pptx_reader" not in src, (
+            "Database.normalize_service_dates must import normalize_service_date "
+            "from worship_catalog.normalize, not pptx_reader (#399)."
+        )


### PR DESCRIPTION
## Summary
- Moves `normalize_service_date` + `_DATE_PARTS_RE` from `pptx_reader.py` to `normalize.py` (a pure string utility)
- `db.py` imports it from `normalize` (no longer imports the PPTX-parsing layer); `pptx_reader` re-imports it (still used internally + by existing tests)
- Adds a layering guard test

Closes #399

## Test plan
- [x] Layering tests fail before, pass after; pptx_reader + db integration suites green (212)
- [x] Full suite (minus e2e): 1155 passed, 2 xfailed
- [x] ruff + mypy clean
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)