### PR TITLE
fix: harden missing-services (US dates, auth-gated exclusions, auto-clear) (#483)

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from worship_catalog.normalize import normalize_service_date
+from worship_catalog.service_slots import classify_service_slot
 
 _log = logging.getLogger("worship_catalog.db")
 
@@ -633,7 +634,15 @@ class Database:
         preacher: str | None = None,
         sermon_title: str | None = None,
     ) -> int:
-        """Insert or update service. Returns service_id."""
+        """Insert or update service. Returns service_id.
+
+        ``service_date`` is canonicalized to ISO ``YYYY-MM-DD`` at this write
+        boundary (#483) so non-ISO input (e.g. US ``05-31-2026``) can never be
+        stored — un-normalized dates sort outside ISO ranges and silently vanish
+        from every date-range report. ``normalize_service_dates()`` remains for
+        cleaning up legacy rows written before this guard existed.
+        """
+        service_date = normalize_service_date(service_date) or service_date
         cursor = self._conn.cursor()
 
         # Look up by (date, name) only — the unique constraint is now on these two
@@ -684,6 +693,17 @@ class Database:
                 ),
             )
             service_id = cursor.lastrowid
+
+        # A real service now exists for this Sunday slot, so any prior
+        # "intentionally excluded" marker is obsolete — clear it so a real
+        # import cleanly supersedes a manual exclude and the marker can't
+        # resurface if the service is later deleted (#483).
+        slot = classify_service_slot(service_name)
+        if slot is not None:
+            cursor.execute(
+                "DELETE FROM service_exclusions WHERE service_date = ? AND service_slot = ?",
+                (service_date, slot),  # already normalized to ISO above
+            )
 
         self._maybe_commit()
         return service_id

--- a/src/worship_catalog/normalize.py
+++ b/src/worship_catalog/normalize.py
@@ -1,6 +1,10 @@
 """Title normalization, candidate selection, and credit parsing."""
 
+import logging
 import re
+from datetime import date
+
+_log = logging.getLogger("worship_catalog.normalize")
 
 # Lines longer than this are considered lyrics, not titles
 _TITLE_MAX_LENGTH: int = 120
@@ -81,17 +85,31 @@ def _normalize_whitespace(text: str) -> str:
     return ' '.join(text.split()).strip()
 
 
-# Year-month-day with ., - or / separators and single-or-double-digit month/day.
+# Year-first: ., - or / separators and single-or-double-digit month/day.
 _DATE_PARTS_RE = re.compile(r"^(\d{4})[.\-/](\d{1,2})[.\-/](\d{1,2})$")
