### PR TITLE
fix: NULL-safe UNIQUE for song_editions & copy_events (#420)

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -14,7 +14,7 @@ _log = logging.getLogger("worship_catalog.db")
 # Bump this integer whenever the schema changes.  Each new version must have a
 # corresponding entry in _MIGRATIONS.  connect() raises SchemaVersionError if the
 # on-disk version is *higher* than this value (DB created by a newer release).
-_SCHEMA_VERSION: int = 3
+_SCHEMA_VERSION: int = 4
 
 # Ordered dict of version → list of SQL statements.  Each migration brings the
 # DB from version (N-1) to version N.  Migration 1 is the baseline — it
@@ -109,6 +109,57 @@ _MIGRATIONS: dict[int, list[str]] = {
         "ALTER TABLE services_new RENAME TO services",
         "PRAGMA foreign_keys=ON",
         "CREATE INDEX IF NOT EXISTS idx_services_date ON services(service_date)",
+    ],
+    4: [
+        # NULL-safe uniqueness for song_editions + copy_events (#420). SQLite's
+        # table-level UNIQUE treats each NULL as distinct, so NULL-credit editions
+        # and NULL-edition copy_events could duplicate under concurrent imports.
+        # De-dupe existing rows (repointing child FKs to the keeper), then add
+        # expression UNIQUE indexes that COALESCE NULLs so the constraint actually
+        # enforces. With these in place, insert_or_get_* raises IntegrityError on a
+        # concurrent NULL duplicate and the existing retry-on-conflict (#400) wins.
+        # --- song_editions: map each row to its canonical keeper (min id) ---
+        """
+        CREATE TEMP TABLE _edition_keep AS
+        SELECT e1.id AS dup_id,
+               (SELECT MIN(e2.id) FROM song_editions e2
+                 WHERE e2.song_id = e1.song_id
+                   AND COALESCE(e2.publisher,'') = COALESCE(e1.publisher,'')
+                   AND COALESCE(e2.words_by,'')  = COALESCE(e1.words_by,'')
+                   AND COALESCE(e2.music_by,'')  = COALESCE(e1.music_by,'')
+                   AND COALESCE(e2.arranger,'')  = COALESCE(e1.arranger,'')) AS keep_id
+        FROM song_editions e1
+        """,
+        """
+        UPDATE service_songs SET song_edition_id =
+            (SELECT keep_id FROM _edition_keep WHERE dup_id = service_songs.song_edition_id)
+        WHERE song_edition_id IN (SELECT dup_id FROM _edition_keep WHERE dup_id <> keep_id)
+        """,
+        """
+        UPDATE copy_events SET song_edition_id =
+            (SELECT keep_id FROM _edition_keep WHERE dup_id = copy_events.song_edition_id)
+        WHERE song_edition_id IN (SELECT dup_id FROM _edition_keep WHERE dup_id <> keep_id)
+        """,
+        "DELETE FROM song_editions WHERE id IN "
+        "(SELECT dup_id FROM _edition_keep WHERE dup_id <> keep_id)",
+        "DROP TABLE _edition_keep",
+        # --- copy_events: collapse duplicates (after the edition repoint) ---
+        """
+        DELETE FROM copy_events WHERE id NOT IN (
+            SELECT MIN(id) FROM copy_events
+            GROUP BY service_id, song_id, COALESCE(song_edition_id, -1), reproduction_type
+        )
+        """,
+        # --- NULL-safe unique indexes (NULLs collapsed via COALESCE) ---
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_song_editions_identity
+        ON song_editions(song_id, COALESCE(publisher,''), COALESCE(words_by,''),
+                         COALESCE(music_by,''), COALESCE(arranger,''))
+        """,
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_copy_events_identity
+        ON copy_events(service_id, song_id, COALESCE(song_edition_id, -1), reproduction_type)
+        """,
     ],
 }
 

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2315,10 +2315,13 @@ class TestDatabaseIndexes:
                 break
         assert has_date_index, "Missing index on services.service_date"
 
-    def test_schema_version_is_3(self, temp_db):
+    def test_schema_version_matches_current(self, temp_db):
+        from worship_catalog.db import _SCHEMA_VERSION
+
         cursor = temp_db.cursor()
         cursor.execute("PRAGMA user_version")
-        assert cursor.fetchone()[0] == 3
+        assert cursor.fetchone()[0] == _SCHEMA_VERSION
+        assert _SCHEMA_VERSION == 4  # bumped for NULL-safe unique indexes (#420)
 
 
 @pytest.mark.integration
@@ -2880,11 +2883,6 @@ class TestConcurrentInsertOrGet:
         finally:
             check.close()
 
-    @pytest.mark.xfail(
-        reason="#420: NULL columns in song_editions UNIQUE are distinct in SQLite, "
-        "so concurrent NULL-credit inserts still duplicate (retry can't catch — no error)",
-        strict=False,
-    )
     def test_concurrent_insert_or_get_song_edition_no_error(self, tmp_path):
         db_path = tmp_path / "race_edition.db"
         init = self._connect(db_path)
