### PR TITLE
fix: set TRUSTED_PROXY=1 so rate limiting works behind the tunnel (#448)

### DIFF
--- a/deploy/pi/.env.example
+++ b/deploy/pi/.env.example
@@ -14,6 +14,11 @@ CSRF_SECRET=your-random-secret-here
 # deployments (behind Cloudflare/Traefik). Leave unset for plain-HTTP/local dev.
 HTTPS_ONLY=1
 
+# Trust Cloudflare's CF-Connecting-IP for the real client IP (#448). Required
+# behind the cloudflared tunnel so the rate limiter identifies clients, not the
+# tunnel container. Compose defaults this to 1.
+TRUSTED_PROXY=1
+
 # Anthropic API key — required only if using --ocr in repair-credits.
 # Leave blank to disable OCR fallback.
 ANTHROPIC_API_KEY=

--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -87,6 +87,9 @@ services:
       UPLOAD_USERNAME: "${UPLOAD_USERNAME:-highland}"
       # Emit HSTS when served over HTTPS (behind Cloudflare/Traefik) (#405).
       HTTPS_ONLY: "${HTTPS_ONLY:-}"
+      # Behind the Cloudflare tunnel, trust CF-Connecting-IP for the real client
+      # IP so the upload rate limiter buckets per client, not per tunnel (#448).
+      TRUSTED_PROXY: "${TRUSTED_PROXY:-1}"
     volumes:
       - /opt/song-history/data:/data
       - /opt/song-history/inbox:/inbox

--- a/tests/test_pi_compose.py
+++ b/tests/test_pi_compose.py
@@ -9,6 +9,19 @@ COMPOSE_PATH = Path("deploy/pi/docker-compose.yml")
 
 
 @pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
+class TestTrustedProxy:
+    """Behind the Cloudflare tunnel the app must trust CF-Connecting-IP so the
+    rate limiter (and /metrics IP checks) identify real clients, not the tunnel
+    container's IP (#448)."""
+
+    def test_compose_sets_trusted_proxy(self) -> None:
+        env = yaml.safe_load(COMPOSE_PATH.read_text())["services"]["song-history"]["environment"]
+        assert "TRUSTED_PROXY" in env, (
+            "song-history env must set TRUSTED_PROXY so _get_client_ip uses "
+            "CF-Connecting-IP instead of bucketing all tunnel traffic as one client"
+        )
+
+
 class TestWatcherHealthcheck:
     """The watcher reuses the app image, which ships a HEALTHCHECK probing
     http://localhost:8000/health (#402). The watcher runs an import loop and does


### PR DESCRIPTION
## Summary
- Adds `TRUSTED_PROXY=1` to the song-history service env (compose default + `.env.example`) so `_get_client_ip` uses Cloudflare's `CF-Connecting-IP`
- Without it, every tunnel request shares one rate-limit bucket (the #404 fix was inactive in prod)
- Guard test in `test_pi_compose.py`

Closes #448

## Test plan
- [x] `TestTrustedProxy` fails before, passes after
- [ ] CI test + security + e2e pass
- [ ] Deploy: verify `_get_client_ip` returns CF-Connecting-IP for tunnel requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)