### PR TITLE
feat: Missing Services report (#480)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,11 @@ LOG_LEVEL=INFO
 # Optional: host port the web UI binds to (default: 8000)
 # WEB_PORT=8000
 
+# Optional: earliest date the Missing Services report will consider (ISO YYYY-MM-DD).
+# Defaults to the first Sunday Highland began collecting data. The report never
+# flags gaps before this date, even for wide lookback windows.
+# DATA_COLLECTION_START=2026-03-01
+
 # Optional: Claude Vision API key, required only when using --ocr
 # Used by: worship-catalog import --ocr, repair-credits --ocr
 # Leave blank (or omit) if you never use OCR credit extraction.

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -9,12 +9,14 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from worship_catalog.normalize import normalize_service_date
+
 _log = logging.getLogger("worship_catalog.db")
 
 # Bump this integer whenever the schema changes.  Each new version must have a
 # corresponding entry in _MIGRATIONS.  connect() raises SchemaVersionError if the
 # on-disk version is *higher* than this value (DB created by a newer release).
-_SCHEMA_VERSION: int = 4
+_SCHEMA_VERSION: int = 6
 
 # Ordered dict of version → list of SQL statements.  Each migration brings the
 # DB from version (N-1) to version N.  Migration 1 is the baseline — it
@@ -170,6 +172,23 @@ _MIGRATIONS: dict[int, list[str]] = {
         "ALTER TABLE import_jobs ADD COLUMN preacher TEXT",
         "ALTER TABLE import_jobs ADD COLUMN sermon_title TEXT",
         "ALTER TABLE import_jobs ADD COLUMN songs_json TEXT",
+    ],
+    6: [
+        # Track Sunday service slots (morning/evening) that are intentionally
+        # absent, so the missing-services report shows them as deliberate rather
+        # than as gaps (#480).
+        """
+        CREATE TABLE IF NOT EXISTS service_exclusions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            service_date TEXT NOT NULL,
+            service_slot TEXT NOT NULL,
+            reason TEXT,
+            excluded_at TEXT NOT NULL,
+            UNIQUE(service_date, service_slot)
+        )
+        """,
+        "CREATE INDEX IF NOT EXISTS idx_service_exclusions_date "
+        "ON service_exclusions(service_date)",
     ],
 }
 
@@ -441,6 +460,21 @@ class Database:
                 completed_at TEXT,
                 songs_imported INTEGER,
                 error_message TEXT
+            )
+            """
+        )
+
+        # Service exclusions table — Sunday slots intentionally left absent so the
+        # missing-services report can distinguish deliberate gaps (#480).
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS service_exclusions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                service_date TEXT NOT NULL,
+                service_slot TEXT NOT NULL,
+                reason TEXT,
+                excluded_at TEXT NOT NULL,
+                UNIQUE(service_date, service_slot)
             )
             """
         )
@@ -850,6 +884,52 @@ class Database:
         while row is not None:
             yield dict(row)
             row = cursor.fetchone()
