### PR TITLE
fix: detect proxied /metrics via X-Forwarded-For (#449 follow-up)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -224,17 +224,29 @@ templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 
 
+# Headers added by the public proxy chain (Cloudflare tunnel → Traefik). Their
+# presence means the request did NOT come from the internal Prometheus scrape,
+# which connects directly to the host-published :8000 with none of these (#449).
+_PROXY_HEADERS: tuple[str, ...] = (
+    "x-forwarded-for",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "cf-connecting-ip",
+    "forwarded",
+)
+
+
 @app.get("/metrics", include_in_schema=False)
 async def metrics(request: Request) -> Response:
     """Prometheus metrics — internal scraping only (#449).
 
-    Requests arriving via the public Cloudflare tunnel carry the
-    ``CF-Connecting-IP`` header; the internal Prometheus scrape (direct to the
-    host-published :8000) does not. Deny the tunnel path with 404 so the metrics
-    (route map, traffic, latency) aren't exposed to the internet, while the
-    internal scrape keeps working.
+    Public requests reach the app through the proxy chain (Cloudflare tunnel →
+    Traefik) and carry forwarding headers (X-Forwarded-For etc.); the internal
+    Prometheus scrape hits :8000 directly with none of them. Deny the proxied
+    path with 404 so the route map / traffic / latency aren't exposed publicly,
+    while the internal scrape keeps working.
     """
-    if request.headers.get("cf-connecting-ip"):
+    if any(h in request.headers for h in _PROXY_HEADERS):
         raise HTTPException(status_code=404)
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3778,16 +3778,20 @@ class TestPrometheusMetrics:
         response = client.get("/metrics")
         assert response.status_code == 200
 
-    def test_metrics_denied_via_cloudflare_tunnel(self, client):
-        """Requests arriving through the public Cloudflare tunnel carry
-        CF-Connecting-IP and must be denied — /metrics is internal-only (#449)."""
-        response = client.get("/metrics", headers={"CF-Connecting-IP": "203.0.113.7"})
-        assert response.status_code == 404, (
-            "/metrics must not be reachable from the public tunnel"
-        )
+    def test_metrics_denied_when_proxied(self, client):
+        """Requests reaching the app through the public proxy chain (Cloudflare
+        tunnel → Traefik) carry forwarding headers and must be denied — /metrics
+        is internal-only (#449). The real tunnel sends X-Forwarded-For (not
+        CF-Connecting-IP), so both must be treated as public."""
+        for hdr in ("X-Forwarded-For", "CF-Connecting-IP", "X-Forwarded-Host"):
+            response = client.get("/metrics", headers={hdr: "203.0.113.7"})
+            assert response.status_code == 404, (
+                f"/metrics must not be reachable from the public proxy chain (via {hdr})"
+            )
 
     def test_metrics_allowed_for_internal_scrape(self, client):
-        """The internal Prometheus scrape (no CF-Connecting-IP) must still work."""
+        """The internal Prometheus scrape (direct to :8000, no forwarding headers)
+        must still work."""
         response = client.get("/metrics")
         assert response.status_code == 200
         assert "http_requests_total" in response.text


### PR DESCRIPTION
## Summary
- The first #449 fix only checked `CF-Connecting-IP`, but a packet capture showed the tunnel reaches the app through **Traefik** with `X-Forwarded-For`/`-Proto`/`-Host` and **no** `CF-Connecting-IP` — so `/metrics` was still publicly 200
- Now deny `/metrics` if **any** proxy/forwarding header is present (covers tunnel→Traefik and a future direct-cloudflared path); the internal Prometheus scrape (direct `:8000`, no such headers) still returns 200

Follow-up to #449.

## Test plan
- [x] `/metrics` with `X-Forwarded-For`/`CF-Connecting-IP`/`X-Forwarded-Host` → 404; direct → 200
- [x] Full suite (minus e2e): 1184 passed; ruff + mypy clean
- [ ] CI passes; re-verify tunnel `/metrics` → 404 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)