### PR TITLE
feat: inline CCLI report preview before download (#411)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -701,6 +701,33 @@ async def reports_stats_xlsx(
     )
 
 
+@app.post("/reports/ccli/preview", response_class=HTMLResponse)
+async def reports_ccli_preview(
+    request: Request,
+    start_date: str = Form(...),
+    end_date: str = Form(...),
+    db: Database = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
+    """Inline summary of the CCLI report before download (#411).
+
+    Lets a church admin confirm the date range covers data before downloading a
+    CSV (which previously could be silently empty).
+    """
+    _validate_date_range(start_date, end_date)
+    events = db.query_copy_events(start_date, end_date)
+    unique_songs = len({e["song_id"] for e in events})
+    return templates.TemplateResponse(
+        request,
+        "ccli_preview.html",
+        {
+            "start_date": start_date,
+            "end_date": end_date,
+            "event_count": len(events),
+            "unique_songs": unique_songs,
+        },
+    )
+
+
 @app.post("/reports/ccli")
 async def reports_ccli_csv(
     start_date: str = Form(...),

--- a/src/worship_catalog/web/templates/ccli_preview.html
+++ b/src/worship_catalog/web/templates/ccli_preview.html
@@ -1,0 +1,19 @@
+{# Inline CCLI report preview (#411): summarise what the CSV download will
+   contain so the admin can confirm the date range before exporting. #}
+<div class="card" style="margin-top:1rem;background:#f1f3f5;" aria-live="polite" aria-atomic="true">
+  {% if event_count == 0 %}
+  <p style="color:#856404;margin:0;">
+    <strong>0</strong> reproduction events for {{ start_date }} → {{ end_date }} —
+    no songs were reproduced in this range. Adjust the dates before downloading.
+  </p>
+  {% else %}
+  <p style="margin:0 0 0.25rem;">
+    <strong>{{ event_count }}</strong> reproduction event{{ "s" if event_count != 1 else "" }}
+    across <strong>{{ unique_songs }}</strong> song{{ "s" if unique_songs != 1 else "" }}
+    for {{ start_date }} → {{ end_date }}.
+  </p>
+  <p style="margin:0;font-size:0.85rem;color:#495057;">
+    Use the <strong>Download CSV</strong> button above to export the full report.
+  </p>
+  {% endif %}
+</div>

--- a/src/worship_catalog/web/templates/reports.html
+++ b/src/worship_catalog/web/templates/reports.html
@@ -68,8 +68,21 @@
           <input type="date" id="ccli-to" name="end_date" required>
         </div>
       </div>
-      <button type="submit">Download CSV</button>
+      <div style="display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;">
+        <button type="submit">Download CSV</button>
+        {# Preview the count inline before downloading so an empty range is
+           obvious without opening the CSV (#411). hx-headers (CSRF) is set
+           globally by reports.js. #}
+        <button type="button" class="btn"
+                style="background:#495057;"
+                hx-post="/reports/ccli/preview"
+                hx-include="#ccli-form"
+                hx-target="#ccli-result"
+                hx-indicator="#ccli-spinner">Preview</button>
+        <span id="ccli-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
+      </div>
     </form>
+    <div id="ccli-result" style="margin-top:0.5rem;"></div>
   </div>
 </section>
 <script src="/static/reports.js"></script>

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -690,6 +690,51 @@ class TestCcliCsvContract:
         )
 
 
+class TestCcliPreview:
+    """Inline CCLI preview before download — count/summary (#411)."""
+
+    def test_preview_shows_event_count_for_nonempty_range(self, client):
+        resp = client.post(
+            "/reports/ccli/preview",
+            data={"start_date": "2020-01-01", "end_date": "2030-12-31"},
+        )
+        assert resp.status_code == 200
+        text = resp.text.lower()
+        assert "event" in text or "reproduction" in text
+        assert "song" in text
+        assert any(str(n) in resp.text for n in (1, 2))
+
+    def test_preview_empty_range_shows_zero(self, client):
+        resp = client.post(
+            "/reports/ccli/preview",
+            data={"start_date": "1990-01-01", "end_date": "1990-12-31"},
+        )
+        assert resp.status_code == 200
+        assert "0" in resp.text
+        assert "no " in resp.text.lower()
+
+    def test_preview_validates_dates(self, client):
+        resp = client.post(
+            "/reports/ccli/preview",
+            data={"start_date": "not-a-date", "end_date": "2026-12-31"},
+        )
+        assert resp.status_code == 422
+
+    def test_preview_is_html_partial_not_full_page(self, client):
+        resp = client.post(
+            "/reports/ccli/preview",
+            data={"start_date": "2020-01-01", "end_date": "2030-12-31"},
+        )
+        assert "<!doctype" not in resp.text.lower()
+        assert "<html" not in resp.text.lower()
+
+    def test_reports_page_has_preview_button_and_download(self, client):
+        resp = client.get("/reports")
+        assert resp.status_code == 200
+        assert "/reports/ccli/preview" in resp.text
+        assert 'action="/reports/ccli"' in resp.text
+
+
 class TestCcliReportWebRoute:
     """Web UI must provide CCLI report generation (#201)."""
 


### PR DESCRIPTION
## Summary
- Adds `POST /reports/ccli/preview` + a **Preview** button on the CCLI tab showing the reproduction-event count and unique-song count inline, with an explicit "no songs" message for empty ranges
- Lets admins confirm the date range covers data before downloading; Download CSV unchanged

Closes #411

## Test plan
- [x] 5 new route/page tests (count, empty range, validation, partial-not-full-page, page wiring)
- [x] Browser-verified HTMX+CSRF: "2 reproduction events across 1 song"; empty → "no songs… adjust the dates"; no JS errors
- [x] Full suite (minus e2e): 1162 passed
- [x] ruff + mypy clean
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)