### PR TITLE
chore(deploy): pin app image + run promtail non-root + add watcher healthcheck (#512, #514)

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -42,17 +42,31 @@ services:
   # Image is pulled from GHCR — no source code needed on the Pi.
   # ---------------------------------------------------------------------------
   watcher:
-    image: ghcr.io/mshirel/song-history:latest
+    # Immutably pinned (#512) — was the mutable :latest. `docker compose pull` on
+    # :latest silently swaps running app code with no digest record and no
+    # rollback target. Pin to the sha- tag + digest CI publishes; Dependabot's
+    # `docker` ecosystem entry (#502) bumps this on a reviewed PR.
+    # Tag sha-<commit> = main@61914d1; digest resolved from GHCR 2026-07-03.
+    image: ghcr.io/mshirel/song-history:sha-61914d1e42feb8b5becf0cf0936e28df14bf561c@sha256:5f3a1a4599e50ce80f8920c91631af6b6e73ec4be702bb511ca301b1cf073a57
     restart: unless-stopped
     init: true
     # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
-    # runs an import loop and serves no HTTP, so disable the inherited check to
-    # avoid a permanently "unhealthy" container and false monitoring alerts.
+    # runs an import loop and serves no HTTP. Instead of disabling liveness
+    # entirely, define our own lightweight heartbeat check (#514): each loop
+    # iteration touches /tmp/watcher-heartbeat, and the check fails if that file
+    # is stale (older than ~2 loop cycles), so a wedged/hung import is caught by
+    # monitoring — `restart: unless-stopped` only catches a full process exit.
     healthcheck:
-      disable: true
+      test:
+        - CMD-SHELL
+        - test $(( $(date +%s) - $(stat -c %Y /tmp/watcher-heartbeat 2>/dev/null || echo 0) )) -lt 660
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 330s
     entrypoint: /bin/sh
     command: >
-      -c "while true; do /app/scripts/import-new.sh; sleep 300; done"
+      -c "while true; do touch /tmp/watcher-heartbeat; /app/scripts/import-new.sh; sleep 300; done"
     environment:
       DB_PATH: /data/worship.db
       INBOX_DIR: /inbox
@@ -68,7 +82,10 @@ services:
         max-file: "3"
 
   song-history:
-    image: ghcr.io/mshirel/song-history:latest
+    # Immutably pinned (#512) — was the mutable :latest. Keep this in lockstep
+    # with the `watcher` service above; Dependabot (#502) bumps both.
+    # Tag sha-<commit> = main@61914d1; digest resolved from GHCR 2026-07-03.
+    image: ghcr.io/mshirel/song-history:sha-61914d1e42feb8b5becf0cf0936e28df14bf561c@sha256:5f3a1a4599e50ce80f8920c91631af6b6e73ec4be702bb511ca301b1cf073a57
     restart: unless-stopped
     stop_grace_period: 35s
     ports:
@@ -134,7 +151,17 @@ services:
     # Digest-pinned (#453) — was :latest. Re-pin on a reviewed Dependabot bump.
     image: grafana/promtail:latest@sha256:6cfa64ec432b24a912d640e2edb940eeae2666f61861a66c121d763dd7241381
     restart: unless-stopped
-    user: root   # needed to read root-owned /var/lib/docker/containers logs
+    # Non-root least-privilege (#514) — was `user: root`. Runs as uid 10001 with
+    # gid 0 (root group) so it can READ the group-readable Docker json logs under
+    # /var/lib/docker/containers WITHOUT root. Requires two host-side prep steps
+    # (see docs/pi-deploy.md):
+    #   1. Container logs must be group-readable. Docker's default is 0640
+    #      root:root (group can read); if a hardened daemon.json sets 0600, apply
+    #      an ACL:  setfacl -R -m g:0:rX -d -m g:0:rX /var/lib/docker/containers
+    #   2. promtail writes positions.yaml into the mounted /opt/song-history/promtail
+    #      dir, so that dir must be writable by uid 10001 (or gid 0):
+    #      chown -R 10001:0 /opt/song-history/promtail && chmod -R g+rwX ...
+    user: "10001:0"
     command: -config.file=/etc/promtail/config.yml
     volumes:
       - /opt/song-history/promtail:/etc/promtail

--- a/docs/pi-deploy.md
+++ b/docs/pi-deploy.md
@@ -25,8 +25,8 @@ Raspberry Pi (pi-songs, DMZ VLAN 249, UPS-backed):
   ├── cloudflared        → outbound tunnel to Cloudflare edge (no inbound ports)
   ├── traefik :80/:443   → LAN alias (pi-songs.tanx95.us) + Let's Encrypt DNS-01
   ├── song-history :8000 → app; host port firewalled to the Prometheus scraper
-  ├── watcher            → import loop (same image, healthcheck disabled)
-  └── promtail           → ships container logs to homelab Loki
+  ├── watcher            → import loop (same image; heartbeat healthcheck, #514)
+  └── promtail           → ships container logs to homelab Loki (non-root, #514)
 
 UniFi DNS: pi-songs.tanx95.us → 10.20.249.10 (LAN alias)
 Cloudflare: songs.highland-coc.com → tunnel; highland-coc.com zone for DNS-01
@@ -53,6 +53,21 @@ Because the host serves a public tunnel, lock it down. Codified in the repo:
   must sort before `50-cloud-init.conf`); `PasswordAuthentication no` (#452).
 - **Token rotation** — if `.env` was ever world-readable, rotate the Cloudflare
   API token and tunnel token in the Cloudflare dashboard (#446).
+- **promtail runs non-root** (`user: "10001:0"`, #514) — least privilege on the
+  public host. It reads container logs as gid 0 (root group) instead of root, so
+  the host needs two one-time prep steps:
+  1. Docker json logs must stay group-readable. The daemon default is `0640
+     root:root` (group can read). If a hardened `daemon.json` sets `0600`, grant
+     an ACL: `sudo setfacl -R -m g:0:rX -d -m g:0:rX /var/lib/docker/containers`.
+  2. promtail writes `positions.yaml` into the mounted positions dir, so make it
+     writable by the uid/gid: `sudo chown -R 10001:0 /opt/song-history/promtail
+     && sudo chmod -R g+rwX /opt/song-history/promtail`.
+  If promtail logs `permission denied` on the log path or positions file, one of
+  these steps was missed.
+- **App image is digest-pinned** (`ghcr.io/mshirel/song-history:sha-…@sha256:…`,
+  #512) — `docker compose pull` no longer swaps app code from mutable `:latest`.
+  Bump it via a reviewed Dependabot PR (#502) or by re-pinning the `sha-<commit>`
+  tag + digest CI publishes; `song-history` and `watcher` must stay in lockstep.
 
 ---
 

--- a/tests/test_pi_compose.py
+++ b/tests/test_pi_compose.py
@@ -1,11 +1,17 @@
 """Tests for the Pi deployment compose file (deploy/pi/docker-compose.yml)."""
 
+import re
 from pathlib import Path
 
 import pytest
 import yaml
 
 COMPOSE_PATH = Path("deploy/pi/docker-compose.yml")
+
+# Services that run the first-party application image (ghcr.io/mshirel/song-history).
+APP_SERVICES = ("song-history", "watcher")
+# Matches a version-pinned tag such as ":v1.2.0".
+_SEMVER_TAG = re.compile(r":v\d+\.\d+\.\d+")
 
 
 @pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
@@ -23,6 +29,58 @@ class TestImagePinning:
 
 
 @pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
+class TestAppImagePinning:
+    """The first-party app image must be immutably pinned, not mutable ':latest'
+    (#512). ``docker compose pull`` on a bare ':latest' silently swaps the running
+    application code with no digest record and no deterministic rollback target."""
+
+    def test_app_services_use_the_app_image(self) -> None:
+        """Guard the assumption behind the other tests: both services run the app
+        image (so the pinning assertion below actually covers the app)."""
+        services = yaml.safe_load(COMPOSE_PATH.read_text())["services"]
+        for name in APP_SERVICES:
+            assert services[name]["image"].startswith("ghcr.io/mshirel/song-history"), (
+                f"{name} is expected to run the first-party app image"
+            )
+
+    def test_app_image_not_bare_latest(self) -> None:
+        for name in APP_SERVICES:
+            image = yaml.safe_load(COMPOSE_PATH.read_text())["services"][name]["image"]
+            assert image != "ghcr.io/mshirel/song-history:latest", (
+                f"{name} must not deploy the mutable ':latest' tag (got {image!r})"
+            )
+
+    def test_app_image_is_digest_or_version_pinned(self) -> None:
+        """Mirror of the issue's regression test: every reference to the app image
+        anywhere in the compose file must carry a digest or an ``:vX.Y.Z`` tag."""
+        text = COMPOSE_PATH.read_text()
+        refs = re.findall(r"ghcr\.io/mshirel/song-history[:@][^\s\"']+", text)
+        assert refs, "expected at least one app-image reference in the compose file"
+        for ref in refs:
+            assert "@sha256:" in ref or _SEMVER_TAG.search(ref), (
+                f"app image must be digest- or version-pinned, got {ref!r}"
+            )
+
+
+@pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
+class TestPromtailNotRoot:
+    """promtail must not run as root (#514). It reads all container logs; root is
+    unnecessary once the log dir is group-readable / ACL'd, and least-privilege
+    matters on this internet-exposed host."""
+
+    def test_promtail_runs_non_root(self) -> None:
+        services = yaml.safe_load(COMPOSE_PATH.read_text())["services"]
+        promtail = next(v for k, v in services.items() if "promtail" in k)
+        user = promtail.get("user")
+        assert user not in (None, "root", "0", 0), (
+            f"promtail must run as an explicit non-root uid (got {user!r})"
+        )
+        # The uid portion (before any ':gid') must not be 0/root.
+        uid = str(user).split(":", 1)[0]
+        assert uid not in ("0", "root"), f"promtail uid must be non-root (got {user!r})"
+
+
+@pytest.mark.skipif(not COMPOSE_PATH.exists(), reason="Pi compose file not present")
 class TestTrustedProxy:
     """Behind the Cloudflare tunnel the app must trust CF-Connecting-IP so the
     rate limiter (and /metrics IP checks) identify real clients, not the tunnel
@@ -37,21 +95,36 @@ class TestTrustedProxy:
 
 
 class TestWatcherHealthcheck:
-    """The watcher reuses the app image, which ships a HEALTHCHECK probing
-    http://localhost:8000/health (#402). The watcher runs an import loop and does
-    NOT serve HTTP, so it must disable the inherited healthcheck — otherwise Docker
-    marks the watcher 'unhealthy' and triggers false monitoring alerts."""
+    """The watcher reuses the app image, whose inherited HEALTHCHECK probes
+    http://localhost:8000/health (#402) — wrong for the watcher, which serves no
+    HTTP. Rather than disable liveness entirely (#402), the watcher now defines its
+    own lightweight heartbeat-based healthcheck so a wedged import loop is caught by
+    monitoring; ``restart: unless-stopped`` only catches a full process exit, not a
+    hang (#514)."""
 
     def _services(self) -> dict:
         return yaml.safe_load(COMPOSE_PATH.read_text())["services"]
 
-    def test_watcher_disables_inherited_healthcheck(self) -> None:
+    def test_watcher_has_an_active_healthcheck(self) -> None:
         watcher = self._services()["watcher"]
         hc = watcher.get("healthcheck")
-        assert hc is not None and hc.get("disable") is True, (
-            "watcher must set 'healthcheck: {disable: true}' — it reuses the app "
-            "image's HEALTHCHECK (probing :8000) but serves no HTTP, so it would "
-            "otherwise be marked unhealthy (#402)."
+        assert hc is not None, "watcher must define a healthcheck (#514)"
+        assert hc.get("disable") is not True, (
+            "watcher healthcheck must not be disabled — a hung import loop would go "
+            "undetected (#514)."
+        )
+        assert hc.get("test"), (
+            "watcher healthcheck must define a 'test' command (#514)."
+        )
+
+    def test_watcher_does_not_inherit_http_probe(self) -> None:
+        """The watcher serves no HTTP, so its healthcheck must not be the app
+        image's :8000 probe — it should test the import-loop heartbeat instead."""
+        watcher = self._services()["watcher"]
+        test = watcher.get("healthcheck", {}).get("test")
+        test_str = " ".join(test) if isinstance(test, list) else str(test)
+        assert "8000" not in test_str, (
+            "watcher healthcheck must not probe :8000 — it serves no HTTP (#514)."
         )
 
     def test_song_history_keeps_its_healthcheck(self) -> None:


### PR DESCRIPTION
## Summary
Hardens the Pi production stack (`deploy/pi/docker-compose.yml`). Config-only; two issues, one file.

Closes #512
Closes #514

### #512 — app image was mutable `:latest`
Both `song-history` and `watcher` ran `ghcr.io/mshirel/song-history:latest`, so `docker compose pull` could silently swap running app code with no digest record or rollback target. Now pinned to the immutable CI-published `sha-` tag + digest:

```
ghcr.io/mshirel/song-history:sha-61914d1e42feb8b5becf0cf0936e28df14bf561c@sha256:5f3a1a4599e50ce80f8920c91631af6b6e73ec4be702bb511ca301b1cf073a57
```

- The `sha-<commit>` tag = current `main` HEAD (`61914d1`); the digest was resolved live from GHCR on 2026-07-03 (it is what `:latest` currently points to). Both tag **and** digest are present (belt-and-suspenders); Docker pulls by digest.
- Both services are pinned in lockstep. Dependabot's `docker` ecosystem entry (#502, once landed) will bump this on a reviewed PR.

> ⚠️ **Maintainer confirmation requested on the exact pin.** I pinned to the digest that `:latest` resolved to today (= `main@61914d1`), because the registry publishes no `:vX.Y.Z` semver tags yet (only `sha-*` + `latest`) — the newest git release tag `v1.2.0` has **no** corresponding image tag in GHCR. If you'd rather deploy a specific older/tested build, swap the `sha-…@sha256:…` reference for the desired one. The value is real and resolvable as-is.

### #514 — promtail root + watcher liveness gap
- **promtail non-root**: `user: root` → `user: "10001:0"` (non-root uid; gid 0 to read the group-readable Docker json logs). Host prep (log-dir ACL if daemon uses 0600, and positions-dir ownership so promtail can write `positions.yaml`) is documented inline and in `docs/pi-deploy.md`.
- **watcher healthcheck**: replaced `healthcheck: {disable: true}` with a lightweight heartbeat check. The import loop now `touch`es `/tmp/watcher-heartbeat` each iteration; the check fails if that file is stale (>660s ≈ 2 loop cycles), so a wedged/hung import is caught by monitoring — `restart: unless-stopped` only catches a full process exit, not a hang. The check does not probe :8000 (the watcher serves no HTTP).

## Tests (`tests/test_pi_compose.py`)
- `TestAppImagePinning` — app image is digest/version-pinned, not bare `:latest`, for both services (mirrors the regex from #512).
- `TestPromtailNotRoot` — promtail uid is non-root.
- `TestWatcherHealthcheck` — watcher has an active healthcheck that is not disabled and does not probe :8000 (replaces the old "must be disabled" assertion from #402).

## Validation
- `uv run python -m pytest tests/test_pi_compose.py -v` — **9 passed**
- `uv run python -m pytest -m "not e2e" -q` — **1284 passed, 9 skipped, 2 xfailed**
- `uv run ruff check src/` — **All checks passed**
- `uv run mypy src/` — 7 pre-existing errors (unused `type: ignore` in `web/app.py`), confirmed present on `origin/main`; this PR touches no `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)