### PR TITLE
test(ci): smoke-test a real rendered route + report route, not just /health (#515)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,19 +320,56 @@ jobs:
             -e CSRF_SECRET=smoke-test-ephemeral-secret \
             -p 8765:8000 \
             local-scan:latest
-          # Wait for the server to start (max 15s)
+          BASE=http://localhost:8765
+
+          fail() {
+            echo "Smoke test FAILED — $1"
+            docker logs smoke-test
+            docker stop smoke-test
+            exit 1
+          }
+
+          # Wait for the server to become healthy (max 15s)
+          healthy=""
           for i in $(seq 1 15); do
-            if curl -sf http://localhost:8765/health; then
-              echo "Smoke test passed"
-              docker stop smoke-test
-              exit 0
+            if curl -sf "$BASE/health" >/dev/null; then
+              healthy=1
+              break
             fi
             sleep 1
           done
-          echo "Smoke test FAILED — server did not start within 15s"
-          docker logs smoke-test
+          [ -n "$healthy" ] || fail "server did not start within 15s"
+
+          # /health only proves the process is up: it returns a static OK without
+          # touching templates, the DB query paths, or a report route. Exercise a
+          # REAL rendered route and a report route so a broken Jinja template, a
+          # missing static asset, or a router-registration regression fails the
+          # smoke test before the multi-platform push (#515).
+
+          # 1. Rendered page — /songs must return the songs template (router +
+          #    Jinja + base layout), not a static string. The smoke container runs
+          #    a fresh empty DB, so the library shows the empty-state card rather
+          #    than a <table>; assert on the page heading, which renders
+          #    regardless of data.
+          curl -sf "$BASE/songs" | grep -qi "Song Library" \
+            || fail "/songs did not render the songs page (template/router regression?)"
+
+          # 2. Report page renders — GET /reports must return the reports template.
+          curl -sf "$BASE/reports" | grep -qi "Generate Reports" \
+            || fail "/reports did not render the reports page"
+
+          # 3. Report route wired end-to-end — a CSRF-protected POST returning 403
+          #    still proves the router + CSRF middleware are registered (200 is
+          #    also acceptable if CSRF is ever relaxed). Any other status (404,
+          #    5xx) means the CCLI route is broken or unregistered.
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/reports/ccli" \
+            -d 'start_date=2020-01-01&end_date=2030-12-31')
+          { [ "$code" = "403" ] || [ "$code" = "200" ]; } \
+            || fail "/reports/ccli not wired (HTTP $code)"
+
+          echo "Smoke test passed — /health, /songs, /reports and /reports/ccli all OK"
           docker stop smoke-test
-          exit 1
+          exit 0
 
       # Build and push multi-platform only after the CVE scan and smoke test pass (#66, #88).
       # GHA cache from the local build above makes this fast (no layer re-download).

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -117,6 +117,65 @@ class TestSmokeTestCsrf:
 
 
 @pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
+class TestSmokeTestRealRoute:
+    """The publish smoke test must exercise a real rendered route and a report
+    route, not just /health (#515). /health returns a static OK without touching
+    templates, the DB query paths, or a router, so a broken Jinja template or an
+    unregistered router would boot healthy and pass — the very failures the
+    smoke test on the real artifact should catch before the multi-platform push."""
+
+    def _smoke_run_block(self) -> str:
+        workflow = yaml.safe_load(CI_PATH.read_text())
+        for job in workflow["jobs"].values():
+            for step in job.get("steps", []):
+                if step.get("name", "").lower().startswith("smoke test"):
+                    return step.get("run", "")
+        raise AssertionError("Smoke test step not found in ci.yml")
+
+    def test_smoke_test_hits_more_than_health(self) -> None:
+        run_block = self._smoke_run_block()
+        # It must still probe /health for readiness, but must not stop there.
+        assert "/health" in run_block, "Smoke test should still probe /health"
+        assert "/songs" in run_block, (
+            "Smoke test must hit the /songs rendered route so a broken template "
+            "or router regression fails before the multi-platform push (#515)."
+        )
+
+    def test_smoke_test_asserts_rendered_songs_page(self) -> None:
+        run_block = self._smoke_run_block()
+        # Assert the songs route is checked for real rendered markup (not just a
+        # 200). The smoke DB is empty, so we match the page heading rather than
+        # a <table>, but either proves the template rendered.
+        assert "curl -sf" in run_block and "/songs" in run_block, (
+            "Smoke test must fetch /songs and grep its rendered HTML."
+        )
+        assert "grep" in run_block, (
+            "Smoke test must grep the /songs response for rendered markup, "
+            "not just check the HTTP status."
+        )
+
+    def test_smoke_test_hits_a_report_route(self) -> None:
+        run_block = self._smoke_run_block()
+        assert "/reports" in run_block, (
+            "Smoke test must exercise a report route (GET /reports render or a "
+            "CSRF-protected POST /reports/ccli) so a router regression is caught "
+            "before the push (#515)."
+        )
+
+    def test_smoke_test_ccli_post_accepts_csrf_status(self) -> None:
+        run_block = self._smoke_run_block()
+        assert "/reports/ccli" in run_block, (
+            "Smoke test must POST to /reports/ccli to prove the report router + "
+            "CSRF middleware are wired."
+        )
+        # A CSRF-protected POST returns 403; 200 is tolerated if CSRF is relaxed.
+        assert "403" in run_block, (
+            "Smoke test must accept the 403 that a CSRF-protected POST returns — "
+            "that status still proves the router + middleware are registered."
+        )
+
+
+@pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
 class TestCveSkipReviewNote:
     """Every pip-audit CVE ignore must carry a re-evaluation note so suppressed
     vulnerabilities don't become a permanent ratchet (#408)."""


### PR DESCRIPTION
Closes #515

## Problem
The `publish` job's "Smoke test image" step only looped on `curl -sf /health`. `/health` returns a static OK without touching templates, the DB query paths, or a router — so a broken Jinja template, a missing static asset, or a router-registration regression would boot healthy and pass the smoke test, right before the multi-platform push. "/health is 200" is a very low bar for "the app actually works".

## Change
Extend the smoke step in `.github/workflows/ci.yml` to exercise real routes after the health check passes:

- **Rendered page** — `GET /songs`, grep the response for the page heading (`Song Library`). The smoke container runs a fresh empty DB, so `/songs` shows the empty-state card rather than a `<table>`; the heading is a DB-independent marker that still proves the router mapped the route and Jinja rendered the template.
- **Report page** — `GET /reports`, assert `Generate Reports` renders.
- **Report route wired** — `POST /reports/ccli` and accept `403` (or `200`). The CSRF-protected POST returning 403 still proves the report router + CSRF middleware are registered; any other status (404/5xx) fails the smoke test.

A shared `fail()` helper dumps `docker logs` and stops the container on any failure. `CSRF_SECRET` is still supplied (#406), so the container boots the same code path a real deployment uses.

`tests/test_ci_config.py` gains `TestSmokeTestRealRoute` (4 assertions) locking in that the smoke step hits `/songs`, greps rendered markup, exercises a report route, and accepts the CSRF 403 — so it can't silently regress to `/health`-only.

## Note on CI coverage
The smoke step only runs in the `publish` job, which is gated to `main` / `schedule` / `workflow_dispatch`. **PR CI will not execute the smoke step** — the new assertions are exercised on merge to main (and scheduled/dispatch runs). The `test_ci_config.py` assertions, which run on every PR, verify the workflow *content* is correct.

## Validation
- `uv run python -m pytest tests/ -k ci_config -q` → 12 passed
- `uv run python -m pytest -m "not e2e" -q` → **1283 passed, 9 skipped** (floor is 950)
- `uv run ruff check src/` → all checks passed
- `uv run mypy src/` → success, no issues
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` → yaml ok
- Verified locally against an empty DB via `TestClient`: `/songs`→200 (heading present, no `<table>`), `/reports`→200, `POST /reports/ccli`→403

🤖 Generated with [Claude Code](https://claude.com/claude-code)