### PR TITLE
chore(deps): refresh requirements.lock to latest pins

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -8,7 +8,7 @@ annotated-doc==0.0.4
     # via fastapi
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.105.2
+anthropic==0.107.0
     # via worship-catalog (pyproject.toml)
 anyio==4.13.0
     # via
@@ -37,7 +37,7 @@ httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via anthropic
-idna==3.17
+idna==3.18
     # via
     #   anyio
     #   httpx
@@ -62,7 +62,7 @@ pydantic==2.13.4
     #   worship-catalog (pyproject.toml)
 pydantic-core==2.46.4
     # via pydantic
-python-multipart==0.0.29
+python-multipart==0.0.32
     # via worship-catalog (pyproject.toml)
 python-pptx==1.0.2
     # via worship-catalog (pyproject.toml)
@@ -90,7 +90,7 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-uvicorn==0.48.0
+uvicorn==0.49.0
     # via worship-catalog (pyproject.toml)
 xlsxwriter==3.2.9
     # via python-pptx


### PR DESCRIPTION
## What
Regenerate `requirements.lock` so it matches a fresh `pip-compile` resolution. Bumps 4 transitive/runtime pins to the latest versions already permitted by `pyproject.toml`:

| Package | Old | New |
|---|---|---|
| anthropic | 0.105.2 | 0.107.0 |
| idna | 3.17 | 3.18 |
| python-multipart | 0.0.29 | 0.0.32 |
| uvicorn | 0.48.0 | 0.49.0 |

## Why
The CI `security` job's **"Verify lockfile is up to date"** step compiles to a fresh `/tmp/requirements.lock` (no existing pins to preserve) and diffs against the committed lock. Upstream released newer versions within the allowed ranges, so the committed lock drifted and the check fails on every open PR (incl. #474). This is environmental drift, not a code change.

## Note
Plain `pip-compile --output-file requirements.lock` does **not** fix this (pip-tools preserves satisfiable existing pins); the file must be resolved fresh (`--upgrade` or remove-then-compile), which is what CI effectively does.

Once merged, #474 picks this up on rebase and its security check goes green.