+# US month-first: M-D-YYYY (Highland is a US congregation). Year is last, so
+# this never overlaps the year-first pattern above. (#483)
+_US_DATE_RE = re.compile(r"^(\d{1,2})[.\-/](\d{1,2})[.\-/](\d{4})$")
+
+
+def _iso_or_passthrough(year: str, month: str, day: str, original: str) -> str:
+    """Build an ISO date from parts, or return *original* (logged) if invalid."""
+    try:
+        return date(int(year), int(month), int(day)).isoformat()
+    except ValueError:
+        _log.warning("Service date is not a real calendar date; storing as-is: %r", original)
+        return original
 
 
 def normalize_service_date(raw: str | None) -> str | None:
     """Canonicalize a service date string to ISO ``YYYY-MM-DD``.
 
-    Accepts any mix of ``.``, ``-`` and ``/`` separators and single-digit
-    month/day (e.g. ``2026.5.10`` → ``2026-05-10``). Returns None for empty
-    input, and the stripped original for anything that isn't a recognizable
-    year-month-day triple (so we never silently drop an unexpected value).
+    Accepts year-first (``2026.5.10`` → ``2026-05-10``) and US month-first
+    (``05-31-2026`` → ``2026-05-31``) with any mix of ``.``, ``-`` and ``/``
+    separators and single-digit month/day. Returns None for empty input. For
+    anything that matches no known shape — or matches but isn't a real calendar
+    date — the stripped original is returned **and a warning is logged**, so a
+    bad value surfaces instead of silently breaking date-range queries (#483).
 
     Lives here (not in pptx_reader) so the data layer can normalize stored dates
     without importing the PPTX-parsing layer (#399).
@@ -102,10 +120,15 @@ def normalize_service_date(raw: str | None) -> str | None:
     if not stripped:
         return None
     match = _DATE_PARTS_RE.match(stripped)
-    if not match:
-        return stripped
-    year, month, day = match.groups()
-    return f"{year}-{int(month):02d}-{int(day):02d}"
+    if match:
+        year, month, day = match.groups()
+        return _iso_or_passthrough(year, month, day, stripped)
+    match = _US_DATE_RE.match(stripped)
+    if match:
+        month, day, year = match.groups()
+        return _iso_or_passthrough(year, month, day, stripped)
+    _log.warning("Unrecognized service date format; storing as-is: %r", stripped)
+    return stripped
 
 
 def select_best_title(candidates: list[str]) -> str | None:

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -881,11 +881,22 @@ def _validate_exclusion_input(service_date: str, service_slot: str) -> None:
 async def missing_services_report(
     request: Request,
     days: int = Query(default=DEFAULT_WINDOW_DAYS),
+    login: bool = Query(default=False),
     db: Database = Depends(get_db),  # noqa: B008
     _rl: None = Depends(_report_rate_limit),  # noqa: B008
 ) -> HTMLResponse:
-    """Report Sunday morning/evening services absent from the DB (#480)."""
+    """Report Sunday morning/evening services absent from the DB (#480).
+
+    The page + JSON are always publicly readable; the exclude/include controls
+    render only for a viewer with valid upload credentials (#483). Visiting with
+    ``?login=1`` issues the Basic-auth challenge so a user can authenticate, then
+    the edit controls appear (the browser sends creds to this path thereafter).
+    """
+    authed = _upload_credentials_valid(request)
+    if login and not authed:
+        require_upload_auth(request)  # raises 401 challenge so the browser prompts
     ctx = _missing_services_context(db, days)
+    ctx["can_edit"] = authed
     # HTMX swaps just the result region; a full navigation renders the page.
     template = (
         "_missing_services_result.html"
@@ -915,12 +926,17 @@ async def missing_services_exclude(
     db: Database = Depends(get_db),  # noqa: B008
     _rl: None = Depends(_report_rate_limit),  # noqa: B008
 ) -> HTMLResponse:
-    """Mark a missing slot as intentionally excluded, then re-render (#480)."""
+    """Mark a missing slot as intentionally excluded, then re-render (#480).
+
+    Gated by the same upload auth that protects /upload (#483) — a write, not a
+    read, so it must not be publicly invokable.
+    """
+    require_upload_auth(request)
     _validate_exclusion_input(service_date, service_slot)
     db.add_exclusion(service_date, service_slot, reason=reason or None)
-    return templates.TemplateResponse(
-        request, "_missing_services_result.html", _missing_services_context(db, days)
-    )
+    ctx = _missing_services_context(db, days)
+    ctx["can_edit"] = True  # request is authenticated to have reached here
+    return templates.TemplateResponse(request, "_missing_services_result.html", ctx)
 
 
 @app.post("/reports/missing-services/include", response_class=HTMLResponse)
@@ -932,12 +948,16 @@ async def missing_services_include(
     db: Database = Depends(get_db),  # noqa: B008
     _rl: None = Depends(_report_rate_limit),  # noqa: B008
 ) -> HTMLResponse:
-    """Remove an intentional-exclusion marker, then re-render (#480)."""
+    """Remove an intentional-exclusion marker, then re-render (#480).
+
+    Gated by the same upload auth that protects /upload (#483).
+    """
+    require_upload_auth(request)
     _validate_exclusion_input(service_date, service_slot)
     db.remove_exclusion(service_date, service_slot)
-    return templates.TemplateResponse(
-        request, "_missing_services_result.html", _missing_services_context(db, days)
-    )
+    ctx = _missing_services_context(db, days)
+    ctx["can_edit"] = True
+    return templates.TemplateResponse(request, "_missing_services_result.html", ctx)
 
 
 @app.get("/songs/{song_id}", response_class=HTMLResponse)
@@ -1166,38 +1186,47 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
 _UPLOAD_USERNAME_DEFAULT = "highland"
 
 
-def require_upload_auth(request: Request) -> None:
-    """Gate the upload routes behind HTTP Basic Auth (#388).
+def _upload_credentials_valid(request: Request) -> bool:
+    """True when upload auth is satisfied for this request (non-raising).
 
-    Active only when ``UPLOAD_PASSWORD`` is set in the environment; when unset
-    the upload stays open (current behavior). The catalog browsing pages are
-    never gated — only write access (the upload form/endpoint).
+    Returns True when ``UPLOAD_PASSWORD`` is unset (auth disabled — open access,
+    current behavior) or when the request carries matching HTTP Basic
+    credentials. This is the companion to :func:`require_upload_auth`, used to
+    decide whether to render edit controls on an otherwise-public page (#483).
     """
     password = os.environ.get("UPLOAD_PASSWORD")
     if not password:
-        return
-
+        return True
     expected_user = os.environ.get("UPLOAD_USERNAME", _UPLOAD_USERNAME_DEFAULT)
-    unauthorized = HTTPException(
+    header = request.headers.get("Authorization", "")
+    scheme, _, encoded = header.partition(" ")
+    if scheme.lower() != "basic" or not encoded:
+        return False
+    try:
+        decoded = base64.b64decode(encoded).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return False
+    user, _, supplied = decoded.partition(":")
+    return secrets.compare_digest(user, expected_user) and secrets.compare_digest(
+        supplied, password
+    )
+
+
+def require_upload_auth(request: Request) -> None:
+    """Gate write routes behind HTTP Basic Auth (#388, #483).
+
+    Active only when ``UPLOAD_PASSWORD`` is set in the environment; when unset
+    the write stays open (current behavior). The catalog browsing/report pages
+    are never gated — only write access (upload + exclusion edits). The realm is
+    shared so a single login unlocks every write surface.
+    """
+    if _upload_credentials_valid(request):
+        return
+    raise HTTPException(
         status_code=401,
         detail="Authentication required to upload.",
         headers={"WWW-Authenticate": 'Basic realm="Highland Worship Catalog upload"'},
     )
-
-    header = request.headers.get("Authorization", "")
-    scheme, _, encoded = header.partition(" ")
-    if scheme.lower() != "basic" or not encoded:
-        raise unauthorized
-    try:
-        decoded = base64.b64decode(encoded).decode("utf-8")
-    except (ValueError, UnicodeDecodeError):
-        raise unauthorized from None
-    user, _, supplied = decoded.partition(":")
-
-    user_ok = secrets.compare_digest(user, expected_user)
-    pass_ok = secrets.compare_digest(supplied, password)
-    if not (user_ok and pass_ok):
-        raise unauthorized
 
 
 @app.get("/upload", response_class=HTMLResponse)

--- a/src/worship_catalog/web/templates/_missing_services_result.html
+++ b/src/worship_catalog/web/templates/_missing_services_result.html
@@ -22,6 +22,12 @@
   Data collection began {{ collection_start }}; nothing earlier is reported.
 </p>
 
+{% if not can_edit %}
+<p style="font-size:0.8rem;color:#6c757d;margin:-0.5rem 0 1rem;">
+  <a href="/reports/missing-services?login=1">Log in to edit</a> to mark services as intentionally excluded.
+</p>
+{% endif %}
+
 {% if summary.uncategorized %}
 <p style="font-size:0.8rem;color:#664d03;background:#fff3cd;border:1px solid #ffecb5;border-radius:6px;padding:0.5rem 0.75rem;">
   {{ summary.uncategorized }} service{{ 's' if summary.uncategorized != 1 else '' }} in this range
@@ -53,6 +59,7 @@
           <span style="color:#198754;" title="{{ slot.service.service_name }}">&#10003; Present</span>
         {% elif slot.status == 'excluded' %}
           <span style="color:#6c757d;">Excluded{% if slot.reason %} &mdash; {{ slot.reason }}{% endif %}</span>
+          {% if can_edit %}
           <form hx-post="/reports/missing-services/include" hx-target="#missing-result"
                 hx-swap="innerHTML" style="display:inline;margin-left:0.4rem;">
             <input type="hidden" name="service_date" value="{{ week.date }}">
@@ -60,8 +67,10 @@
             <input type="hidden" name="days" value="{{ window_days }}">
             <button type="submit" style="background:none;border:none;color:#0d6efd;cursor:pointer;padding:0;font-size:0.8rem;text-decoration:underline;">Unmark</button>
           </form>
+          {% endif %}
         {% else %}
           <span style="color:#b02a37;font-weight:600;">Missing</span>
+          {% if can_edit %}
           <form hx-post="/reports/missing-services/exclude" hx-target="#missing-result"
                 hx-swap="innerHTML" style="display:inline-flex;gap:0.3rem;margin-left:0.4rem;align-items:center;">
             <input type="hidden" name="service_date" value="{{ week.date }}">
@@ -72,6 +81,7 @@
                    style="font-size:0.75rem;padding:0.15rem 0.3rem;max-width:150px;">
             <button type="submit" style="font-size:0.75rem;padding:0.15rem 0.5rem;">Mark excluded</button>
           </form>
+          {% endif %}
         {% endif %}
       </td>
       {% endfor %}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2306,7 +2306,15 @@ class TestNormalizeDatesCommand:
         db = Database(db_path)
         db.connect()
         db.init_schema()
-        db.insert_or_update_service("2026.05.10", "Evening Worship", "f1.pptx", "h1")
+        # The dotted date is seeded via raw SQL to bypass the insert-time
+        # normalization guard (#483) — it represents a legacy row written before
+        # that guard, which is exactly what `cleanup normalize-dates` repairs.
+        db.cursor().execute(
+            "INSERT INTO services (service_date, service_name, source_file, "
+            "source_hash, imported_at) VALUES (?,?,?,?,?)",
+            ("2026.05.10", "Evening Worship", "f1.pptx", "h1", "2026-01-01T00:00:00+00:00"),
+        )
+        db._conn.commit()
         db.insert_or_update_service("2026-05-17", "Morning Worship", "f2.pptx", "h2")
         db.close()
         return db_path

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2827,9 +2827,32 @@ class TestNormalizeServiceDates:
             yield db
             db.close()
 
-    def test_normalize_rewrites_non_iso_dates(self, temp_db):
+    @staticmethod
+    def _seed_legacy(temp_db, service_date, service_name, source_hash):
+        """Insert a row with a NON-canonical date via raw SQL, bypassing the
+        insert_or_update_service normalization guard (#483) so we can exercise
+        normalize_service_dates() against the kind of legacy data it exists to
+        repair."""
+        cur = temp_db.cursor()
+        cur.execute(
+            "INSERT INTO services (service_date, service_name, source_file, "
+            "source_hash, imported_at) VALUES (?,?,?,?,?)",
+            (service_date, service_name, f"{source_hash}.pptx", source_hash,
+             "2026-01-01T00:00:00+00:00"),
+        )
+        temp_db._conn.commit()
+        return cur.lastrowid
+
+    def test_insert_normalizes_non_iso_at_write_boundary(self, temp_db):
+        # The write boundary now canonicalizes dates — no bad data can enter (#483).
         a = temp_db.insert_or_update_service("2026.05.10", "Evening Worship", "f1.pptx", "h1")
-        b = temp_db.insert_or_update_service("2026-05.10", "Morning Worship", "f2.pptx", "h2")
+        b = temp_db.insert_or_update_service("05-31-2026", "Morning Worship", "f2.pptx", "h2")
+        assert temp_db.query_service_by_id(a)["service_date"] == "2026-05-10"
+        assert temp_db.query_service_by_id(b)["service_date"] == "2026-05-31"
+
+    def test_normalize_rewrites_non_iso_dates(self, temp_db):
+        a = self._seed_legacy(temp_db, "2026.05.10", "Evening Worship", "h1")
+        b = self._seed_legacy(temp_db, "2026-05.10", "Morning Worship", "h2")
         temp_db.normalize_service_dates()
         assert temp_db.query_service_by_id(a)["service_date"] == "2026-05-10"
         assert temp_db.query_service_by_id(b)["service_date"] == "2026-05-10"
@@ -2841,17 +2864,17 @@ class TestNormalizeServiceDates:
         assert temp_db.query_service_by_id(a)["service_date"] == "2026-05-17"
 
     def test_dry_run_does_not_modify(self, temp_db):
-        a = temp_db.insert_or_update_service("2026.05.10", "Evening Worship", "f1.pptx", "h1")
+        a = self._seed_legacy(temp_db, "2026.05.10", "Evening Worship", "h1")
         report = temp_db.normalize_service_dates(dry_run=True)
         assert any(r["service_id"] == a and r["new_date"] == "2026-05-10" for r in report)
         # unchanged on dry run
         assert temp_db.query_service_by_id(a)["service_date"] == "2026.05.10"
 
     def test_normalize_skips_when_target_would_collide(self, temp_db):
-        # An ISO row already occupies (2026-05-10, Evening Worship); a dotted
-        # row for the same service must be flagged as a collision, not applied.
+        # An ISO row already occupies (2026-05-10, Evening Worship); a legacy
+        # dotted row for the same service must be flagged as a collision, not applied.
         temp_db.insert_or_update_service("2026-05-10", "Evening Worship", "f1.pptx", "h1")
-        b = temp_db.insert_or_update_service("2026.05.10", "Evening Worship", "f2.pptx", "h2")
+        b = self._seed_legacy(temp_db, "2026.05.10", "Evening Worship", "h2")
         report = temp_db.normalize_service_dates(dry_run=True)
         assert any(r["service_id"] == b and r.get("collision") for r in report)
         # Applying must not raise and must not change the colliding row.
@@ -3188,3 +3211,23 @@ class TestServiceExclusions:
         temp_db.add_exclusion("2026-09-06", "evening")
         rows = temp_db.query_exclusions("2026-06-01", "2026-06-30")
         assert rows == []
+
+    def test_import_clears_matching_exclusion(self, temp_db):
+        # A real import for an excluded (date, slot) supersedes the manual mark (#483).
+        temp_db.add_exclusion("2026-05-31", "morning", reason="thought it was cancelled")
+        temp_db.insert_or_update_service("2026-05-31", "Morning Worship", "f.pptx", "h1")
+        assert temp_db.query_exclusions("2026-05-01", "2026-05-31") == []
+
+    def test_import_clears_exclusion_with_us_date(self, temp_db):
+        # The exclusion is stored ISO; an import passing a US-format date must
+        # still match it (remove_exclusion path normalizes the date).
+        temp_db.add_exclusion("2026-05-31", "evening", reason="rained out")
+        temp_db.insert_or_update_service("05-31-2026", "Evening Worship", "f.pptx", "h2")
+        assert temp_db.query_exclusions("2026-05-01", "2026-05-31") == []
+
+    def test_import_leaves_other_slot_exclusion(self, temp_db):
+        # Importing the morning service must not clear the evening exclusion.
+        temp_db.add_exclusion("2026-05-31", "evening", reason="rained out")
+        temp_db.insert_or_update_service("2026-05-31", "Morning Worship", "f.pptx", "h3")
+        rows = temp_db.query_exclusions("2026-05-01", "2026-05-31")
+        assert len(rows) == 1 and rows[0]["service_slot"] == "evening"

--- a/tests/test_pptx_reader_unit.py
+++ b/tests/test_pptx_reader_unit.py
@@ -207,6 +207,11 @@ class TestNormalizeServiceDate:
         ("2026.5.10", "2026-05-10"),   # single-digit month/day
         ("2026-5-1", "2026-05-01"),
         ("  2026.5.1  ", "2026-05-01"),
+        # US month-first format (Highland is a US congregation) — #483
+        ("05-31-2026", "2026-05-31"),
+        ("5/31/2026", "2026-05-31"),
+        ("5.31.2026", "2026-05-31"),
+        ("1-1-2026", "2026-01-01"),
     ])
     def test_normalizes_to_iso(self, raw, expected):
         from worship_catalog.pptx_reader import normalize_service_date
@@ -217,6 +222,24 @@ class TestNormalizeServiceDate:
         from worship_catalog.pptx_reader import normalize_service_date
 
         assert normalize_service_date("Easter Sunday") == "Easter Sunday"
+
+    def test_unrecognized_format_logs_warning(self, caplog):
+        import logging
+
+        from worship_catalog.pptx_reader import normalize_service_date
+
+        with caplog.at_level(logging.WARNING):
+            assert normalize_service_date("Easter Sunday") == "Easter Sunday"
+        assert any("Easter Sunday" in r.message for r in caplog.records), (
+            "unrecognized date formats must be logged, not silently stored"
+        )
+
+    def test_invalid_calendar_date_passed_through(self):
+        from worship_catalog.pptx_reader import normalize_service_date
+
+        # 2026-13-40 matches the year-first shape but is not a real date — must
+        # not be silently 'normalized' into a bogus ISO string.
+        assert normalize_service_date("2026-13-40") == "2026-13-40"
 
     def test_none_and_empty(self):
         from worship_catalog.pptx_reader import normalize_service_date

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1109,6 +1109,68 @@ class TestUploadAuth:
         assert client.get("/jobs").status_code == 200
 
 
+class TestExclusionAuth:
+    """Marking services excluded is a write — gated by the same UPLOAD_PASSWORD
+    auth as /upload. The report page + JSON stay publicly readable; edit controls
+    appear only for an authenticated viewer (#483)."""
+
+    _CREDS = ("highland", "s3cret")
+
+    @pytest.fixture
+    def auth_client(self, db_with_songs, tmp_path, monkeypatch):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        monkeypatch.setenv("UPLOAD_PASSWORD", "s3cret")
+        from importlib import reload
+        import worship_catalog.web.app as app_module
+        reload(app_module)
+        return CsrfAwareClient(TestClient(app_module.app))
+
+    _EXCL = {"service_date": "2026-05-31", "service_slot": "evening", "days": "90"}
+
+    def test_exclude_requires_auth_when_password_set(self, auth_client):
+        assert auth_client.post(
+            "/reports/missing-services/exclude", data=self._EXCL
+        ).status_code == 401
+
+    def test_include_requires_auth_when_password_set(self, auth_client):
+        assert auth_client.post(
+            "/reports/missing-services/include", data=self._EXCL
+        ).status_code == 401
+
+    def test_exclude_succeeds_with_credentials(self, auth_client):
+        r = auth_client.post(
+            "/reports/missing-services/exclude", data=self._EXCL, auth=self._CREDS
+        )
+        assert r.status_code == 200
+
+    def test_report_page_and_json_stay_public(self, auth_client):
+        assert auth_client.get("/reports/missing-services").status_code == 200
+        assert auth_client.get("/reports/missing-services.json").status_code == 200
+
+    def test_report_readonly_without_auth(self, auth_client):
+        body = auth_client.get("/reports/missing-services").text
+        assert "Mark excluded" not in body, "edit controls must be hidden when not logged in"
+        assert "Log in to edit" in body
+
+    def test_report_editable_with_auth(self, auth_client):
+        body = auth_client.get("/reports/missing-services", auth=self._CREDS).text
+        assert "Mark excluded" in body
+
+    def test_login_param_challenges_when_unauthed(self, auth_client):
+        r = auth_client.get("/reports/missing-services?login=1")
+        assert r.status_code == 401
+        assert "basic" in r.headers.get("www-authenticate", "").lower()
+
+    def test_exclude_open_when_password_unset(self, client):
+        # No UPLOAD_PASSWORD → write stays open (backwards-compatible).
+        assert client.post(
+            "/reports/missing-services/exclude", data=self._EXCL
+        ).status_code == 200
+
+
 class TestReportRateLimiting:
     """Public report endpoints must be rate-limited to prevent unauthenticated
     CPU/memory exhaustion (esp. /reports/stats/xlsx) on the public site (#450)."""


### PR DESCRIPTION
Closes #483. Three follow-ups from reviewing the Missing Services report (#480) against live production data.

## 1. Data integrity — US-format dates silently broke date-range reports
A 5/31/2026 upload was stored as `05-31-2026` (US M-D-Y). `insert_or_update_service` stored dates *as given*, and `normalize_service_date` only knew year-first formats — so the value sorted outside every ISO range and vanished from **stats, CCLI, and missing-services** queries.
- `normalize_service_date()` now parses US month-first dates, validates a real calendar date, and **logs** anything unrecognized (surface, don't silently store).
- **`insert_or_update_service()` canonicalizes `service_date` at the write boundary** — no non-ISO date can enter. `normalize_service_dates()` remains the cleanup tool for *legacy* rows (their tests now seed dirty data via raw SQL, since that's how legacy rows realistically exist).

## 2. Security — exclusions were publicly writable
The exclude/include POST routes carried only CSRF + rate-limiting. They now require the **same `UPLOAD_PASSWORD` auth as `/upload`** (shared realm, so one login unlocks both). The report **page + JSON stay public/read-only**; the exclude/include controls render only for an authenticated viewer, with a **"Log in to edit"** (`?login=1`) Basic-auth challenge affordance.

## 3. Self-healing — importing supersedes a manual exclusion
Importing a PPTX for an excluded slot now clears the matching exclusion in `insert_or_update_service`, so a real service supersedes the manual mark and it can't resurface if the service is later deleted.

## Validation
- `pytest -m "not e2e"` → **1274 passed, 9 skipped**; `ruff check src/` + `mypy src/` clean.
- New/updated tests: `test_pptx_reader_unit.py` (US dates + logging), `test_db_integration.py` (write-boundary normalization, auto-clear, legacy-row cleanup), `test_web_security.py::TestExclusionAuth` (auth gating, read-only vs editable, login challenge), `test_cli.py` (legacy-row fixture).
- The 5/31 production row was already corrected manually; this PR prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)