+
+    # --- Service exclusions (missing-services report) ---
+
+    def add_exclusion(
+        self, service_date: str, service_slot: str, reason: str | None = None
+    ) -> None:
+        """Mark a (date, slot) as intentionally absent; upsert on conflict (#480).
+
+        The date is normalized to ISO ``YYYY-MM-DD`` so it lines up with stored
+        ``services.service_date`` values regardless of the caller's separators.
+        """
+        normalized = normalize_service_date(service_date)
+        now = datetime.now(timezone.utc).isoformat()
+        self._conn.execute(
+            """
+            INSERT INTO service_exclusions (service_date, service_slot, reason, excluded_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(service_date, service_slot)
+            DO UPDATE SET reason = excluded.reason, excluded_at = excluded.excluded_at
+            """,
+            (normalized, service_slot, reason, now),
+        )
+        self._maybe_commit()
+
+    def remove_exclusion(self, service_date: str, service_slot: str) -> None:
+        """Remove an intentional-exclusion marker for a (date, slot) (#480)."""
+        normalized = normalize_service_date(service_date)
+        self._conn.execute(
+            "DELETE FROM service_exclusions WHERE service_date = ? AND service_slot = ?",
+            (normalized, service_slot),
+        )
+        self._maybe_commit()
+
+    def query_exclusions(self, start_date: str, end_date: str) -> list[dict]:
+        """Return intentional-exclusion rows within the inclusive date range."""
+        cursor = self._conn.cursor()
+        cursor.execute(
+            """
+            SELECT id, service_date, service_slot, reason, excluded_at
+            FROM service_exclusions
+            WHERE service_date >= ? AND service_date <= ?
+            ORDER BY service_date, service_slot
+            """,
+            (start_date, end_date),
+        )
+        return [dict(row) for row in cursor.fetchall()]
 
     def query_songs_missing_credits(self) -> list[dict]:
         """

--- a/src/worship_catalog/service_slots.py
+++ b/src/worship_catalog/service_slots.py
@@ -1,0 +1,99 @@
+"""Service-slot classification and missing-services report constants (#480).
+
+A worship week is expected to have two services: a morning and an evening slot.
+This module classifies a stored ``service_name`` into one of those slots and
+holds the constants the missing-services report depends on (the data-collection
+floor and the selectable lookback windows).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import date, timedelta
+
+SLOT_MORNING: str = "morning"
+SLOT_EVENING: str = "evening"
+# Order matters: the report renders/iterates slots in this order.
+EXPECTED_SLOTS: tuple[str, str] = (SLOT_MORNING, SLOT_EVENING)
+VALID_SLOTS: frozenset[str] = frozenset(EXPECTED_SLOTS)
+
+# Highland began formally collecting service data on the first Sunday of March
+# 2026. The report never reports gaps earlier than this, even for wide windows.
+# Overridable via the DATA_COLLECTION_START env var (ISO YYYY-MM-DD).
+_DEFAULT_COLLECTION_START: str = "2026-03-01"
+
+DEFAULT_WINDOW_DAYS: int = 90
+# Insertion order is preserved and drives the template's selector options.
+WINDOW_OPTIONS: dict[str, str] = {
+    "90": "Last 90 days",
+    "180": "Last 180 days",
+    "365": "Last 1 year",
+    "730": "Last 2 years",
+}
+
+# Whole-word AM/PM matchers so older "AM Worship" / "Sunday PM" naming maps to a
+# slot without matching "am"/"pm" buried inside unrelated words.
+_AM_RE = re.compile(r"\bam\b", re.IGNORECASE)
+_PM_RE = re.compile(r"\bpm\b", re.IGNORECASE)
+
+
+def get_data_collection_start() -> date:
+    """Return the earliest date the report will consider (the collection floor)."""
+    raw = os.environ.get("DATA_COLLECTION_START", _DEFAULT_COLLECTION_START).strip()
+    try:
+        return date.fromisoformat(raw)
+    except ValueError:
+        return date.fromisoformat(_DEFAULT_COLLECTION_START)
+
+
+def classify_service_slot(service_name: str | None) -> str | None:
+    """Map a stored ``service_name`` to ``morning``/``evening`` (or None).
+
+    Production data uses "Morning Worship" / "Evening Worship"; older or
+    hand-entered data may use "AM Worship" / "PM Worship". Anything that matches
+    neither (midweek classes, special events) returns None and does not fill a
+    Sunday slot.
+    """
+    if not service_name:
+        return None
+    lowered = service_name.lower()
+    if "morning" in lowered or _AM_RE.search(service_name):
+        return SLOT_MORNING
+    if "evening" in lowered or _PM_RE.search(service_name):
+        return SLOT_EVENING
+    return None
+
+
+def normalize_window_days(days: int | str | None) -> int:
+    """Coerce a requested window to a supported size, falling back to the default."""
+    try:
+        key = str(int(days))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return DEFAULT_WINDOW_DAYS
+    return int(key) if key in WINDOW_OPTIONS else DEFAULT_WINDOW_DAYS
+
+
+def resolve_window(days: int, today: date) -> tuple[str, str]:
+    """Return (start_iso, end_iso) for *days* back from *today*, clamped to floor.
+
+    The start never precedes ``get_data_collection_start()`` so the report does
+    not flag "gaps" from before data collection began.
+    """
+    start = today - timedelta(days=days)
+    floor = get_data_collection_start()
+    if start < floor:
+        start = floor
+    return start.isoformat(), today.isoformat()
+
+
+def sundays_in_range(start: date, end: date) -> list[date]:
+    """List every Sunday in the inclusive ``[start, end]`` range, ascending."""
+    offset = (6 - start.weekday()) % 7  # weekday(): Mon=0 .. Sun=6
+    first_sunday = start + timedelta(days=offset)
+    out: list[date] = []
+    current = first_sunday
+    while current <= end:
+        out.append(current)
+        current += timedelta(days=7)
+    return out

--- a/src/worship_catalog/services/missing_services_report.py
+++ b/src/worship_catalog/services/missing_services_report.py
@@ -1,0 +1,105 @@
+"""Missing-services report computation (#480).
+
+Identifies which expected Sunday morning/evening services are absent from the
+database over a lookback window, distinguishing genuine gaps from slots that
+have been intentionally marked excluded.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from worship_catalog.db import Database
+from worship_catalog.service_slots import (
+    EXPECTED_SLOTS,
+    WINDOW_OPTIONS,
+    classify_service_slot,
+    get_data_collection_start,
+    normalize_window_days,
+    resolve_window,
+    sundays_in_range,
+)
+
+STATUS_PRESENT: str = "present"
+STATUS_MISSING: str = "missing"
+STATUS_EXCLUDED: str = "excluded"
+
+
+def compute_missing_services(
+    db: Database, days: int, today: date
+) -> dict[str, Any]:
+    """Compute the missing-services report for *days* back from *today*.
+
+    *today* is injected (not read from the clock) so the result is deterministic
+    and testable. Returns a dict consumed by the HTML partial and JSON API:
+
+      - window_days / window_label: the resolved lookback selection
+      - start_date / end_date / collection_start: ISO date bounds
+      - weeks: newest-first list of ``{date, slots, has_missing}`` where each
+        slot is ``{slot, status, service, reason}``
+      - uncategorized: in-range services whose name maps to no slot
+      - summary: counts (sundays, expected, present, missing, excluded,
+        uncategorized)
+    """
+    days = normalize_window_days(days)
+    start_str, end_str = resolve_window(days, today)
+    start = date.fromisoformat(start_str)
+    end = date.fromisoformat(end_str)
+
+    # Build a (date, slot) -> service map for everything stored in range.
+    present: dict[tuple[str, str], dict[str, Any]] = {}
+    uncategorized: list[dict[str, Any]] = []
+    for svc in db.query_services(start_str, end_str):
+        slot = classify_service_slot(svc.get("service_name"))
+        if slot is None:
+            uncategorized.append(svc)
+            continue
+        present[(svc["service_date"], slot)] = svc
+
+    exclusions = {
+        (e["service_date"], e["service_slot"]): e.get("reason")
+        for e in db.query_exclusions(start_str, end_str)
+    }
+
+    counts = {STATUS_PRESENT: 0, STATUS_MISSING: 0, STATUS_EXCLUDED: 0}
+    weeks: list[dict[str, Any]] = []
+    for sunday in sundays_in_range(start, end):
+        iso = sunday.isoformat()
+        slots: list[dict[str, Any]] = []
+        has_missing = False
+        for slot in EXPECTED_SLOTS:
+            key = (iso, slot)
+            if key in present:
+                status, service, reason = STATUS_PRESENT, present[key], None
+            elif key in exclusions:
+                status, service, reason = STATUS_EXCLUDED, None, exclusions[key]
+            else:
+                status, service, reason = STATUS_MISSING, None, None
+                has_missing = True
+            counts[status] += 1
+            slots.append(
+                {"slot": slot, "status": status, "service": service, "reason": reason}
+            )
+        weeks.append({"date": iso, "slots": slots, "has_missing": has_missing})
+
+    weeks.reverse()  # newest Sunday first — most actionable at the top
+
+    sundays_count = len(weeks)
+    return {
+        "window_days": days,
+        "window_label": WINDOW_OPTIONS[str(days)],
+        "start_date": start_str,
+        "end_date": end_str,
+        "collection_start": get_data_collection_start().isoformat(),
+        "weeks": weeks,
+        "uncategorized": uncategorized,
+        "summary": {
+            "sundays": sundays_count,
+            "expected": sundays_count * len(EXPECTED_SLOTS),
+            "present": counts[STATUS_PRESENT],
+            "missing": counts[STATUS_MISSING],
+            "excluded": counts[STATUS_EXCLUDED],
+            "uncategorized": len(uncategorized),
+        },
+    }

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -45,6 +45,12 @@ from worship_catalog.import_service import run_import
 from worship_catalog.log_config import RequestLoggingMiddleware
 from worship_catalog.log_config import setup as _setup_logging
 from worship_catalog.notify import send_pushover
+from worship_catalog.service_slots import (
+    DEFAULT_WINDOW_DAYS,
+    VALID_SLOTS,
+    WINDOW_OPTIONS,
+)
+from worship_catalog.services.missing_services_report import compute_missing_services
 from worship_catalog.services.report_service import compute_stats_data
 from worship_catalog.web.csrf import SelfHealingCSRFMiddleware
 
@@ -621,7 +627,14 @@ async def songs(
 
 @app.get("/reports", response_class=HTMLResponse)
 async def reports_page(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse(request, "reports.html")
+    return templates.TemplateResponse(
+        request,
+        "reports.html",
+        {
+            "window_options": WINDOW_OPTIONS,
+            "default_window": str(DEFAULT_WINDOW_DAYS),
+        },
+    )
 
 
 @app.get("/about", response_class=HTMLResponse)
@@ -832,6 +845,98 @@ async def reports_ccli_csv(
         iter([output.getvalue()]),
         media_type="text/csv",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+def _missing_services_context(db: Database, days: int) -> dict[str, Any]:
+    """Compute the report for *days* back from today, plus selector context."""
+    data = compute_missing_services(db, days, date.today())
+    data["window_options"] = WINDOW_OPTIONS
+    return data
+
+
+def _validate_exclusion_input(service_date: str, service_slot: str) -> None:
+    """Raise HTTPException 422 for a bad exclusion date or slot."""
+    if not _DATE_RE.match(service_date):
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid service_date: '{service_date}' — expected YYYY-MM-DD",
+        )
+    try:
+        date.fromisoformat(service_date)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid service_date: '{service_date}' — not a real calendar date",
+        ) from exc
+    if service_slot not in VALID_SLOTS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid service_slot: '{service_slot}' — expected one of "
+            f"{sorted(VALID_SLOTS)}",
+        )
+
+
+@app.get("/reports/missing-services", response_class=HTMLResponse)
+async def missing_services_report(
+    request: Request,
+    days: int = Query(default=DEFAULT_WINDOW_DAYS),
+    db: Database = Depends(get_db),  # noqa: B008
+    _rl: None = Depends(_report_rate_limit),  # noqa: B008
+) -> HTMLResponse:
+    """Report Sunday morning/evening services absent from the DB (#480)."""
+    ctx = _missing_services_context(db, days)
+    # HTMX swaps just the result region; a full navigation renders the page.
+    template = (
+        "_missing_services_result.html"
+        if request.headers.get("HX-Request")
+        else "missing_services.html"
+    )
+    return templates.TemplateResponse(request, template, ctx)
+
+
+@app.get("/reports/missing-services.json")
+async def missing_services_report_json(
+    days: int = Query(default=DEFAULT_WINDOW_DAYS),
+    db: Database = Depends(get_db),  # noqa: B008
+    _rl: None = Depends(_report_rate_limit),  # noqa: B008
+) -> JSONResponse:
+    """JSON view of the missing-services report for automation/reuse (#480)."""
+    return JSONResponse(content=_missing_services_context(db, days))
+
+
+@app.post("/reports/missing-services/exclude", response_class=HTMLResponse)
+async def missing_services_exclude(
+    request: Request,
+    service_date: str = Form(...),
+    service_slot: str = Form(...),
+    reason: str = Form(default=""),
+    days: int = Form(default=DEFAULT_WINDOW_DAYS),
+    db: Database = Depends(get_db),  # noqa: B008
+    _rl: None = Depends(_report_rate_limit),  # noqa: B008
+) -> HTMLResponse:
+    """Mark a missing slot as intentionally excluded, then re-render (#480)."""
+    _validate_exclusion_input(service_date, service_slot)
+    db.add_exclusion(service_date, service_slot, reason=reason or None)
+    return templates.TemplateResponse(
+        request, "_missing_services_result.html", _missing_services_context(db, days)
+    )
+
+
+@app.post("/reports/missing-services/include", response_class=HTMLResponse)
+async def missing_services_include(
+    request: Request,
+    service_date: str = Form(...),
+    service_slot: str = Form(...),
+    days: int = Form(default=DEFAULT_WINDOW_DAYS),
+    db: Database = Depends(get_db),  # noqa: B008
+    _rl: None = Depends(_report_rate_limit),  # noqa: B008
+) -> HTMLResponse:
+    """Remove an intentional-exclusion marker, then re-render (#480)."""
+    _validate_exclusion_input(service_date, service_slot)
+    db.remove_exclusion(service_date, service_slot)
+    return templates.TemplateResponse(
+        request, "_missing_services_result.html", _missing_services_context(db, days)
     )
 
 

--- a/src/worship_catalog/web/templates/_missing_services_result.html
+++ b/src/worship_catalog/web/templates/_missing_services_result.html
@@ -1,0 +1,83 @@
+<div class="summary-grid">
+  <div class="stat-box">
+    <div class="val">{{ summary.sundays }}</div>
+    <div class="lbl">Sundays</div>
+  </div>
+  <div class="stat-box">
+    <div class="val" style="color:#198754;">{{ summary.present }}</div>
+    <div class="lbl">Present</div>
+  </div>
+  <div class="stat-box">
+    <div class="val" style="color:#b02a37;">{{ summary.missing }}</div>
+    <div class="lbl">Missing</div>
+  </div>
+  <div class="stat-box">
+    <div class="val" style="color:#6c757d;">{{ summary.excluded }}</div>
+    <div class="lbl">Excluded</div>
+  </div>
+</div>
+
+<p style="font-size:0.85rem;color:#6c757d;margin:0.5rem 0 1rem;">
+  Showing <strong>{{ window_label }}</strong> ({{ start_date }} &rarr; {{ end_date }}).
+  Data collection began {{ collection_start }}; nothing earlier is reported.
+</p>
+
+{% if summary.uncategorized %}
+<p style="font-size:0.8rem;color:#664d03;background:#fff3cd;border:1px solid #ffecb5;border-radius:6px;padding:0.5rem 0.75rem;">
+  {{ summary.uncategorized }} service{{ 's' if summary.uncategorized != 1 else '' }} in this range
+  could not be classified as morning or evening and {{ 'are' if summary.uncategorized != 1 else 'is' }}
+  not counted toward a Sunday slot.
+</p>
+{% endif %}
+
+{% if not weeks %}
+<p style="color:#6c757d;">No Sundays fall within this window.</p>
+{% else %}
+<div class="table-wrap">
+<table>
+  <caption class="sr-only">Sunday morning and evening services present, missing, or intentionally excluded</caption>
+  <thead>
+    <tr>
+      <th scope="col">Sunday</th>
+      <th scope="col">Morning</th>
+      <th scope="col">Evening</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for week in weeks %}
+    <tr>
+      <td style="white-space:nowrap;{% if week.has_missing %}font-weight:600;{% endif %}">{{ week.date }}</td>
+      {% for slot in week.slots %}
+      <td>
+        {% if slot.status == 'present' %}
+          <span style="color:#198754;" title="{{ slot.service.service_name }}">&#10003; Present</span>
+        {% elif slot.status == 'excluded' %}
+          <span style="color:#6c757d;">Excluded{% if slot.reason %} &mdash; {{ slot.reason }}{% endif %}</span>
+          <form hx-post="/reports/missing-services/include" hx-target="#missing-result"
+                hx-swap="innerHTML" style="display:inline;margin-left:0.4rem;">
+            <input type="hidden" name="service_date" value="{{ week.date }}">
+            <input type="hidden" name="service_slot" value="{{ slot.slot }}">
+            <input type="hidden" name="days" value="{{ window_days }}">
+            <button type="submit" style="background:none;border:none;color:#0d6efd;cursor:pointer;padding:0;font-size:0.8rem;text-decoration:underline;">Unmark</button>
+          </form>
+        {% else %}
+          <span style="color:#b02a37;font-weight:600;">Missing</span>
+          <form hx-post="/reports/missing-services/exclude" hx-target="#missing-result"
+                hx-swap="innerHTML" style="display:inline-flex;gap:0.3rem;margin-left:0.4rem;align-items:center;">
+            <input type="hidden" name="service_date" value="{{ week.date }}">
+            <input type="hidden" name="service_slot" value="{{ slot.slot }}">
+            <input type="hidden" name="days" value="{{ window_days }}">
+            <input type="text" name="reason" placeholder="reason (optional)"
+                   aria-label="Reason for excluding {{ week.date }} {{ slot.slot }}"
+                   style="font-size:0.75rem;padding:0.15rem 0.3rem;max-width:150px;">
+            <button type="submit" style="font-size:0.75rem;padding:0.15rem 0.5rem;">Mark excluded</button>
+          </form>
+        {% endif %}
+      </td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+</div>
+{% endif %}

--- a/src/worship_catalog/web/templates/missing_services.html
+++ b/src/worship_catalog/web/templates/missing_services.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Missing Services — Highland Worship Catalog{% endblock %}
+{% block content %}
+<h1>Missing Services</h1>
+<p style="font-size:0.9rem;color:#495057;max-width:48rem;">
+  Sundays normally have both a morning and an evening worship service. This report
+  lists the slots with no service in the catalog over the selected time frame, and
+  lets you mark intentional gaps as excluded.
+</p>
+
+<div class="card">
+  <form id="missing-form" style="margin-bottom:1rem;">
+    <label for="missing-window" style="font-size:0.85rem;font-weight:600;color:#495057;margin-right:0.5rem;">Time frame</label>
+    <select id="missing-window" name="days"
+            hx-get="/reports/missing-services"
+            hx-trigger="change"
+            hx-target="#missing-result"
+            hx-swap="innerHTML"
+            hx-indicator="#missing-spinner">
+      {% for value, label in window_options.items() %}
+      <option value="{{ value }}"{% if value == window_days|string %} selected{% endif %}>{{ label }}</option>
+      {% endfor %}
+    </select>
+    <span id="missing-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
+  </form>
+  <div id="missing-result" aria-live="polite">{% include "_missing_services_result.html" %}</div>
+</div>
+<script src="/static/reports.js"></script>
+{% endblock %}

--- a/src/worship_catalog/web/templates/reports.html
+++ b/src/worship_catalog/web/templates/reports.html
@@ -8,6 +8,8 @@
           aria-controls="panel-stats" aria-selected="true">Song Statistics</button>
   <button type="button" class="tab" role="tab" id="tab-ccli"
           aria-controls="panel-ccli" aria-selected="false" tabindex="-1">CCLI Compliance</button>
+  <button type="button" class="tab" role="tab" id="tab-missing"
+          aria-controls="panel-missing" aria-selected="false" tabindex="-1">Missing Services</button>
 </div>
 
 <!-- Song Statistics (default tab) -->
@@ -83,6 +85,32 @@
       </div>
     </form>
     <div id="ccli-result" style="margin-top:0.5rem;"></div>
+  </div>
+</section>
+
+<!-- Missing Services (tertiary tab) -->
+<section role="tabpanel" id="panel-missing" aria-labelledby="tab-missing" tabindex="0" hidden>
+  <div class="card">
+    <h2>Missing Services <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(view in browser)</small></h2>
+    <p style="font-size:0.85rem;color:#495057;margin-bottom:0.75rem;">
+      Sundays normally have a morning and an evening service. This lists slots with no
+      service in the catalog over the selected time frame; mark intentional gaps as excluded.
+    </p>
+    <form id="missing-form" style="margin-bottom:0.75rem;">
+      <label for="missing-window" style="font-size:0.8rem;font-weight:600;color:#495057;margin-right:0.5rem;">Time frame</label>
+      <select id="missing-window" name="days"
+              hx-get="/reports/missing-services"
+              hx-trigger="load, change"
+              hx-target="#missing-result"
+              hx-swap="innerHTML"
+              hx-indicator="#missing-spinner">
+        {% for value, label in window_options.items() %}
+        <option value="{{ value }}"{% if value == default_window %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+      <span id="missing-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
+    </form>
+    <div id="missing-result" style="margin-top:0.5rem;" aria-live="polite"></div>
   </div>
 </section>
 <script src="/static/reports.js"></script>

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2358,7 +2358,7 @@ class TestDatabaseIndexes:
         cursor = temp_db.cursor()
         cursor.execute("PRAGMA user_version")
         assert cursor.fetchone()[0] == _SCHEMA_VERSION
-        assert _SCHEMA_VERSION == 4  # bumped for NULL-safe unique indexes (#420)
+        assert _SCHEMA_VERSION == 6  # bumped for service_exclusions table (#480)
 
 
 @pytest.mark.integration
@@ -3136,3 +3136,55 @@ class TestMigrationV4NullSafeUnique:
         )
         assert cur.fetchone()[0] == 1, "duplicate NULL-edition copy_events must be collapsed"
         db.close()
+
+
+@pytest.mark.integration
+class TestServiceExclusions:
+    """Tests for the service_exclusions table and CRUD helpers (#480)."""
+
+    @pytest.fixture
+    def temp_db(self):
+        with TemporaryDirectory() as tmpdir:
+            db = Database(Path(tmpdir) / "test.db")
+            db.connect()
+            db.init_schema()
+            yield db
+            db.close()
+
+    def test_exclusions_table_created(self, temp_db):
+        cursor = temp_db.conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = [row[0] for row in cursor.fetchall()]
+        assert "service_exclusions" in tables
+
+    def test_add_and_query_exclusion(self, temp_db):
+        temp_db.add_exclusion("2026-06-14", "evening", reason="Fellowship meal")
+        rows = temp_db.query_exclusions("2026-06-01", "2026-06-30")
+        assert len(rows) == 1
+        assert rows[0]["service_date"] == "2026-06-14"
+        assert rows[0]["service_slot"] == "evening"
+        assert rows[0]["reason"] == "Fellowship meal"
+        assert rows[0]["excluded_at"]  # timestamp recorded
+
+    def test_add_exclusion_normalizes_date(self, temp_db):
+        temp_db.add_exclusion("2026.6.14", "morning")
+        rows = temp_db.query_exclusions("2026-06-01", "2026-06-30")
+        assert rows[0]["service_date"] == "2026-06-14"
+
+    def test_add_exclusion_upserts_on_conflict(self, temp_db):
+        temp_db.add_exclusion("2026-06-14", "evening", reason="first")
+        temp_db.add_exclusion("2026-06-14", "evening", reason="second")
+        rows = temp_db.query_exclusions("2026-06-01", "2026-06-30")
+        assert len(rows) == 1  # UNIQUE(date, slot) — updated, not duplicated
+        assert rows[0]["reason"] == "second"
+
+    def test_remove_exclusion(self, temp_db):
+        temp_db.add_exclusion("2026-06-14", "evening", reason="x")
+        temp_db.remove_exclusion("2026-06-14", "evening")
+        assert temp_db.query_exclusions("2026-06-01", "2026-06-30") == []
+
+    def test_query_exclusions_respects_range(self, temp_db):
+        temp_db.add_exclusion("2026-03-01", "morning")
+        temp_db.add_exclusion("2026-09-06", "evening")
+        rows = temp_db.query_exclusions("2026-06-01", "2026-06-30")
+        assert rows == []

--- a/tests/test_missing_services_report.py
+++ b/tests/test_missing_services_report.py
@@ -1,0 +1,150 @@
+"""Unit tests for the missing-services report (slot classifier + compute)."""
+
+from datetime import date, timedelta
+
+import pytest
+
+from worship_catalog.db import Database
+from worship_catalog.service_slots import (
+    DEFAULT_WINDOW_DAYS,
+    SLOT_EVENING,
+    SLOT_MORNING,
+    classify_service_slot,
+    get_data_collection_start,
+    normalize_window_days,
+    resolve_window,
+)
+from worship_catalog.services.missing_services_report import compute_missing_services
+
+# A known Sunday used as a deterministic "today" so the window math is stable.
+SUNDAY_TODAY = date(2026, 6, 21)
+COLLECTION_START = date(2026, 3, 1)  # first Sunday in March 2026
+
+
+def _make_db(tmp_path):
+    db = Database(tmp_path / "missing.db")
+    db.connect()
+    db.init_schema()
+    return db
+
+
+def _add_service(db, service_date: str, service_name: str) -> int:
+    return db.insert_or_update_service(
+        service_date=service_date,
+        service_name=service_name,
+        source_file="x.pptx",
+        source_hash=f"hash-{service_date}-{service_name}",
+    )
+
+
+class TestClassifyServiceSlot:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("Morning Worship", SLOT_MORNING),
+            ("Evening Worship", SLOT_EVENING),
+            ("AM Worship", SLOT_MORNING),
+            ("PM Worship", SLOT_EVENING),
+            ("Sunday AM", SLOT_MORNING),
+            ("Sunday PM", SLOT_EVENING),
+            ("morning service", SLOT_MORNING),
+            ("Wednesday Bible Class", None),
+            ("", None),
+            (None, None),
+        ],
+    )
+    def test_classification(self, name, expected):
+        assert classify_service_slot(name) == expected
+
+    def test_am_not_matched_inside_words(self):
+        # "am"/"pm" must be whole-word, not substrings of unrelated words.
+        assert classify_service_slot("Sermon Camp") is None
+
+
+class TestWindowResolution:
+    def test_default_window_constant(self):
+        assert DEFAULT_WINDOW_DAYS == 90
+
+    def test_collection_start_is_first_sunday_in_march(self):
+        start = get_data_collection_start()
+        assert start == COLLECTION_START
+        assert start.weekday() == 6  # Sunday
+
+    def test_90_day_window_start_is_today_minus_90(self):
+        start_str, end_str = resolve_window(90, SUNDAY_TODAY)
+        assert end_str == SUNDAY_TODAY.isoformat()
+        assert start_str == (SUNDAY_TODAY - timedelta(days=90)).isoformat()
+
+    def test_long_window_clamps_to_collection_start(self):
+        start_str, end_str = resolve_window(730, SUNDAY_TODAY)
+        # 2 years back is well before data collection began — clamp to the floor.
+        assert start_str == COLLECTION_START.isoformat()
+        assert end_str == SUNDAY_TODAY.isoformat()
+
+    @pytest.mark.parametrize(
+        "given,expected",
+        [("90", 90), ("180", 180), (365, 365), (730, 730), ("999", 90), (None, 90), ("x", 90)],
+    )
+    def test_normalize_window_days(self, given, expected):
+        assert normalize_window_days(given) == expected
+
+
+class TestComputeMissingServices:
+    @pytest.mark.integration
+    def test_long_window_first_week_is_collection_start(self, tmp_path):
+        db = _make_db(tmp_path)
+        data = compute_missing_services(db, days=730, today=SUNDAY_TODAY)
+        db.close()
+        # Weeks are newest-first; the earliest (last) week is the collection start.
+        assert data["weeks"][-1]["date"] == COLLECTION_START.isoformat()
+        assert data["start_date"] == COLLECTION_START.isoformat()
+
+    @pytest.mark.integration
+    def test_all_sundays_missing_when_db_empty(self, tmp_path):
+        db = _make_db(tmp_path)
+        data = compute_missing_services(db, days=90, today=SUNDAY_TODAY)
+        db.close()
+        summary = data["summary"]
+        # Every Sunday slot is missing; present/excluded are zero.
+        assert summary["present"] == 0
+        assert summary["excluded"] == 0
+        assert summary["missing"] == summary["expected"]
+        assert summary["expected"] == summary["sundays"] * 2
+
+    @pytest.mark.integration
+    def test_per_slot_present_missing_and_excluded(self, tmp_path):
+        db = _make_db(tmp_path)
+        # 2026-06-14 is the Sunday before our 'today'. Add only the morning service.
+        sunday = "2026-06-14"
+        _add_service(db, sunday, "Morning Worship")
+        # Mark that Sunday's evening as intentionally excluded.
+        db.add_exclusion(sunday, SLOT_EVENING, reason="No evening service (fellowship meal)")
+
+        data = compute_missing_services(db, days=90, today=SUNDAY_TODAY)
+        db.close()
+
+        week = next(w for w in data["weeks"] if w["date"] == sunday)
+        slots = {s["slot"]: s for s in week["slots"]}
+        assert slots[SLOT_MORNING]["status"] == "present"
+        assert slots[SLOT_MORNING]["service"]["service_name"] == "Morning Worship"
+        assert slots[SLOT_EVENING]["status"] == "excluded"
+        assert slots[SLOT_EVENING]["reason"] == "No evening service (fellowship meal)"
+
+    @pytest.mark.integration
+    def test_uncategorized_service_is_surfaced_not_counted_as_present(self, tmp_path):
+        db = _make_db(tmp_path)
+        # A midweek service on a Sunday-less slot name — cannot fill a Sunday slot.
+        _add_service(db, "2026-06-17", "Wednesday Bible Class")
+        data = compute_missing_services(db, days=90, today=SUNDAY_TODAY)
+        db.close()
+        assert data["summary"]["uncategorized"] == 1
+        assert data["summary"]["present"] == 0
+
+    @pytest.mark.integration
+    def test_window_metadata_present(self, tmp_path):
+        db = _make_db(tmp_path)
+        data = compute_missing_services(db, days=180, today=SUNDAY_TODAY)
+        db.close()
+        assert data["window_days"] == 180
+        assert data["window_label"] == "Last 180 days"
+        assert data["end_date"] == SUNDAY_TODAY.isoformat()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -128,6 +128,93 @@ class TestReportsPage:
         assert "/reports/stats" in response.text
 
 
