### PR TITLE
fix: gate /jobs and /jobs/{id} behind upload auth (#451)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -1146,15 +1146,26 @@ async def upload(
 
 
 @app.get("/jobs")
-async def list_jobs(db: Database = Depends(get_db)) -> JSONResponse:  # noqa: B008
-    """Return all import job records, newest first."""
+async def list_jobs(
+    db: Database = Depends(get_db),  # noqa: B008
+    _: None = Depends(require_upload_auth),  # noqa: B008
+) -> JSONResponse:
+    """Return all import job records, newest first.
+
+    Gated behind the upload auth (#451): the job log leaks uploaded filenames
+    and raw error messages, so it's part of the write/admin surface, not public.
+    """
     jobs = db.list_import_jobs()
     return JSONResponse(content=jobs)
 
 
 @app.get("/jobs/{job_id}")
-async def get_job(job_id: str, db: Database = Depends(get_db)) -> JSONResponse:  # noqa: B008
-    """Return a single import job record or 404."""
+async def get_job(
+    job_id: str,
+    db: Database = Depends(get_db),  # noqa: B008
+    _: None = Depends(require_upload_auth),  # noqa: B008
+) -> JSONResponse:
+    """Return a single import job record or 404 (auth-gated like /jobs, #451)."""
     job = db.get_import_job(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1091,3 +1091,18 @@ class TestUploadAuth:
     def test_upload_open_when_password_unset(self, client):
         # The default fixture sets no UPLOAD_PASSWORD → upload stays open.
         assert client.get("/upload").status_code == 200
+
+    # /jobs is part of the same write/admin workflow and leaks uploaded
+    # filenames + raw error messages — it must be gated like /upload (#451).
+    def test_jobs_list_requires_auth_when_password_set(self, auth_client):
+        assert auth_client.get("/jobs").status_code == 401
+
+    def test_job_detail_requires_auth_when_password_set(self, auth_client):
+        assert auth_client.get("/jobs/anything").status_code == 401
+
+    def test_jobs_list_succeeds_with_credentials(self, auth_client):
+        assert auth_client.get("/jobs", auth=("highland", "s3cret")).status_code == 200
+
+    def test_jobs_open_when_password_unset(self, client):
+        # Backwards-compatible: scripted consumers keep working when no password.
+        assert client.get("/jobs").status_code == 200


### PR DESCRIPTION
## Summary
- `GET /jobs` and `/jobs/{id}` now require `require_upload_auth` (same as `/upload`) — they leaked uploaded filenames + raw error messages publicly
- 401 when `UPLOAD_PASSWORD` is set; open when unset (backwards-compatible for scripted consumers and the CI e2e server)
- Browser upload→poll flow keeps working via cached Basic Auth creds

Closes #451

## Test plan
- [x] `/jobs` + `/jobs/{id}` → 401 with password set, 200 with creds, open without password (10 auth tests pass)
- [x] Existing open-mode `/jobs` tests + upload e2e unaffected
- [x] Full suite (minus e2e): 1181 passed; ruff + mypy clean
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)