### PR TITLE
fix: restrict /metrics to internal scrapes, deny via tunnel (#449)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -225,7 +225,17 @@ app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 
 
 @app.get("/metrics", include_in_schema=False)
-async def metrics() -> Response:
+async def metrics(request: Request) -> Response:
+    """Prometheus metrics — internal scraping only (#449).
+
+    Requests arriving via the public Cloudflare tunnel carry the
+    ``CF-Connecting-IP`` header; the internal Prometheus scrape (direct to the
+    host-published :8000) does not. Deny the tunnel path with 404 so the metrics
+    (route map, traffic, latency) aren't exposed to the internet, while the
+    internal scrape keeps working.
+    """
+    if request.headers.get("cf-connecting-ip"):
+        raise HTTPException(status_code=404)
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3778,6 +3778,20 @@ class TestPrometheusMetrics:
         response = client.get("/metrics")
         assert response.status_code == 200
 
+    def test_metrics_denied_via_cloudflare_tunnel(self, client):
+        """Requests arriving through the public Cloudflare tunnel carry
+        CF-Connecting-IP and must be denied — /metrics is internal-only (#449)."""
+        response = client.get("/metrics", headers={"CF-Connecting-IP": "203.0.113.7"})
+        assert response.status_code == 404, (
+            "/metrics must not be reachable from the public tunnel"
+        )
+
+    def test_metrics_allowed_for_internal_scrape(self, client):
+        """The internal Prometheus scrape (no CF-Connecting-IP) must still work."""
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        assert "http_requests_total" in response.text
+
 
 class TestBuildDateFormatting:
     """Build date on About page should be human-readable (#331)."""


### PR DESCRIPTION
## Summary
- `/metrics` denies requests carrying `CF-Connecting-IP` (Cloudflare tunnel traffic) with 404; the internal Prometheus scrape (no such header) still returns 200
- Closes the public exposure of the route map / traffic / latency histogram
- Defence-in-depth with the host firewall (#447), which already limits host `:8000` to the scraper

Closes #449

## Test plan
- [x] `/metrics` with `CF-Connecting-IP` → 404; without → 200 (9 metrics tests pass)
- [x] Full suite (minus e2e): 1179 passed
- [x] ruff + mypy clean
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)