+class TestMissingServicesReport:
+    """Missing-services report: HTML page, HTMX partial, JSON API, exclude toggle."""
+
+    def test_reports_page_has_missing_services_tab(self, client):
+        body = client.get("/reports").text
+        assert "Missing Services" in body
+        assert "/reports/missing-services" in body
+
+    def test_window_selector_offers_all_options(self, client):
+        body = client.get("/reports").text
+        # 90 / 180 / 1 year / 2 years selectable windows.
+        for label in ("Last 90 days", "Last 180 days", "Last 1 year", "Last 2 years"):
+            assert label in body
+
+    def test_get_report_returns_full_page(self, client):
+        resp = client.get("/reports/missing-services")
+        assert resp.status_code == 200
+        assert "text/html" in resp.headers["content-type"]
+        assert "<!doctype" in resp.text.lower() or "<html" in resp.text.lower()
+
+    def test_get_report_htmx_returns_partial(self, client):
+        resp = client.get("/reports/missing-services", headers={"HX-Request": "true"})
+        assert resp.status_code == 200
+        lowered = resp.text.lower()
+        assert "<!doctype" not in lowered
+        assert "<html" not in lowered
+
+    def test_json_endpoint_shape(self, client):
+        data = client.get("/reports/missing-services.json").json()
+        for key in ("window_days", "start_date", "end_date", "weeks", "summary"):
+            assert key in data
+        assert data["window_days"] == 90  # default window
+
+    def test_json_respects_days_param(self, client):
+        data = client.get("/reports/missing-services.json?days=180").json()
+        assert data["window_days"] == 180
+
+    def test_json_invalid_days_falls_back_to_default(self, client):
+        data = client.get("/reports/missing-services.json?days=9999").json()
+        assert data["window_days"] == 90
+
+    def test_post_exclude_marks_slot(self, client, db_with_songs):
+        resp = client.post(
+            "/reports/missing-services/exclude",
+            data={"service_date": "2026-06-14", "service_slot": "evening",
+                  "reason": "Fellowship", "days": "90"},
+        )
+        assert resp.status_code == 200
+        db = Database(db_with_songs)
+        db.connect()
+        rows = db.query_exclusions("2026-06-01", "2026-06-30")
+        db.close()
+        assert len(rows) == 1
+        assert rows[0]["service_slot"] == "evening"
+        assert rows[0]["reason"] == "Fellowship"
+
+    def test_post_include_removes_exclusion(self, client, db_with_songs):
+        client.post(
+            "/reports/missing-services/exclude",
+            data={"service_date": "2026-06-14", "service_slot": "evening", "days": "90"},
+        )
+        resp = client.post(
+            "/reports/missing-services/include",
+            data={"service_date": "2026-06-14", "service_slot": "evening", "days": "90"},
+        )
+        assert resp.status_code == 200
+        db = Database(db_with_songs)
+        db.connect()
+        rows = db.query_exclusions("2026-06-01", "2026-06-30")
+        db.close()
+        assert rows == []
+
+    def test_post_exclude_rejects_invalid_slot(self, client):
+        resp = client.post(
+            "/reports/missing-services/exclude",
+            data={"service_date": "2026-06-14", "service_slot": "noon", "days": "90"},
+        )
+        assert resp.status_code == 422
+
+    def test_post_exclude_rejects_invalid_date(self, client):
+        resp = client.post(
+            "/reports/missing-services/exclude",
+            data={"service_date": "not-a-date", "service_slot": "evening", "days": "90"},
+        )
+        assert resp.status_code == 422
+
+
 class TestReportsTabs:
     """Reports page is tabbed: Song Statistics primary/default, CCLI secondary (#390)."""
 


