### PR TITLE
deploy(pi): pin cloudflared & promtail images to digests (#453)

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -131,7 +131,8 @@ services:
   # Requires a DMZ->Loki (10.20.100.249:3100) firewall allow on VLAN 249.
   # ---------------------------------------------------------------------------
   promtail:
-    image: grafana/promtail:latest
+    # Digest-pinned (#453) — was :latest. Re-pin on a reviewed Dependabot bump.
+    image: grafana/promtail:latest@sha256:6cfa64ec432b24a912d640e2edb940eeae2666f61861a66c121d763dd7241381
     restart: unless-stopped
     user: root   # needed to read root-owned /var/lib/docker/containers logs
     command: -config.file=/etc/promtail/config.yml
@@ -153,7 +154,9 @@ services:
   # in the Cloudflare Zero Trust dashboard. Set TUNNEL_TOKEN in .env.
   # ---------------------------------------------------------------------------
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    # Digest-pinned (#453) — was :latest. The internet-facing tunnel daemon must
+    # not silently upgrade; re-pin on a reviewed Dependabot bump.
+    image: cloudflare/cloudflared:latest@sha256:59bab8d3aceec09bf6bdb07d6beca0225ca5cd7ab79436a87ea97978fe1dc4f9
     restart: unless-stopped
     command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
     # If IPS in Prevention mangles the QUIC/UDP edge connection, force HTTP/2:

--- a/tests/test_pi_compose.py
+++ b/tests/test_pi_compose.py
@@ -9,6 +9,20 @@ COMPOSE_PATH = Path("deploy/pi/docker-compose.yml")
 
 
 @pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
+class TestImagePinning:
+    """All third-party images on the public host must be digest-pinned (#453)."""
+
+    def test_third_party_images_pinned_to_digest(self) -> None:
+        services = yaml.safe_load(COMPOSE_PATH.read_text())["services"]
+        for name in ("cloudflared", "promtail", "traefik"):
+            image = services[name]["image"]
+            assert "@sha256:" in image, (
+                f"{name} image must be digest-pinned (got {image!r}) — mutable :latest "
+                "is non-reproducible and a supply-chain risk on the public host"
+            )
+
+
+@pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
 class TestTrustedProxy:
     """Behind the Cloudflare tunnel the app must trust CF-Connecting-IP so the
     rate limiter (and /metrics IP checks) identify real clients, not the tunnel


### PR DESCRIPTION
## Summary
- Pins `cloudflared` and `promtail` to the digests currently running on the Pi (were mutable `:latest`)
- Adds a `test_pi_compose` guard requiring cloudflared/promtail/traefik to be `@sha256`-pinned

Closes #453

## Test plan
- [x] `TestImagePinning` passes; pinned to running digests (no surprise upgrade on deploy)
- [ ] CI test + security + e2e pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)