### PR TITLE
fix: consistent read snapshot for paginated queries (#415)

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -240,6 +240,28 @@ class Database:
         if not self._in_transaction:
             self._conn.commit()
 
+    @contextmanager
+    def _read_snapshot(self) -> Generator[None, None, None]:
+        """Run a group of read queries inside one transaction so they share a
+        single, consistent SQLite snapshot (#415).
+
+        Pagination issues a COUNT then a SELECT; without a shared snapshot a
+        concurrent writer committing between them yields a total that disagrees
+        with the returned rows. A DEFERRED read transaction freezes the snapshot
+        at the first read; WAL still allows concurrent writers. No-ops (and does
+        not roll back) if a transaction is already active, to avoid disturbing an
+        enclosing transaction().
+        """
+        if self._conn.in_transaction:
+            yield
+            return
+        self._conn.execute("BEGIN")
+        try:
+            yield
+        finally:
+            # Read-only: rollback simply releases the snapshot/read lock.
+            self._conn.rollback()
+
     def init_schema(self) -> None:
         """Create database schema and apply any pending migrations.
 
@@ -1111,27 +1133,31 @@ class Database:
             LEFT JOIN service_songs ss ON ss.song_id = s.id
         """
         offset = (page - 1) * per_page
-        if search:
-            like = f"%{_escape_like(search)}%"
-            where = """
-                WHERE (LOWER(s.display_title) LIKE LOWER(?) ESCAPE '\\'
-                   OR LOWER(COALESCE(se.words_by, '')) LIKE LOWER(?) ESCAPE '\\'
-                   OR LOWER(COALESCE(se.music_by, '')) LIKE LOWER(?) ESCAPE '\\')
-            """
-            cursor.execute(count_base + where, (like, like, like))
-            total: int = cursor.fetchone()[0]
-            cursor.execute(
-                base + where + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
-                (like, like, like, per_page, offset),
-            )
-        else:
-            cursor.execute(count_base)
-            total = cursor.fetchone()[0]
-            cursor.execute(
-                base + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
-                (per_page, offset),
-            )
-        return [dict(row) for row in cursor.fetchall()], total
+        # COUNT and SELECT share one snapshot so the total can't disagree with
+        # the rows when a concurrent import commits between them (#415).
+        with self._read_snapshot():
+            if search:
+                like = f"%{_escape_like(search)}%"
+                where = """
+                    WHERE (LOWER(s.display_title) LIKE LOWER(?) ESCAPE '\\'
+                       OR LOWER(COALESCE(se.words_by, '')) LIKE LOWER(?) ESCAPE '\\'
+                       OR LOWER(COALESCE(se.music_by, '')) LIKE LOWER(?) ESCAPE '\\')
+                """
+                cursor.execute(count_base + where, (like, like, like))
+                total: int = cursor.fetchone()[0]
+                cursor.execute(
+                    base + where + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
+                    (like, like, like, per_page, offset),
+                )
+            else:
+                cursor.execute(count_base)
+                total = cursor.fetchone()[0]
+                cursor.execute(
+                    base + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
+                    (per_page, offset),
+                )
+            rows = [dict(row) for row in cursor.fetchall()]
+        return rows, total
 
     def query_all_services_paginated(
         self,
@@ -1173,24 +1199,27 @@ class Database:
         order = f"{sort} {_safe_sort_dir(sort_dir)}, sv.service_name"
         offset = (page - 1) * per_page
         cursor = self._conn.cursor()
-        cursor.execute(
-            f"SELECT COUNT(DISTINCT sv.id) FROM services sv {where_sql}",
-            params,
-        )
-        total: int = cursor.fetchone()[0]
-        cursor.execute(
-            f"""
-            SELECT sv.*, COUNT(DISTINCT ss.song_id) AS song_count
-            FROM services sv
-            LEFT JOIN service_songs ss ON ss.service_id = sv.id
-            {where_sql}
-            GROUP BY sv.id
-            ORDER BY {order}
-            LIMIT ? OFFSET ?
-            """,
-            params + [per_page, offset],
-        )
-        return [dict(row) for row in cursor.fetchall()], total
+        # COUNT and SELECT share one snapshot for consistent pagination (#415).
+        with self._read_snapshot():
+            cursor.execute(
+                f"SELECT COUNT(DISTINCT sv.id) FROM services sv {where_sql}",
+                params,
+            )
+            total: int = cursor.fetchone()[0]
+            cursor.execute(
+                f"""
+                SELECT sv.*, COUNT(DISTINCT ss.song_id) AS song_count
+                FROM services sv
+                LEFT JOIN service_songs ss ON ss.service_id = sv.id
+                {where_sql}
+                GROUP BY sv.id
+                ORDER BY {order}
+                LIMIT ? OFFSET ?
+                """,
+                params + [per_page, offset],
+            )
+            rows = [dict(row) for row in cursor.fetchall()]
+        return rows, total
 
     # --- Cleanup queries (#266) ---
 

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2973,3 +2973,80 @@ class TestConcurrentInsertOrGet:
             assert cur.fetchone()[0] == 1
         finally:
             check.close()
+
+
+@pytest.mark.integration
+class TestPaginationSnapshotConsistency:
+    """COUNT and SELECT in paginated queries must share one snapshot (#415)."""
+
+    def test_song_pagination_total_matches_rows_under_concurrent_insert(self, tmp_path):
+        db_path = tmp_path / "snap_songs.db"
+        db = Database(db_path)
+        db.connect()
+        db.init_schema()
+        for i in range(10):
+            db.insert_or_get_song(f"song{i:02d}", f"Song {i:02d}")
+
+        # A separate connection inserts a new song right after the COUNT query
+        # runs inside the method, simulating a concurrent importer between the
+        # COUNT and the SELECT.
+        writer = Database(db_path)
+        writer.connect()
+        writer.conn.execute("PRAGMA busy_timeout=5000")
+        state = {"fired": False}
+
+        class _HookCursor:
+            def __init__(self, inner):
+                self._inner = inner
+
+            def execute(self, sql, *args):
+                result = self._inner.execute(sql, *args)
+                if "COUNT(DISTINCT s.id)" in sql and not state["fired"]:
+                    state["fired"] = True
+                    writer.insert_or_get_song("song99", "Song 99")
+                return result
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        class _ConnProxy:
+            """Wrap the connection so cursors are hooked; sqlite3.Connection
+            attributes are read-only, so .cursor can't be patched directly."""
+
+            def __init__(self, inner):
+                self._inner = inner
+
+            def cursor(self):
+                return _HookCursor(self._inner.cursor())
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        real_conn = db.conn
+        db.conn = _ConnProxy(real_conn)
+        try:
+            rows, total = db.query_songs_paginated(page=1, per_page=50)
+        finally:
+            db.conn = real_conn
+            writer.close()
+
+        assert state["fired"], "Hook did not fire — test did not exercise the race"
+        assert len(rows) == total, (
+            f"Pagination inconsistent: {len(rows)} rows but total={total}"
+        )
+        # The concurrent insert must be invisible to this snapshot.
+        assert total == 10, f"total should reflect the pre-insert snapshot, got {total}"
+        db.close()
+
+    def test_song_pagination_page_boundaries(self, tmp_path):
+        """Refactor must not break basic pagination math."""
+        db_path = tmp_path / "snap_pages.db"
+        db = Database(db_path)
+        db.connect()
+        db.init_schema()
+        for i in range(100):
+            db.insert_or_get_song(f"song{i:03d}", f"Song {i:03d}")
+        rows, total = db.query_songs_paginated(page=2, per_page=10)
+        assert total == 100
+        assert len(rows) == 10
+        db.close()


### PR DESCRIPTION
## Summary
- Adds `Database._read_snapshot()` (DEFERRED read transaction) and wraps the COUNT+SELECT in `query_songs_paginated` / `query_all_services_paginated` so they share one snapshot
- Prevents the total disagreeing with the returned rows when a concurrent import commits mid-query; WAL still allows concurrent writers
- Deterministic test injects an insert between COUNT and SELECT and asserts `len(rows) == total`

Closes #415

## Test plan
- [x] Concurrency test fails without the snapshot, passes with it; page-boundary test green
- [x] Full suite (minus e2e): 1157 passed, 2 xfailed
- [x] ruff + mypy clean
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)