### PR TITLE
fix(a11y): concise live-region count on services filter (#431)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -884,7 +884,7 @@ async def services_list(
         "page": page, "per_page": per_page, "total_pages": total_pages, "total": total,
     }
     if request.headers.get("HX-Request"):
-        return templates.TemplateResponse(request, "services_rows.html", ctx)
+        return templates.TemplateResponse(request, "_services_results.html", ctx)
     ctx["service_names"] = db.query_distinct_service_names()
     ctx["leaders"] = db.query_distinct_song_leaders()
     ctx["preachers"] = db.query_distinct_preachers()

--- a/src/worship_catalog/web/templates/_services_results.html
+++ b/src/worship_catalog/web/templates/_services_results.html
@@ -1,0 +1,63 @@
+{# Services results region: concise count + table + pagination. Rendered in the
+   full page (inside #services-results) and as the HTMX filter response, so the
+   count and pagination stay in sync with the rows shown — and screen readers
+   hear a short "N services found" instead of the whole table (#431, mirrors #386). #}
+{% set filter_qs %}start_date={{ start_date }}&end_date={{ end_date }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}{% endset %}
+
+{% macro sort_th(label, col, align="left") %}
+{% set next_dir = "asc" if (sort == col and sort_dir == "desc") else "desc" %}
+{% set aria_sort_val = ("ascending" if sort_dir == "asc" else "descending") if sort == col else "none" %}
+<th scope="col" style="text-align:{{ align }};white-space:nowrap;user-select:none;cursor:pointer;" aria-sort="{{ aria_sort_val }}">
+  <a href="/services?sort={{ col }}&sort_dir={{ next_dir }}&{{ filter_qs }}"
+     style="color:inherit;text-decoration:none;">
+    {{ label }}{% if sort == col %}&nbsp;{{ '▲' if sort_dir == 'asc' else '▼' }}{% endif %}
+  </a>
+</th>
+{% endmacro %}
+
+<p id="services-count" class="sr-only" aria-live="polite" aria-atomic="true">
+  {{ total }} service{{ "s" if total != 1 else "" }} found.
+</p>
+
+{% if total == 0 and not q_service and not q_leader and not q_preacher and not q_sermon and not start_date and not end_date %}
+<div class="card" style="text-align:center;padding:2rem;">
+  <h2>No services yet</h2>
+  <p>Import your first worship service to get started.</p>
+  <p>Upload a PPTX file on the <a href="/upload">Upload</a> page, or run:</p>
+  <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
+</div>
+{% else %}
+<div class="card" style="padding:0;">
+  <div class="table-wrap">
+  <table>
+    <caption class="sr-only">Worship services — sortable and filterable</caption>
+    <thead>
+      <tr>
+        {{ sort_th("Date", "service_date") }}
+        {{ sort_th("Service", "service_name") }}
+        {{ sort_th("Song Leader", "song_leader") }}
+        {{ sort_th("Preacher", "preacher") }}
+        <th scope="col">Sermon</th>
+        {{ sort_th("Songs", "song_count", align="right") }}
+        <th scope="col"><span class="sr-only">Actions</span></th>
+      </tr>
+    </thead>
+    <tbody id="services-tbody">
+      {% include "services_rows.html" %}
+    </tbody>
+  </table>
+  </div>
+</div>
+{% endif %}
+
+{% if total_pages > 1 %}
+<nav class="pagination" aria-label="Pagination">
+  {% if page > 1 %}
+    <a href="/services?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}" aria-label="Previous page">← Prev</a>
+  {% endif %}
+  <span>Page {{ page }} of {{ total_pages }}</span>
+  {% if page < total_pages %}
+    <a href="/services?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}" aria-label="Next page">Next →</a>
+  {% endif %}
+</nav>
+{% endif %}

--- a/src/worship_catalog/web/templates/services.html
+++ b/src/worship_catalog/web/templates/services.html
@@ -18,19 +18,19 @@
       <div>
         <label for="filter-start-date" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Date From</label>
         <input type="date" id="filter-start-date" name="start_date" value="{{ start_date }}"
-          hx-get="/services" hx-trigger="change" hx-target="#services-tbody"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
           hx-include="#filter-form">
       </div>
       <div>
         <label for="filter-end-date" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Date To</label>
         <input type="date" id="filter-end-date" name="end_date" value="{{ end_date }}"
-          hx-get="/services" hx-trigger="change" hx-target="#services-tbody"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
           hx-include="#filter-form">
       </div>
       <div>
         <label for="filter-service" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Service</label>
         <select id="filter-service" name="q_service"
-          hx-get="/services" hx-trigger="change" hx-target="#services-tbody"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
           hx-include="#filter-form">
           <option value="">All services</option>
           {% for name in service_names %}
@@ -41,7 +41,7 @@
       <div>
         <label for="filter-leader" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Song Leader</label>
         <select id="filter-leader" name="q_leader"
-          hx-get="/services" hx-trigger="change" hx-target="#services-tbody"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
           hx-include="#filter-form">
           <option value="">All leaders</option>
           {% for leader in leaders %}
@@ -52,7 +52,7 @@
       <div>
         <label for="filter-preacher" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Preacher</label>
         <select id="filter-preacher" name="q_preacher"
-          hx-get="/services" hx-trigger="change" hx-target="#services-tbody"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
           hx-include="#filter-form">
           <option value="">All preachers</option>
           {% for preacher in preachers %}
@@ -63,67 +63,16 @@
       <div>
         <label for="filter-sermon" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Sermon</label>
         <input type="text" id="filter-sermon" name="q_sermon" value="{{ q_sermon }}" placeholder="filter…"
-          hx-get="/services" hx-trigger="input changed delay:300ms" hx-target="#services-tbody"
+          hx-get="/services" hx-trigger="input changed delay:300ms" hx-target="#services-results" hx-swap="innerHTML"
           hx-include="#filter-form">
       </div>
     </div>
   </div>
 </form>
 
-{# Build a query string from current filter params for sort links #}
-{% set filter_qs %}start_date={{ start_date }}&end_date={{ end_date }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}{% endset %}
-
-{% macro sort_th(label, col, align="left") %}
-{% set next_dir = "asc" if (sort == col and sort_dir == "desc") else "desc" %}
-{% set aria_sort_val = ("ascending" if sort_dir == "asc" else "descending") if sort == col else "none" %}
-<th scope="col" style="text-align:{{ align }};white-space:nowrap;user-select:none;cursor:pointer;" aria-sort="{{ aria_sort_val }}">
-  <a href="/services?sort={{ col }}&sort_dir={{ next_dir }}&{{ filter_qs }}"
-     style="color:inherit;text-decoration:none;">
-    {{ label }}{% if sort == col %}&nbsp;{{ '▲' if sort_dir == 'asc' else '▼' }}{% endif %}
-  </a>
-</th>
-{% endmacro %}
-
-{% if total == 0 and not q_service and not q_leader and not q_preacher and not q_sermon and not start_date and not end_date %}
-<div class="card" style="text-align:center;padding:2rem;">
-  <h2>No services yet</h2>
-  <p>Import your first worship service to get started.</p>
-  <p>Upload a PPTX file on the <a href="/upload">Upload</a> page, or run:</p>
-  <p><code>worship-catalog import "AM Worship 2026.01.01.pptx"</code></p>
+{# Filter/sort swaps this whole region (count + table + pagination) so the
+   footer and screen-reader count never drift from the rows shown (#431). #}
+<div id="services-results">
+{% include "_services_results.html" %}
 </div>
-{% else %}
-<div class="card" style="padding:0;" aria-live="polite">
-  <div class="table-wrap">
-  <table>
-    <caption class="sr-only">Worship services — sortable and filterable</caption>
-    <thead>
-      <tr>
-        {{ sort_th("Date", "service_date") }}
-        {{ sort_th("Service", "service_name") }}
-        {{ sort_th("Song Leader", "song_leader") }}
-        {{ sort_th("Preacher", "preacher") }}
-        <th scope="col">Sermon</th>
-        {{ sort_th("Songs", "song_count", align="right") }}
-        <th scope="col"><span class="sr-only">Actions</span></th>
-      </tr>
-    </thead>
-    <tbody id="services-tbody">
-      {% include "services_rows.html" %}
-    </tbody>
-  </table>
-  </div>
-</div>
-{% endif %}
-
-{% if total_pages > 1 %}
-<div class="pagination">
-  {% if page > 1 %}
-    <a href="/services?page={{ page - 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}" aria-label="Previous page">← Prev</a>
-  {% endif %}
-  <span>Page {{ page }} of {{ total_pages }}</span>
-  {% if page < total_pages %}
-    <a href="/services?page={{ page + 1 }}&per_page={{ per_page }}&sort={{ sort }}&sort_dir={{ sort_dir }}&q_service={{ q_service | urlencode }}&q_leader={{ q_leader | urlencode }}&q_preacher={{ q_preacher | urlencode }}&q_sermon={{ q_sermon | urlencode }}&start_date={{ start_date }}&end_date={{ end_date }}" aria-label="Next page">Next →</a>
-  {% endif %}
-</div>
-{% endif %}
 {% endblock %}

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -242,6 +242,33 @@ class TestSongsConciseLiveRegion:
         assert 'id="songs-count"' in resp.text
 
 
+class TestServicesConciseLiveRegion:
+    """Services filtering must announce a concise result count, not the whole table (#431)."""
+
+    def test_services_table_card_is_not_the_live_region(self, client: TestClient) -> None:
+        """The table-wrapping card must no longer carry aria-live — otherwise every
+        HTMX filter change re-announces all rows to screen readers."""
+        resp = client.get("/services")
+        assert 'style="padding:0;" aria-live="polite"' not in resp.text, (
+            "Services table card is still an aria-live region — it announces the entire "
+            "table on every filter change. Move aria-live to a concise count region."
+        )
+
+    def test_services_has_concise_count_live_region(self, client: TestClient) -> None:
+        resp = client.get("/services")
+        m = re.search(r'id="services-count"[^>]*>', resp.text)
+        assert m, "Expected a concise #services-count live region"
+        tag = m.group(0)
+        assert 'aria-live="polite"' in tag and 'aria-atomic="true"' in tag, (
+            "The count region must be a polite, atomic live region"
+        )
+
+    def test_services_htmx_partial_includes_count(self, client: TestClient) -> None:
+        """The HTMX filter response must re-render the count so it updates on filter."""
+        resp = client.get("/services?q_service=AM", headers={"HX-Request": "true"})
+        assert 'id="services-count"' in resp.text
+
+
 class TestErrorPageContrast:
     """Tests for error page text contrast (#307)."""
 


### PR DESCRIPTION
## Summary
- The services filter swapped `#services-tbody` inside an `aria-live` card, so each filter/sort change re-announced the **entire table** to screen readers.
- Mirrors the songs pattern (#386/#413): new `#services-results` region with a concise sr-only `N services found` count (`aria-live="polite" aria-atomic="true"`) + table + pagination, swapped as a whole on filter/sort. Table-card `aria-live` removed.
- Route returns `_services_results.html` for `HX-Request` so the count and pagination footer stay in sync with the rows shown.

Closes #431.

## Tests
- `tests/test_accessibility.py::TestServicesConciseLiveRegion` (TDD: written first, confirmed failing, now passing) — asserts the table card is no longer the live region, a concise `#services-count` polite/atomic region exists, and the HX partial re-renders the count.
- Existing `TestAriaLiveRegions::test_services_table_has_aria_live` still passes (count region carries `aria-live`).
- `#services-tbody` is preserved inside the swapped region, so the e2e UAT filter tests remain valid.

## Validation
- `uv run python -m pytest -m "not e2e"` → 1194 passed, 2 xfailed
- `uv run ruff check src/` → clean
- `uv run mypy src/` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)