### PR TITLE
fix: move off malicious fastapi 0.136.3 (MAL-2026-4750) (#458)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ ocr = [
     "anthropic>=0.40,<1",
 ]
 web = [
-    "fastapi>=0.110,<1",
+    "fastapi>=0.110,<1,!=0.136.3",  # 0.136.3 is malicious (MAL-2026-4750)
     "jinja2>=3.1,<4",
     "uvicorn>=0.27,<1",
     "python-multipart>=0.0.9,<1",
@@ -45,7 +45,7 @@ dev = [
     "mypy>=1.0,<3",
     "types-PyYAML>=6.0,<7",
     "httpx>=0.27,<1",
-    "fastapi>=0.110,<1",
+    "fastapi>=0.110,<1,!=0.136.3",  # 0.136.3 is malicious (MAL-2026-4750)
     "starlette>=0.36,<2",
     "bandit>=1.7,<2",
     "pip-audit>=2.7,<3",

--- a/requirements.lock
+++ b/requirements.lock
@@ -27,7 +27,7 @@ distro==1.9.0
     # via anthropic
 docstring-parser==0.18.0
     # via anthropic
-fastapi==0.136.3
+fastapi==0.136.1
     # via worship-catalog (pyproject.toml)
 h11==0.16.0
     # via

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -5,6 +5,23 @@ from pathlib import Path
 _PROJECT_ROOT = Path(__file__).parent.parent
 
 
+class TestNoMaliciousFastapi:
+    """The lockfile must not pin the malicious fastapi 0.136.3 (MAL-2026-4750, #458)."""
+
+    def test_lockfile_excludes_malicious_fastapi(self):
+        lock = (_PROJECT_ROOT / "requirements.lock").read_text()
+        assert "fastapi==0.136.3" not in lock, (
+            "fastapi 0.136.3 is malicious (MAL-2026-4750) — it adds an undocumented "
+            "'fastar' dependency. The lockfile must pin a different version."
+        )
+
+    def test_pyproject_excludes_malicious_fastapi(self):
+        pp = (_PROJECT_ROOT / "pyproject.toml").read_text()
+        assert "!=0.136.3" in pp, (
+            "pyproject must exclude fastapi 0.136.3 so pip-compile can't re-pin it"
+        )
+
+
 class TestDependencyReproducibility:
     """A lockfile must exist and be used in the Dockerfile (#174)."""
 


### PR DESCRIPTION
## Summary
- `fastapi 0.136.3` is flagged malicious (`MAL-2026-4750` — adds undocumented `fastar>=0.9.0`); pip-audit now fails `security` on **every** PR
- Exclude it (`!=0.136.3`) in pyproject + recompile → `fastapi==0.136.1` (1-line lockfile change)
- **Prod was not running the malicious extra** (`fastar` is optional, absent from lockfile + image); this moves off the flagged release and unblocks CI
- Regression guard test added

Closes #458

## Test plan
- [x] `TestNoMaliciousFastapi` (lockfile + pyproject) pass
- [x] Full suite (minus e2e): 1175 passed on fastapi 0.136.1 + starlette 1.1.0
- [x] Lockfile matches CI's `pip-compile` verify regen (diff clean)
- [x] mypy clean
- [ ] CI `security` (pip-audit) now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)