### PR TITLE
fix: detect dot-style & dash-prefixed scripture refs in older decks (#427)

### DIFF
--- a/src/worship_catalog/normalize.py
+++ b/src/worship_catalog/normalize.py
@@ -164,7 +164,12 @@ def select_best_title(candidates: list[str]) -> str | None:
 # Matches: optional numeric book prefix + book name + chapter:verse[(-|–|—) verse]
 # Accepts hyphens, en-dashes, em-dashes, and optional spaces around the separator (#313).
 _SCRIPTURE_RE = re.compile(
-    r"^(1|2|3)?\s*[A-Za-z][a-z]+(\s[A-Za-z][a-z]+)?\s+\d{1,3}:\d{1,3}(\s*[-–—]\s*\d{1,3})?$",
+    # Optional leading dash/en/em-dash (older decks prefix scripture refs, #427),
+    # optional numeric book prefix, book name, then chapter[:.]verse with an
+    # optional verse range. The [:.] accepts dot-style refs ("Romans 12.20") as
+    # well as the canonical colon ("John 3:16").
+    r"^[–—-]?\s*(1|2|3)?\s*[A-Za-z][a-z]+(\s[A-Za-z][a-z]+)?\s+\d{1,3}[:.]\d{1,3}"
+    r"(\s*[-–—]\s*\d{1,3})?$",
     re.IGNORECASE,
 )
 

--- a/tests/test_credits_parsing.py
+++ b/tests/test_credits_parsing.py
@@ -290,3 +290,46 @@ def test_canonicalize_title_golden(display_title: str, expected_canonical: str) 
     assert result == expected_canonical, (
         f"canonicalize_title({display_title!r}) = {result!r}, expected {expected_canonical!r}"
     )
+
+
+from worship_catalog.normalize import is_non_song_title  # noqa: E402
+
+
+class TestScriptureRefVariants:
+    """Older (pre-2021) decks use dot separators and a leading dash (#427)."""
+
+    @pytest.mark.parametrize("title", [
+        "– 2 Corinthians 3.5",      # leading en-dash + dot separator
+        "2 Corinthians 3.5",         # dot separator, no dash
+        "Romans 12.20",              # dot separator, single ref
+        "– Romans 12.20 – 21",       # leading dash + dot + range
+        "Romans 12.20 – 21",         # dot + range, no dash
+        "- John 3.16",               # hyphen prefix variant
+        "John 3:16",                 # existing colon form still works
+        "1 Peter 1:3-4",             # existing colon + range still works
+    ])
+    def test_scripture_refs_are_non_songs(self, title):
+        assert is_non_song_title(title) is True
+
+    @pytest.mark.parametrize("title", [
+        "Is He Worthy?",             # real song ending in '?'
+        "Amazing Grace",
+        "10,000 Reasons",            # number + comma, real title
+        "Days of Elijah",
+        "Come Thou Fount",
+        "Christ for the World We Sing",
+    ])
+    def test_real_titles_are_not_dropped(self, title):
+        assert is_non_song_title(title) is False
+
+
+class TestSermonPointFragments:
+    """Secondary/exploratory (#427): short sermon points with no scripture/dash
+    signal. Deferred — no heuristic catches 'The problem?' without also dropping
+    legitimate short titles like 'Is He Worthy?'."""
+
+    @pytest.mark.xfail(reason="#427: no safe heuristic that preserves 'Is He Worthy?'",
+                       strict=False)
+    @pytest.mark.parametrize("title", ["The problem?", "Straightness. Fairness."])
+    def test_short_sermon_points_are_non_songs(self, title):
+        assert is_non_song_title(title) is True


### PR DESCRIPTION
## Summary
- Broadens `_SCRIPTURE_RE` to accept an optional leading dash and a dot-or-colon chapter/verse separator, so older-deck refs like `– 2 Corinthians 3.5` and `– Romans 12.20 – 21` are recognized as non-songs and stop leaking into the import
- Preserves legitimate titles (regression guard incl. `Is He Worthy?`, `10,000 Reasons`)
- Sermon-point fragments deferred as `xfail` (no safe heuristic that doesn't drop short real titles)

Closes #427

## Test plan
- [x] `TestScriptureRefVariants` (8 incl. existing colon forms) + `test_real_titles_are_not_dropped` pass
- [x] `TestSermonPointFragments` xfail (deferred)
- [x] Full suite (minus e2e): 1209 passed, 2 xfailed; ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)