### PR TITLE
feat: upload page inert 'Log in to upload' state (#485)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -1232,10 +1232,25 @@ def require_upload_auth(request: Request) -> None:
 @app.get("/upload", response_class=HTMLResponse)
 async def upload_page(
     request: Request,
-    _: None = Depends(require_upload_auth),  # noqa: B008
+    login: bool = Query(default=False),
 ) -> HTMLResponse:
-    """Render the browser upload form for PPTX files."""
-    return templates.TemplateResponse(request, "upload.html")
+    """Render the browser upload form for PPTX files.
+
+    Mirrors the missing-services report (#483, #485): the page is always
+    viewable, but the upload control renders only for a viewer with valid upload
+    credentials — otherwise an inert "Log in to upload" state is shown. Visiting
+    with ``?login=1`` issues the Basic-auth challenge so the browser prompts and
+    caches creds for the /upload realm. POST /upload stays auth-gated, so the
+    inert front-end is never the only guard.
+    """
+    authed = _upload_credentials_valid(request)
+    if login and not authed:
+        require_upload_auth(request)  # raises 401 challenge so the browser prompts
+    return templates.TemplateResponse(
+        request,
+        "upload.html",
+        {"authed": authed, "auth_required": bool(os.environ.get("UPLOAD_PASSWORD"))},
+    )
 
 
 @app.post("/upload")

--- a/src/worship_catalog/web/templates/upload.html
+++ b/src/worship_catalog/web/templates/upload.html
@@ -4,6 +4,7 @@
 <h1>Upload Slide Deck</h1>
 
 <div class="card">
+  {% if authed %}
   <p style="color:#495057;font-size:0.9rem;margin-top:0;">
     Select a PowerPoint (.pptx) worship slide deck to import.
     Songs and service metadata will be extracted automatically.
@@ -18,7 +19,16 @@
     <button type="submit">Upload</button>
   </form>
   <div id="upload-result" style="margin-top:1rem;" aria-live="polite" aria-atomic="true"></div>
+  {% else %}
+  <p style="color:#495057;font-size:0.9rem;margin-top:0;">
+    Uploading worship slide decks requires logging in.
+  </p>
+  <p>
+    <a class="btn" href="/upload?login=1"
+       style="display:inline-block;padding:0.5rem 1rem;">Log in to upload</a>
+  </p>
+  {% endif %}
 </div>
 
-<script src="/static/upload.js"></script>
+{% if authed %}<script src="/static/upload.js"></script>{% endif %}
 {% endblock %}

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -1065,18 +1065,31 @@ class TestUploadAuth:
         reload(app_module)
         return CsrfAwareClient(TestClient(app_module.app))
 
-    def test_get_upload_requires_auth_when_password_set(self, auth_client):
+    def test_get_upload_inert_when_password_set(self, auth_client):
+        # GET /upload is viewable (not a hard 401) but inert: a login affordance,
+        # no upload control, until the viewer has valid credentials (#485).
         r = auth_client.get("/upload")
-        assert r.status_code == 401
-        assert "basic" in r.headers.get("www-authenticate", "").lower()
+        assert r.status_code == 200
+        assert "Log in" in r.text
+        assert 'type="file"' not in r.text
 
     def test_get_upload_succeeds_with_valid_credentials(self, auth_client):
         r = auth_client.get("/upload", auth=("highland", "s3cret"))
         assert r.status_code == 200
+        assert 'type="file"' in r.text  # full functional form
 
-    def test_get_upload_rejects_wrong_password(self, auth_client):
+    def test_get_upload_inert_with_wrong_password(self, auth_client):
+        # Wrong creds = not authenticated → inert page (no hard 401 on GET).
         r = auth_client.get("/upload", auth=("highland", "wrong"))
+        assert r.status_code == 200
+        assert 'type="file"' not in r.text
+
+    def test_login_param_challenges_upload(self, auth_client):
+        # The "Log in" affordance points at ?login=1, which issues the Basic
+        # challenge so the browser caches creds for the /upload realm (#485).
+        r = auth_client.get("/upload?login=1")
         assert r.status_code == 401
+        assert "basic" in r.headers.get("www-authenticate", "").lower()
 
     def test_post_upload_requires_auth(self, auth_client):
         r = auth_client.post(
@@ -1090,8 +1103,11 @@ class TestUploadAuth:
             assert auth_client.get(path).status_code == 200, path
 
     def test_upload_open_when_password_unset(self, client):
-        # The default fixture sets no UPLOAD_PASSWORD → upload stays open.
-        assert client.get("/upload").status_code == 200
+        # The default fixture sets no UPLOAD_PASSWORD → upload stays fully open.
+        r = client.get("/upload")
+        assert r.status_code == 200
+        assert 'type="file"' in r.text
+        assert "Log in" not in r.text
 
     # /jobs is part of the same write/admin workflow and leaks uploaded
     # filenames + raw error messages — it must be gated like /upload (#451).


### PR DESCRIPTION
Closes #485. Brings the **upload page** in line with the missing-services auth pattern from #483.

## Behavior (when `UPLOAD_PASSWORD` is set)
- `GET /upload` is **viewable, not a hard 401** — it renders an **inert** state: no file picker, with a **"Log in to upload"** affordance.
- The affordance links to `?login=1`, which issues the Basic-auth challenge so the browser prompts and caches creds for the `/upload` realm (same realm as `require_upload_auth`).
- With valid creds, `GET /upload` renders the **full functional form**.
- `POST /upload` (and `/jobs*`) stay gated by `require_upload_auth` → still **401** without creds. The inert UI is never the only guard.

When `UPLOAD_PASSWORD` is **unset**: fully functional, no login button — exactly as before.

## Implementation
- `GET /upload` drops the raising `require_upload_auth` dependency for the **non-raising `_upload_credentials_valid()`** helper (shared with #483) and passes `authed`/`auth_required` to the template.
- `upload.html` renders the form + `upload.js` only when `authed`, else the inert login state.

## Validation
- `pytest -m "not e2e"` → **1275 passed**; `ruff check src/` + `mypy src/` clean.
- `tests/test_web_security.py::TestUploadAuth` updated: GET is now inert (200) instead of 401; added wrong-creds-inert, `?login=1` challenge, and open-mode form-present assertions. POST-requires-auth unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)