### PR DESCRIPTION
Closes #480.

## What
Adds a **Missing Services** report that identifies which expected Sunday worship services are absent from the catalog over a selectable lookback window, and lets users mark intentional gaps as excluded.

- **Default 90-day window**, with selector for **180 days / 1 year / 2 years**.
- **Per-slot** detection — morning and evening tracked independently (a Sunday can show "morning present, evening missing").
- **Floor at the first Sunday of March 2026** (`2026-03-01`, configurable via `DATA_COLLECTION_START`) — never reports gaps before data collection began.
- **Intentional exclusions** persisted in a new `service_exclusions` table; marked slots render as excluded (with reason) rather than missing, and can be un-marked.
- Surfaced as an **HTML report** (new tab in `/reports`, HTMX partial) **and a JSON API** (`/reports/missing-services.json`).

## Slot classification
`classify_service_slot()` maps `"Morning Worship"`/`"Evening Worship"` (production) and `"AM Worship"`/`"PM Worship"` (older data) to slots; unclassifiable services (midweek/special) are surfaced as a count, not counted toward a Sunday slot.

## Changes
| Area | Files |
|---|---|
| DB | `db.py` — migration 6 (`service_exclusions`), `_SCHEMA_VERSION`→6, `add_exclusion`/`remove_exclusion`/`query_exclusions` |
| Logic | `service_slots.py`, `services/missing_services_report.py` |
| Web | `web/app.py` — GET page+partial, GET `.json`, CSRF-protected POST exclude/include |
| Templates | `reports.html` (tab), `missing_services.html`, `_missing_services_result.html` |
| Config | `.env.example` — `DATA_COLLECTION_START` |

## Validation
- `python3 -m pytest -m "not e2e"` → **1256 passed, 9 skipped** (e2e require a running server; covered in CI).
- `ruff check src/` and `mypy src/` → clean.
- New tests: `tests/test_missing_services_report.py` (unit), `tests/test_db_integration.py::TestServiceExclusions`, `tests/test_web.py::TestMissingServicesReport`.
- Manual smoke against a live server confirmed: window clamping, present/missing/excluded statuses, exclude→include toggle persistence, and 422 on invalid slot/date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)