### PR TITLE
deploy(pi): host hardening for public exposure (#446, #447, #452)

### DIFF
--- a/deploy/pi/firewall/docker-user-firewall.service
+++ b/deploy/pi/firewall/docker-user-firewall.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Restrict Docker-published ports (8000/2000) to Prometheus (#447)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/docker-user-firewall.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/pi/firewall/docker-user-firewall.sh
+++ b/deploy/pi/firewall/docker-user-firewall.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Restrict Docker-published ports 8000/2000 on eth0 to the Prometheus scraper (#447).
+# Docker bypasses ufw's INPUT chain, so DOCKER-USER is the supported firewall hook.
+set -e
+IF=eth0
+SRC=10.20.100.245
+for port in 8000 2000; do
+  iptables -D DOCKER-USER -i "$IF" -p tcp --dport "$port" -s "$SRC" -j RETURN 2>/dev/null || true
+  iptables -D DOCKER-USER -i "$IF" -p tcp --dport "$port" -j DROP 2>/dev/null || true
+  iptables -I DOCKER-USER -i "$IF" -p tcp --dport "$port" -j DROP
+  iptables -I DOCKER-USER -i "$IF" -p tcp --dport "$port" -s "$SRC" -j RETURN
+done

--- a/deploy/pi/firewall/ufw-setup.sh
+++ b/deploy/pi/firewall/ufw-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# deploy/pi/firewall/ufw-setup.sh — host firewall baseline for pi-songs (#447).
+#
+# pi-songs serves songs.highland-coc.com publicly via an OUTBOUND cloudflared
+# tunnel, so the host needs NO inbound ports for the public site. This locks the
+# host down to: SSH from the homelab management supernet, Traefik 80/443 (LAN
+# alias + Uptime-Kuma monitor), and the Prometheus scraper for node_exporter.
+#
+# NOTE: ufw only filters HOST-process ports (e.g. node_exporter :9100). Docker
+# publishes :8000/:2000 via iptables in a way that BYPASSES ufw's INPUT chain —
+# those are restricted separately in docker-user-firewall.sh (DOCKER-USER hook).
+#
+# Run as root. Idempotent. Re-running re-asserts the ruleset.
+set -e
+
+PROM=10.20.100.245   # lxc-obsv-prometheus — the only host allowed to scrape
+MGMT=10.20.0.0/16    # homelab management supernet (covers the admin workstation)
+
+ufw --force reset
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow from "$MGMT" to any port 22 proto tcp comment 'SSH homelab mgmt'
+ufw allow 80/tcp  comment 'Traefik HTTP (LAN alias + redirect)'
+ufw allow 443/tcp comment 'Traefik HTTPS (LAN alias + Kuma monitor)'
+ufw allow from "$PROM" to any port 9100 proto tcp comment 'Prometheus node_exporter'
+ufw --force enable
+ufw status verbose

--- a/deploy/pi/init.sh
+++ b/deploy/pi/init.sh
@@ -18,6 +18,9 @@ set -eu
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ACME_DIR="${ACME_DIR:-${SCRIPT_DIR}/traefik}"
 ACME_FILE="${ACME_DIR}/acme.json"
+# .env holds all deployment secrets (Cloudflare/tunnel tokens, CSRF, upload
+# password) — it must be owner-only (600), never world-readable (#446).
+ENV_FILE="${ENV_FILE:-${SCRIPT_DIR}/.env}"
 
 # ---------------------------------------------------------------------------
 # Check: acme.json permissions
@@ -28,6 +31,20 @@ if [ -f "$ACME_FILE" ]; then
     if [ "$PERMS" != "600" ]; then
         echo "ERROR: acme.json has permissions $PERMS — must be 600" >&2
         echo "Fix with: chmod 600 $ACME_FILE" >&2
+        exit 1
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Check: .env permissions
+# .env contains every deployment secret; it must be 600 so other local users
+# (and non-root container breakouts) can't read it (#446).
+# ---------------------------------------------------------------------------
+if [ -f "$ENV_FILE" ]; then
+    ENV_PERMS="$(stat -c "%a" "$ENV_FILE")"
+    if [ "$ENV_PERMS" != "600" ]; then
+        echo "ERROR: .env has permissions $ENV_PERMS — must be 600 (it holds secrets)" >&2
+        echo "Fix with: chmod 600 $ENV_FILE" >&2
         exit 1
     fi
 fi

--- a/deploy/pi/ssh/00-hardening.conf
+++ b/deploy/pi/ssh/00-hardening.conf
@@ -1,0 +1,11 @@
+# deploy/pi/ssh/00-hardening.conf — install to /etc/ssh/sshd_config.d/ (#452).
+#
+# Key-only SSH on the public-service host. The 00- prefix is REQUIRED: OpenSSH
+# honours the FIRST occurrence of a keyword, and Ubuntu ships
+# 50-cloud-init.conf with `PasswordAuthentication yes` — this file must sort
+# before it to win. Install with:
+#   sudo cp deploy/pi/ssh/00-hardening.conf /etc/ssh/sshd_config.d/
+#   sudo sshd -t && sudo systemctl reload ssh
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitRootLogin prohibit-password

--- a/docs/code-review-history.md
+++ b/docs/code-review-history.md
@@ -7,6 +7,47 @@ Each review produces GitHub issues for every significant finding.
 
 ---
 
+## Review 11 — 2026-05-26
+
+**Branch:** `agent/claude/review-11-history`
+**Reviewer:** Claude Code (full-code-review skill)
+**Focus:** Heavy security emphasis — code **and** the pi-songs host — after `songs.highland-coc.com` was exposed publicly via a cloudflared tunnel.
+**Issues created:** #446–#455
+
+### Findings
+
+| Issue | Persona | Title | Severity |
+|-------|---------|-------|----------|
+| #446 | Security | pi-songs `.env` world-readable (644) — exposes CF API/tunnel tokens, CSRF & upload secrets | HIGH |
+| #447 | Security | App port 8000 (incl. `/metrics`) bound to 0.0.0.0, no host firewall — bypasses Cloudflare/Traefik | HIGH |
+| #448 | Security | `TRUSTED_PROXY` unset → CF-Connecting-IP unused → upload rate limiter buckets all tunnel traffic as one client | MED |
+| #449 | Security | `/metrics` unauthenticated & reachable through the public tunnel — leaks routes/traffic/latency | MED |
+| #450 | Security | Public report endpoints unrate-limited — unauthenticated CPU/memory DoS (esp. `/reports/stats/xlsx`) | MED |
+| #451 | Security | `/jobs` & `/jobs/{id}` public & unauthenticated — leak uploaded filenames + raw error messages | MED |
+| #452 | Security | pi-songs SSH allows password auth, no fail2ban | MED |
+| #453 | DevSecOps | cloudflared & promtail pinned to `:latest` on the public-facing host | MED |
+| #454 | DevOps | pi-deploy runbook still says "LAN-only, no public internet exposure" — now false | MED |
+| #455 | Product | Public exposure publishes leader/preacher names, sermon titles & full history — confirm intended audience (re-triage #2) | MED |
+
+### Grades
+
+| Persona | Grade | Notes |
+|---------|-------|-------|
+| Senior Architect | A- | Code structure clean (Review 10 fixes landed); only smell is the dual public-tunnel vs Traefik path |
+| Senior Developer | A- | No new code-logic bugs; findings are deployment/exposure, not application logic |
+| Senior DevOps | C | Public host has no firewall, app port on 0.0.0.0, unpinned tunnel image, and a runbook that contradicts reality |
+| Senior Security Architect | C | Strong code-level controls (CSP/CSRF/HSTS/param queries), but weak posture for a public service: world-readable secrets, app+metrics reachable off-Cloudflare, defeated rate limiting, public /jobs & /metrics |
+| Senior DevSecOps | B- | CI supply chain solid; the two most-privileged runtime containers are unpinned and secret-at-rest perms are wrong |
+| Senior QA Engineer | A- | Large healthy suite + e2e/contract coverage; gap was no tests asserting deploy security posture (now embedded in issues) |
+| Product Manager | B | Features solid; the live question is the privacy/audience decision for now-public congregant data |
+| UAT Analyst | A- | Strong Playwright coverage incl. the new upload→songs pipeline; no new gaps |
+| Accessibility Specialist | B+ | Songs concise live region + polite upload landed; #431 (services) still open |
+| Database / Data Engineer | A- | WAL, indexes, read-snapshot pagination (#415), retry-safe inserts (#400) landed; #420 still tracked |
+
+**Overall: C+** — the codebase is in good shape, but the production security posture for the newly public deployment has several real, fixable gaps (the focus of this review).
+
+---
+
 ## Review 10 — 2026-05-25
 
 **Branch:** `agent/claude/import-summary-output`

--- a/tests/test_pi_hardening.py
+++ b/tests/test_pi_hardening.py
@@ -1,0 +1,69 @@
+"""Tests for pi-songs host-hardening artifacts (#446, #447, #452).
+
+These assert the repo carries reproducible, correct deployment-hardening config
+for the public-facing host. They guard against drift/regression in the firewall
+and SSH posture that was applied live during Review-11 remediation.
+"""
+
+from pathlib import Path
+
+_PI = Path(__file__).parent.parent / "deploy" / "pi"
+_PROM = "10.20.100.245"  # the only host allowed to scrape pi-songs
+
+
+class TestDockerUserFirewall:
+    """Docker-published :8000/:2000 must be restricted to the Prometheus scraper,
+    since Docker bypasses ufw's INPUT chain (#447)."""
+
+    def _script(self) -> str:
+        return (_PI / "firewall" / "docker-user-firewall.sh").read_text()
+
+    def test_script_and_unit_exist(self) -> None:
+        assert (_PI / "firewall" / "docker-user-firewall.sh").is_file()
+        assert (_PI / "firewall" / "docker-user-firewall.service").is_file()
+
+    def test_restricts_metrics_ports_to_prometheus(self) -> None:
+        s = self._script()
+        assert _PROM in s, "must allow only the Prometheus scraper"
+        for port in ("8000", "2000"):
+            assert port in s, f"must cover Docker-published port {port}"
+        assert "DROP" in s and "RETURN" in s, "must DROP non-Prometheus, RETURN Prometheus"
+        assert "DOCKER-USER" in s, "must use the DOCKER-USER hook (ufw can't filter Docker)"
+
+    def test_unit_runs_after_docker(self) -> None:
+        unit = (_PI / "firewall" / "docker-user-firewall.service").read_text()
+        assert "After=docker.service" in unit and "WantedBy=multi-user.target" in unit
+
+
+class TestUfwBaseline:
+    """ufw baseline must deny-by-default and allow only SSH(mgmt)/80/443/scraper (#447)."""
+
+    def test_ufw_setup_exists_and_denies_by_default(self) -> None:
+        s = (_PI / "firewall" / "ufw-setup.sh").read_text()
+        assert "default deny incoming" in s
+        assert "10.20.0.0/16" in s and 'from "$MGMT" to any port 22' in s  # SSH mgmt
+        assert "443/tcp" in s and "80/tcp" in s                            # Traefik
+        assert _PROM in s and 'from "$PROM" to any port 9100' in s         # scrape only
+
+    def test_ufw_does_not_loopback_bind_app_port(self) -> None:
+        # Binding :8000 to loopback would break the external Prometheus scrape;
+        # the firewall (not a loopback bind) is the chosen control. Guard the intent.
+        compose = (_PI / "docker-compose.yml").read_text()
+        assert '"127.0.0.1:8000' not in compose, (
+            "Do NOT loopback-bind :8000 — it breaks the Prometheus scrape from "
+            f"{_PROM}; restrict via ufw + DOCKER-USER instead"
+        )
+
+
+class TestSshHardening:
+    """Key-only SSH drop-in must sort before cloud-init and disable passwords (#452)."""
+
+    def test_drop_in_disables_password_auth(self) -> None:
+        conf = (_PI / "ssh" / "00-hardening.conf").read_text()
+        assert "PasswordAuthentication no" in conf
+
+    def test_drop_in_sorts_before_cloud_init(self) -> None:
+        # Must be 00- (or otherwise < 50-cloud-init) so OpenSSH first-match wins.
+        assert (_PI / "ssh" / "00-hardening.conf").is_file(), (
+            "drop-in must be named 00-* to beat 50-cloud-init.conf (first-match-wins)"
+        )

--- a/tests/test_pi_init_sh.py
+++ b/tests/test_pi_init_sh.py
@@ -71,3 +71,24 @@ class TestInitShAcmePermissions:
         assert "chmod" in result.stderr, (
             "Error message must include 'chmod' to guide the operator"
         )
+
+
+@pytest.mark.slow
+class TestInitShEnvPermissions:
+    """deploy/pi/init.sh must reject a world/group-readable .env (#446)."""
+
+    def test_init_sh_fails_when_env_not_600(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("CSRF_SECRET=x\n")
+        env_file.chmod(0o644)
+        result = run_init({"ENV_DIR": str(tmp_path), "ENV_FILE": str(env_file),
+                           "ACME_DIR": str(tmp_path)})
+        assert result.returncode != 0, "init.sh must fail when .env is not 600"
+        assert "600" in result.stderr
+
+    def test_init_sh_passes_when_env_600(self, tmp_path: Path) -> None:
+        env_file = tmp_path / ".env"
+        env_file.write_text("CSRF_SECRET=x\n")
+        env_file.chmod(0o600)
+        result = run_init({"ENV_FILE": str(env_file), "ACME_DIR": str(tmp_path)})
+        assert result.returncode == 0, f"init.sh should pass with 600 .env: {result.stderr}"


### PR DESCRIPTION
## Summary
Captures the pi-songs host hardening applied during Review-11 remediation as reproducible, tested repo artifacts. Host changes were applied **live** and verified; this PR version-controls them.

- **#446** — `init.sh` now rejects a non-`600` `.env`; live `.env` chmod'd to 600. (Secret **rotation** still pending — owner/dashboard action; #446 stays open to track it.)
- **#447** — `firewall/ufw-setup.sh` + `firewall/docker-user-firewall.sh` & systemd unit restricting Docker-published `:8000`/`:2000` to the Prometheus scraper. Loopback-bind rejected — it would break the external scrape.
- **#452** — `ssh/00-hardening.conf` key-only SSH drop-in (00- prefix beats `50-cloud-init.conf`). Password auth disabled live; key auth verified.

## Live verification (pi-songs)
- `:8000/metrics`, `:2000`, `:9100` now return `000` (blocked) from a non-Prometheus host; tunnel `/health` → 200, LAN Traefik → 200, localhost → 200.
- Fresh key-only SSH works; `passwordauthentication no`; no failed units.

## Deferred / hand-off
- **fail2ban**: packaged 1.0.2-3 broken on Ubuntu 24.04 / Py3.12 (`asynchat` removed); key-only SSH removes the password brute-force vector. jail.local staged.
- **Secret rotation (#446)**: `.env` was world-readable → rotate the CF API token + tunnel token in the Cloudflare dashboard (owner action). Tracked in #446.

## Test plan
- [x] `test_pi_hardening.py` + `test_pi_init_sh.py` (.env 600) — 14 pass
- [x] Full suite (minus e2e): 1175 passed
- [ ] CI test + security + e2e pass

Closes #447, #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)