@@ -2925,11 +2923,6 @@ class TestConcurrentInsertOrGet:
         finally:
             check.close()
 
-    @pytest.mark.xfail(
-        reason="#420: NULL song_edition_id in copy_events UNIQUE is distinct in SQLite, "
-        "so concurrent NULL-edition inserts still duplicate (retry can't catch — no error)",
-        strict=False,
-    )
     def test_concurrent_insert_or_get_copy_event_no_error(self, tmp_path):
         db_path = tmp_path / "race_copy.db"
         init = self._connect(db_path)
@@ -3049,4 +3042,60 @@ class TestPaginationSnapshotConsistency:
         rows, total = db.query_songs_paginated(page=2, per_page=10)
         assert total == 100
         assert len(rows) == 10
+        db.close()
+
+
+@pytest.mark.integration
+class TestMigrationV4NullSafeUnique:
+    """Migration v4 adds NULL-safe unique indexes + de-dupes existing rows (#420)."""
+
+    def test_v4_creates_null_safe_indexes(self, tmp_path):
+        db = Database(tmp_path / "v4idx.db")
+        db.connect()
+        db.init_schema()
+        cur = db.conn.cursor()
+        cur.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name IN "
+            "('idx_song_editions_identity', 'idx_copy_events_identity')"
+        )
+        names = {r[0] for r in cur.fetchall()}
+        assert names == {"idx_song_editions_identity", "idx_copy_events_identity"}
+        db.close()
+
+    def test_v4_dedupes_existing_null_duplicates(self, tmp_path):
+        db = Database(tmp_path / "v4dedup.db")
+        db.connect()
+        db.init_schema()
+        cur = db.conn.cursor()
+        # Simulate a pre-v4 DB: drop the NULL-safe indexes + unmark migration 4,
+        # so we can insert the duplicate NULL rows the constraint now forbids.
+        cur.execute("DROP INDEX IF EXISTS idx_song_editions_identity")
+        cur.execute("DROP INDEX IF EXISTS idx_copy_events_identity")
+        cur.execute("DELETE FROM schema_migrations WHERE version = 4")
+        song_id = db.insert_or_get_song("dup song", "Dup Song")
+        svc = db.insert_or_update_service("2026-02-15", "AM Worship", "f.pptx", "h1")
+        cur.execute("INSERT INTO song_editions (song_id, words_by) VALUES (?, NULL)", (song_id,))
+        cur.execute("INSERT INTO song_editions (song_id, words_by) VALUES (?, NULL)", (song_id,))
+        cur.execute(
+            "INSERT INTO copy_events (service_id, song_id, reproduction_type) VALUES (?,?,?)",
+            (svc, song_id, "projection"),
+        )
+        cur.execute(
+            "INSERT INTO copy_events (service_id, song_id, reproduction_type) VALUES (?,?,?)",
+            (svc, song_id, "projection"),
+        )
+        db.conn.commit()
+
+        # Re-run migrations → v4 de-dupes and recreates the indexes.
+        db._apply_migrations()
+        db.conn.commit()
+
+        cur.execute("SELECT COUNT(*) FROM song_editions WHERE song_id = ?", (song_id,))
+        assert cur.fetchone()[0] == 1, "duplicate NULL-credit editions must be collapsed"
+        cur.execute(
+            "SELECT COUNT(*) FROM copy_events WHERE service_id=? AND song_id=? "
+            "AND reproduction_type='projection'",
+            (svc, song_id),
+        )
+        assert cur.fetchone()[0] == 1, "duplicate NULL-edition copy_events must be collapsed"
         db.close()


### PR DESCRIPTION
## Summary
- Migration **v4**: adds expression UNIQUE indexes (`COALESCE` NULLs) on `song_editions` and `copy_events`, after de-duping any existing NULL-duplicate rows (repointing child FKs to the keeper)
- The constraint now enforces, so `insert_or_get_*` raises `IntegrityError` on a concurrent NULL duplicate and #400's retry-on-conflict re-reads the winner
- The two #420 concurrency tests are **un-xfailed** and pass

## Validation
- Dry-run on a **copy of the production DB**: clean apply (v3→v4, 212 editions / 560 copy_events unchanged — no dups present, 0 FK issues, both indexes created)
- New migration tests: fresh-DB index creation + de-dup path (inserts dups in a simulated pre-v4 state, re-runs v4, asserts collapse)

Closes #420

## Test plan
- [x] Concurrency tests (edition + copy_event) pass without xfail
- [x] `TestMigrationV4NullSafeUnique` (indexes + dedup) pass
- [x] Full suite (minus e2e): 1195 passed; ruff + mypy clean
- [ ] CI passes; verify clean migration on the Pi at deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)