### PR TITLE
fix(ci): correct Dependabot ecosystem for deploy/pi (docker, not docker-compose) (#502)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,11 @@ updates:
       day: "monday"
     open-pull-requests-limit: 2
 
-  # Docker Compose images in Pi deploy stack (Traefik, Watchtower) — weekly
-  - package-ecosystem: "docker-compose"
+  # Docker images in Pi deploy stack (Traefik, Promtail, Cloudflared) — weekly.
+  # Uses the "docker" ecosystem (not "docker-compose", which is not a valid
+  # Dependabot ecosystem); since 2024 "docker" scans both Dockerfiles and
+  # docker-compose.yml files in the directory.
+  - package-ecosystem: "docker"
     directory: "/deploy/pi"
     schedule:
       interval: "weekly"

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -6,6 +6,70 @@ import pytest
 import yaml
 
 CI_PATH = Path(".github/workflows/ci.yml")
+DEPENDABOT_PATH = Path(".github/dependabot.yml")
+
+# The set of valid Dependabot package-ecosystem values.  "docker-compose" is
+# deliberately absent — it is NOT a valid ecosystem; the "docker" ecosystem
+# scans both Dockerfiles and docker-compose.yml files (#502).
+_VALID_DEPENDABOT_ECOSYSTEMS = {
+    "pip",
+    "github-actions",
+    "docker",
+    "npm",
+    "gomod",
+    "bundler",
+    "cargo",
+    "composer",
+    "nuget",
+    "gitsubmodule",
+    "terraform",
+    "gradle",
+    "maven",
+    "pub",
+    "mix",
+    "devcontainers",
+    "uv",
+}
+
+
+@pytest.mark.skipif(not DEPENDABOT_PATH.exists(), reason="Dependabot config not present")
+class TestDependabotEcosystems:
+    """Every Dependabot ecosystem must be valid, and the Pi deploy stack images
+    must be covered by a real "docker" entry — not the invalid "docker-compose"
+    ecosystem that Dependabot silently ignores (#502)."""
+
+    def _updates(self) -> list[dict]:
+        cfg = yaml.safe_load(DEPENDABOT_PATH.read_text())
+        return cfg["updates"]
+
+    def test_no_docker_compose_ecosystem(self) -> None:
+        """'docker-compose' is not a valid Dependabot ecosystem and must not appear."""
+        ecos = [u["package-ecosystem"] for u in self._updates()]
+        assert "docker-compose" not in ecos, (
+            "'docker-compose' is not a valid Dependabot package-ecosystem — "
+            "Dependabot silently ignores it. Use 'docker' instead (#502)."
+        )
+
+    def test_all_ecosystems_valid(self) -> None:
+        """Every package-ecosystem entry must be a recognised Dependabot value."""
+        ecos = [u["package-ecosystem"] for u in self._updates()]
+        invalid = [e for e in ecos if e not in _VALID_DEPENDABOT_ECOSYSTEMS]
+        assert not invalid, (
+            f"Invalid Dependabot package-ecosystem value(s): {invalid}. "
+            f"Valid values: {sorted(_VALID_DEPENDABOT_ECOSYSTEMS)}"
+        )
+
+    def test_deploy_pi_covered_by_docker_ecosystem(self) -> None:
+        """The Pi deploy stack (/deploy/pi) must have a 'docker' update entry so
+        traefik/promtail/cloudflared receive digest-bump PRs (#502)."""
+        assert any(
+            u["package-ecosystem"] == "docker"
+            and u["directory"] in ("/deploy/pi", "/deploy/pi/")
+            for u in self._updates()
+        ), (
+            "No 'docker' Dependabot entry for '/deploy/pi' — the production Pi "
+            "stack images (traefik, promtail, cloudflared) get no update PRs."
+        )
 
 
 @pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")


### PR DESCRIPTION
Closes #502

## Problem
`.github/dependabot.yml`'s 4th entry used `package-ecosystem: "docker-compose"` for `/deploy/pi`. `docker-compose` is **not** a valid Dependabot ecosystem, so Dependabot silently ignored the entry and the production Pi stack images (`traefik`, `promtail`, `cloudflared`) in `deploy/pi/docker-compose.yml` received **no** digest-bump PRs. The stale comment referenced Watchtower, which isn't in the stack.

## Fix
- Changed the 4th entry to `package-ecosystem: "docker"`, `directory: "/deploy/pi"`. The `docker` ecosystem has scanned both Dockerfiles and `docker-compose.yml` since 2024. Two `docker` entries with distinct directories coexist fine.
- Rewrote the stale comment to reflect the real stack (Traefik, Promtail, Cloudflared) and explain the ecosystem choice.
- Added `TestDependabotEcosystems` to `tests/test_ci_config.py` (where existing CI-config tests live), asserting: no `docker-compose` ecosystem, every `package-ecosystem` is valid, and a `docker` entry covers `/deploy/pi`.

## Validation
- `uv run python -m pytest tests/ -k "dependabot or ci_config" -v` — 11 passed
- `uv run python -m pytest -m "not e2e" -q` — 1282 passed, 9 skipped, 2 xfailed (well above the 950 floor)
- `uv run ruff check src/ tests/test_ci_config.py` — All checks passed
- `uv run mypy src/` — Success, no issues in 18 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)