### PR TITLE
docs: allow auto-merge after green CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,17 @@ CI config changes and documentation-only changes are exempt, but any change touc
 5. Run linter: python3 -m ruff check src/
 6. Run type check: python3 -m mypy src/
 7. Run QA agents (see below)
-8. Commit and push to the agent branch (do not merge to main — open a PR for review)
-9. Confirm CI passes before closing the issue
+8. Commit and push to the agent branch, then open a PR
+9. Confirm CI passes (test, e2e, security), then merge the PR — auto-merge is OK
+   once all required checks are green. Branch protection requires the head to be
+   up to date with main, so `gh pr update-branch <n>` before merging if needed.
+   Leave a PR unmerged for review only when the change is risky/ambiguous, checks
+   fail, or Matt asked for review.
 ```
+
+> **Merge policy:** auto-merge after green CI is the default (Matt, 2026-06-21).
+> Always go through a PR (never push straight to `main`) so CI runs, but you may
+> merge your own green PR rather than waiting for manual review.
 
 ## Agent Workflow
 


### PR DESCRIPTION
Updates the Development Workflow so merging your own PR after green CI (test/e2e/security) is the default, instead of leaving it for manual review. Still always via a PR — never a direct push to main. Per Matt's instruction (2026-06-21). Docs-only (TDD-exempt).