### PR TITLE
fix(deploy): disable insecure Traefik API dashboard (#513)

### DIFF
--- a/deploy/pi/traefik/traefik.yml
+++ b/deploy/pi/traefik/traefik.yml
@@ -33,10 +33,13 @@ providers:
     exposedByDefault: false           # require traefik.enable=true label
     network: song-history_default
 
-# --- API / dashboard (LAN-only, no auth needed) ----------------------------
+# --- API / dashboard --------------------------------------------------------
+# Dashboard disabled on the Pi (#513). `insecure: true` previously exposed the
+# unauthenticated dashboard on :8080, leaking full routing config on a host that
+# also mounts the docker socket. To re-enable for LAN, add a router with an auth
+# middleware on an internal hostname only — never `insecure: true`.
 api:
-  dashboard: true
-  insecure: true                      # dashboard on :8080, LAN-only
+  dashboard: false
 
 # --- Logging ----------------------------------------------------------------
 log:

--- a/tests/test_pi_compose.py
+++ b/tests/test_pi_compose.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 COMPOSE_PATH = Path("deploy/pi/docker-compose.yml")
+TRAEFIK_PATH = Path("deploy/pi/traefik/traefik.yml")
 
 
 @pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
@@ -33,6 +34,23 @@ class TestTrustedProxy:
         assert "TRUSTED_PROXY" in env, (
             "song-history env must set TRUSTED_PROXY so _get_client_ip uses "
             "CF-Connecting-IP instead of bucketing all tunnel traffic as one client"
+        )
+
+
+@pytest.mark.skipif(not TRAEFIK_PATH.exists(), reason="Pi traefik config not present")
+class TestTraefikDashboard:
+    """The Traefik API dashboard must not run in insecure mode (#513).
+
+    `api.insecure: true` exposes the unauthenticated dashboard on :8080, leaking
+    full routing config. The traefik container also mounts the docker socket, so
+    an accidental port publish turns this info-leak into a socket-adjacent
+    exposure on the internet-facing Pi. Defense-in-depth: never ship insecure."""
+
+    def test_traefik_dashboard_not_insecure(self) -> None:
+        cfg = yaml.safe_load(TRAEFIK_PATH.read_text())
+        assert not cfg.get("api", {}).get("insecure", False), (
+            "traefik api.insecure must not be true — it exposes the "
+            "unauthenticated dashboard on :8080 (#513)."
         )
 
 


### PR DESCRIPTION
Closes #513

## Problem
`deploy/pi/traefik/traefik.yml` set `api: {dashboard: true, insecure: true}`, exposing the unauthenticated Traefik dashboard on `:8080`. The dashboard leaks full routing config, and the traefik container also mounts `/var/run/docker.sock:ro`. Although `:8080` is not currently published (container-internal only), this is a defense-in-depth gap: one accidental `ports:` entry turns an info-leak into a socket-adjacent exposure on the internet-facing Pi.

## Fix (config-only)
- Drop `insecure: true` and set `dashboard: false` in `deploy/pi/traefik/traefik.yml`.
- Documented that any LAN re-enable must go behind a router + auth middleware on an internal hostname — never `insecure: true`.

## Test (TDD)
Added `TestTraefikDashboard::test_traefik_dashboard_not_insecure` in `tests/test_pi_compose.py` (where the Pi traefik config tests live), asserting `api.insecure` is not true. Confirmed it failed before the fix, passes after.

## Validation
- `uv run python -m pytest tests/ -k "traefik or pi_compose" -v` — 5 passed
- `uv run python -m pytest -m "not e2e" -q` — 1280 passed, 9 skipped, 2 xfailed
- `uv run ruff check src/` — All checks passed
- `uv run mypy src/` — Success, no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)