### PR TITLE
fix: close sprint 2 and sprint 4 backlog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Specialized QA agents (invoke when relevant):
 
 Run a specific file: `python3 -m pytest tests/test_web.py -v`
 Run with coverage: `python3 -m pytest --cov=worship_catalog`
-Run only fast tests: `python3 -m pytest -m "not integration"`
+Run only fast tests: `python3 -m pytest -m "unit and not slow"`
 
 ---
 

--- a/deploy/pi/fail2ban/jail.d/sshd.local
+++ b/deploy/pi/fail2ban/jail.d/sshd.local
@@ -1,0 +1,6 @@
+[sshd]
+enabled = true
+backend = systemd
+maxretry = 5
+findtime = 10m
+bantime = 1h

--- a/docs/pi-deploy.md
+++ b/docs/pi-deploy.md
@@ -51,6 +51,14 @@ Because the host serves a public tunnel, lock it down. Codified in the repo:
   `deploy/pi/firewall/docker-user-firewall.sh` + its systemd unit (#447).
 - **Key-only SSH** — install `deploy/pi/ssh/00-hardening.conf` (the `00-` prefix
   must sort before `50-cloud-init.conf`); `PasswordAuthentication no` (#452).
+- **fail2ban for SSH** — install `fail2ban`, copy
+  `deploy/pi/fail2ban/jail.d/sshd.local` into `/etc/fail2ban/jail.d/`, then
+  `sudo systemctl enable --now fail2ban`. Verify with
+  `systemctl is-active fail2ban` and `sudo fail2ban-client status sshd` (#452).
+  On Ubuntu Noble / Python 3.12, the distro `fail2ban` package also needs the
+  `asynchat` compatibility module; install `pyasynchat` into
+  `/usr/local/lib/python3.12/dist-packages/asynchat` before starting the
+  service if the journal shows `No module named 'asynchat'`.
 - **Token rotation** — if `.env` was ever world-readable, rotate the Cloudflare
   API token and tunnel token in the Cloudflare dashboard (#446).
 - **promtail runs non-root** (`user: "10001:0"`, #514) — least privilege on the
@@ -88,7 +96,7 @@ Install **Raspberry Pi OS Lite 64-bit** (no desktop). Enable SSH during flash wi
 sudo apt-get update && sudo apt-get upgrade -y
 curl -fsSL https://get.docker.com | sh
 sudo usermod -aG docker $USER
-sudo apt-get install -y sqlite3   # needed by backup.sh
+sudo apt-get install -y sqlite3 fail2ban   # backup + SSH hardening
 # Log out and back in for docker group change to take effect
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,8 @@ select = ["E", "F", "W", "I", "N", "UP", "B"]
 paths_to_mutate = [
     "src/worship_catalog/normalize.py",
     "src/worship_catalog/extractor.py",
+    "src/worship_catalog/import_service.py",
+    "src/worship_catalog/db.py",
 ]
 tests_dir = ["tests/"]
 

--- a/src/worship_catalog/ocr.py
+++ b/src/worship_catalog/ocr.py
@@ -47,6 +47,31 @@ def _validate_ocr_output(text: str) -> str | None:
     return text
 
 
+def _iter_text_blocks(content: object) -> list[str]:
+    """Return text payloads from Claude response blocks, tolerating absent/empty blocks."""
+    if not isinstance(content, list):
+        return []
+
+    texts: list[str] = []
+    for block in content:
+        text = getattr(block, "text", None)
+        block_type = getattr(block, "type", None)
+        if isinstance(text, str) and (block_type == "text" or not isinstance(block_type, str)):
+            texts.append(text)
+    return texts
+
+
+def _retryable_ocr_errors(anthropic: object) -> tuple[type[BaseException], ...]:
+    """Return only transient Anthropic exception classes."""
+    retryable_names = ("RateLimitError", "InternalServerError", "APIConnectionError")
+    retryable: list[type[BaseException]] = []
+    for name in retryable_names:
+        exc_type = getattr(anthropic, name, None)
+        if isinstance(exc_type, type) and issubclass(exc_type, BaseException):
+            retryable.append(exc_type)
+    return tuple(retryable)
+
+
 def extract_credits_via_vision(image_bytes: bytes) -> str | None:
     """
     Use Claude Vision API to extract the credits line from a slide image.
@@ -115,8 +140,8 @@ def extract_credits_via_vision(image_bytes: bytes) -> str | None:
     }
 
     # Retry on transient API errors with exponential backoff
-    _retryable = (anthropic.RateLimitError, anthropic.APIStatusError)
-    last_exc: Exception | None = None
+    _retryable = _retryable_ocr_errors(anthropic)
+    last_exc: BaseException | None = None
     for attempt in range(_MAX_RETRIES):
         try:
             message = client.messages.create(**request_kwargs)
@@ -138,7 +163,10 @@ def extract_credits_via_vision(image_bytes: bytes) -> str | None:
     else:
         raise last_exc  # type: ignore[misc]
 
-    raw = message.content[0].text.strip()
+    text_blocks = _iter_text_blocks(message.content)
+    if not text_blocks:
+        return None
+    raw = text_blocks[0].strip()
     if raw.lower() == "none" or not raw:
         return None
     return _validate_ocr_output(raw)

--- a/src/worship_catalog/services/report_service.py
+++ b/src/worship_catalog/services/report_service.py
@@ -29,7 +29,11 @@ def compute_stats_data(
     """
     services = db.query_services(start_date, end_date, song_leader=leader or None)
     service_ids = [s["id"] for s in services]
-    events = db.query_copy_events(start_date, end_date, service_ids=service_ids or None)
+    events = (
+        db.query_copy_events(start_date, end_date, service_ids=service_ids)
+        if service_ids
+        else []
+    )
 
     # Count distinct services per song title (not raw copy-event rows).
     # A song with multiple copy events in one service (e.g., projection + recording)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ os.environ.setdefault("TESTING", "1")
 
 import socket  # noqa: E402
 from collections.abc import Generator  # noqa: E402
+from pathlib import Path  # noqa: E402
 from typing import Any  # noqa: E402
 
 import pytest  # noqa: E402
@@ -20,6 +21,20 @@ from worship_catalog.pptx_reader import Slide, SlideImage, SlideText  # noqa: E4
 
 # E2E server URL — configurable via env var for CI (default: local dev server)
 E2E_BASE_URL = os.environ.get("E2E_BASE_URL", "http://localhost:8000")
+
+_TEST_MARKERS = ("unit", "integration", "slow", "e2e")
+_FILE_MARKERS: dict[str, str] = {
+    "test_backup_sh.py": "slow",
+    "test_db_integration.py": "integration",
+    "test_e2e_htmx.py": "e2e",
+    "test_e2e_playwright.py": "e2e",
+    "test_extraction_integration.py": "integration",
+    "test_missing_services_report.py": "integration",
+    "test_pi_init_sh.py": "slow",
+    "test_scripts_sigterm.py": "slow",
+    "test_seed_pi_db_sh.py": "slow",
+    "test_uat_acceptance.py": "e2e",
+}
 
 
 def _e2e_server_is_running() -> bool:
@@ -37,6 +52,25 @@ def _e2e_server_is_running() -> bool:
 
 
 _e2e_server_available = _e2e_server_is_running()
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Auto-mark unclassified tests so marker-based slices stay meaningful."""
+    for item in items:
+        if any(item.get_closest_marker(name) for name in _TEST_MARKERS):
+            continue
+
+        filename = Path(str(item.fspath)).name
+        marker_name = _FILE_MARKERS.get(filename)
+        if marker_name is None:
+            if filename.startswith("test_e2e_") or filename == "test_uat_acceptance.py":
+                marker_name = "e2e"
+            elif filename.endswith("_integration.py"):
+                marker_name = "integration"
+            else:
+                marker_name = "unit"
+
+        item.add_marker(getattr(pytest.mark, marker_name))
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_e2e_htmx.py
+++ b/tests/test_e2e_htmx.py
@@ -21,7 +21,7 @@ import pytest
 pytest.importorskip("playwright", reason="playwright not installed — run: pip install playwright")
 
 # browser_page fixture and BASE_URL come from conftest.py
-from tests.conftest import E2E_BASE_URL as BASE_URL
+from conftest import E2E_BASE_URL as BASE_URL
 
 
 @pytest.mark.e2e

--- a/tests/test_e2e_imports.py
+++ b/tests/test_e2e_imports.py
@@ -1,0 +1,23 @@
+"""Collection-safety checks for Playwright modules."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def test_e2e_module_imports_cleanly_for_non_e2e_collection() -> None:
+    """Non-e2e pytest collection should not depend on a tests.* package import."""
+    tests_dir = Path(__file__).parent
+    module_path = tests_dir / "test_e2e_htmx.py"
+
+    sys.path.insert(0, str(tests_dir))
+    try:
+        spec = importlib.util.spec_from_file_location("test_e2e_htmx_import_smoke", module_path)
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.pop(0)

--- a/tests/test_e2e_playwright.py
+++ b/tests/test_e2e_playwright.py
@@ -24,7 +24,8 @@ import pytest
 pytest.importorskip("playwright", reason="playwright not installed — run: pip install playwright")
 
 # browser_page fixture and BASE_URL come from conftest.py
-from tests.conftest import E2E_BASE_URL as BASE_URL
+from conftest import E2E_BASE_URL as BASE_URL
+from conftest import UPLOAD_PROBE_SONG_TITLE
 
 
 @pytest.mark.e2e
@@ -104,6 +105,91 @@ class TestServicesPageHTMX:
         browser_page.goto(f"{BASE_URL}/services")
         browser_page.wait_for_load_state("networkidle")
         assert browser_page.locator("table").count() >= 1
+
+    def test_song_leader_filter_updates_results_via_htmx(self, browser_page) -> None:
+        """Changing the leader filter should update #services-results without duplicating tables."""
+        browser_page.goto(f"{BASE_URL}/services")
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.select_option("#filter-leader", label="Matt")
+        browser_page.wait_for_load_state("networkidle")
+
+        rows = browser_page.locator("#services-results tbody tr").count()
+        assert rows >= 1
+        assert browser_page.locator("#services-results table").count() == 1
+
+
+@pytest.mark.e2e
+class TestReportsE2E:
+    """E2E tests for HTMX report flows and dynamic download bindings."""
+
+    def test_ccli_preview_renders_inline_results(self, browser_page) -> None:
+        """The Preview button should swap report content into the CCLI result region."""
+        browser_page.goto(f"{BASE_URL}/reports")
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.click("#tab-ccli")
+        browser_page.wait_for_selector("#ccli-from", state="visible")
+        browser_page.fill("#ccli-from", "2026-01-01")
+        browser_page.fill("#ccli-to", "2026-12-31")
+        browser_page.click('button[hx-post="/reports/ccli/preview"]')
+        browser_page.wait_for_selector("#ccli-result", state="visible")
+        browser_page.wait_for_timeout(500)
+
+        result_text = (browser_page.text_content("#ccli-result") or "").lower()
+        assert "reproduction" in result_text or "no songs were reproduced" in result_text
+
+    def test_stats_xlsx_download_works_after_htmx_swap(self, browser_page) -> None:
+        """Stats XLSX form should be rebound after the HTMX stats result swap."""
+        browser_page.goto(f"{BASE_URL}/reports")
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.fill("#stats-from", "2026-01-01")
+        browser_page.fill("#stats-to", "2026-12-31")
+        browser_page.click('form[hx-post="/reports/stats"] button[type="submit"]')
+        browser_page.wait_for_selector("#stats-result .stat-box", timeout=10000)
+        browser_page.wait_for_timeout(500)
+
+        with browser_page.expect_download(timeout=15000) as download_info:
+            browser_page.locator("#stats-xlsx-form button").click()
+
+        download = download_info.value
+        assert download.suggested_filename.endswith(".xlsx")
+
+    def test_missing_services_tab_loads_without_duplicate_tables(self, browser_page) -> None:
+        """The Missing Services tab should load its HTMX result region cleanly."""
+        browser_page.goto(f"{BASE_URL}/reports")
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.click("#tab-missing")
+        browser_page.wait_for_selector("#missing-result", state="visible")
+        browser_page.wait_for_timeout(1000)
+
+        assert browser_page.locator("#missing-result").count() == 1
+        assert browser_page.locator("#missing-result table").count() <= 1
+
+
+@pytest.mark.e2e
+class TestUploadFlowE2E:
+    """E2E coverage for the async upload -> job poll flow."""
+
+    def test_upload_probe_song_reaches_library(self, browser_page, upload_probe_pptx) -> None:
+        """Uploading a valid PPTX should complete and make the probe song searchable."""
+        browser_page.goto(f"{BASE_URL}/upload")
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.set_input_files('input[type="file"]', str(upload_probe_pptx))
+        browser_page.click('button[type="submit"]')
+        browser_page.wait_for_function(
+            """() => {
+                const el = document.getElementById('upload-result');
+                if (!el) return false;
+                const t = el.textContent.toLowerCase();
+                return t.includes('imported') || t.includes('complete') || t.includes('no songs');
+            }""",
+            timeout=30000,
+        )
+
+        browser_page.goto(f"{BASE_URL}/songs")
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.fill('input[name="q"]', UPLOAD_PROBE_SONG_TITLE)
+        browser_page.wait_for_load_state("networkidle")
+        assert UPLOAD_PROBE_SONG_TITLE in (browser_page.text_content("body") or "")
 
 
 @pytest.mark.e2e

--- a/tests/test_extractor_unit.py
+++ b/tests/test_extractor_unit.py
@@ -425,7 +425,6 @@ class TestPptxSizeLimits:
 
     def test_file_within_limit_is_accepted(self, tmp_path: Path) -> None:
         """A small PPTX within size limit is not rejected by size check."""
-        from tests.test_extractor_unit import TestExtractSongsFileHash
         pptx_bytes = TestExtractSongsFileHash()._minimal_pptx()
         small_file = tmp_path / "small.pptx"
         small_file.write_bytes(pptx_bytes)
@@ -482,7 +481,6 @@ class TestExtractionLogging:
     def test_extract_songs_logs_song_count(self, tmp_path, caplog):
         """extract_songs() should log how many songs were found."""
         import logging
-        from tests.test_extractor_unit import TestExtractSongsFileHash
 
         pptx_bytes = TestExtractSongsFileHash()._minimal_pptx()
         pptx_path = tmp_path / "test.pptx"

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -5,6 +5,37 @@ Also verifies mutation testing tooling is installed (issue #90).
 
 import subprocess
 import sys
+from collections.abc import Sequence
+
+
+def _run_pytest_collect(args: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Run pytest collection and return the completed process."""
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _parse_collect_counts(output: str) -> tuple[int, int]:
+    """Return (selected, deselected) from quiet collect-only output."""
+    import re
+
+    no_tests = re.search(r"no tests collected(?: \((\d+) deselected\))?", output)
+    if no_tests:
+        return 0, int(no_tests.group(1) or 0)
+
+    match = re.search(r"(\d+)(?:/(\d+))? tests? collected(?: \((\d+) deselected\))?", output)
+    assert match, f"Could not parse collection counts from output:\n{output}"
+
+    if match.group(2) is not None:
+        selected = int(match.group(1))
+        deselected = int(match.group(3) or 0)
+    else:
+        selected = int(match.group(1))
+        deselected = 0
+    return selected, deselected
 
 
 def test_slow_marker_is_registered() -> None:
@@ -50,24 +81,20 @@ def test_not_slow_excludes_marked_tests() -> None:
     Collects tests from test_backup_sh.py and asserts none are selected when
     ``-m 'not slow'`` is active (all backup tests carry @pytest.mark.slow).
     """
-    result = subprocess.run(
+    result = _run_pytest_collect(
         [
-            sys.executable, "-m", "pytest",
             "tests/test_backup_sh.py",
-            "-m", "not slow",
-            "--collect-only", "-q",
+            "-m",
+            "not slow",
+            "--collect-only",
+            "-q",
             "--no-header",
             "--no-cov",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
+        ]
     )
-    # All backup tests are marked slow, so none should appear in the collected list
-    assert "test_backup" not in result.stdout or "deselected" in result.stdout, (
-        "Expected all backup tests to be deselected by -m 'not slow'. "
-        f"Output:\n{result.stdout}"
-    )
+    selected, deselected = _parse_collect_counts(result.stdout)
+    assert selected == 0, f"Expected all backup tests to be deselected, got:\n{result.stdout}"
+    assert deselected > 0, f"Expected backup tests to count as deselected, got:\n{result.stdout}"
 
 
 def test_e2e_marker_is_registered() -> None:
@@ -108,7 +135,6 @@ class TestIntegrationSkipBehavior:
 
     def test_integration_marker_is_registered(self, pytestconfig):
         """The 'integration' marker must be a known pytest marker (in pyproject.toml)."""
-        markers = {m.name for m in pytestconfig.getini("markers") if hasattr(m, "name")}
         # Fallback: check via string representation of registered markers
         marker_strings = pytestconfig.getini("markers")
         registered_names = set()
@@ -131,25 +157,43 @@ class TestIntegrationSkipBehavior:
         file is absent — that is expected and correct behaviour.  The count below
         verifies there are DB-only integration tests that always run.
         """
-        result = subprocess.run(
+        result = _run_pytest_collect(
             [
-                sys.executable, "-m", "pytest",
-                "-m", "integration",
-                "--collect-only", "-q",
+                "-m",
+                "integration",
+                "--collect-only",
+                "-q",
                 "--no-header",
                 "--no-cov",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
+            ]
         )
         # The output line "N/M tests collected (K deselected)" should show N > 0.
         # We just assert the command succeeded and found some integration tests.
         assert result.returncode == 0, (
             f"pytest collect for integration tests failed:\n{result.stderr}"
         )
-        # There should be integration tests collected — if count is 0 the test suite
-        # has lost coverage of DB-layer integration paths.
-        assert "collected" in result.stdout or "test" in result.stdout, (
-            f"No integration tests found in collection output:\n{result.stdout}"
-        )
+        selected, _ = _parse_collect_counts(result.stdout)
+        assert selected >= 5, f"Expected at least 5 integration tests, got:\n{result.stdout}"
+
+
+def test_all_tests_are_sliceable_by_runtime_markers() -> None:
+    """Every test should land in at least one of the runtime markers."""
+    total = _run_pytest_collect(["--collect-only", "-q", "--no-header", "--no-cov"])
+    marked = _run_pytest_collect(
+        [
+            "-m",
+            "unit or integration or slow or e2e",
+            "--collect-only",
+            "-q",
+            "--no-header",
+            "--no-cov",
+        ]
+    )
+    assert total.returncode == 0, f"Full collection failed:\n{total.stderr}"
+    assert marked.returncode == 0, f"Marked collection failed:\n{marked.stderr}"
+    total_selected, _ = _parse_collect_counts(total.stdout)
+    marked_selected, _ = _parse_collect_counts(marked.stdout)
+    assert marked_selected == total_selected, (
+        "Some tests are still outside the marker slices.\n"
+        f"Full: {total.stdout}\nMarked: {marked.stdout}"
+    )

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,7 +1,7 @@
 """Tests for worship_catalog.ocr — Vision API credit extraction."""
 
 import sys
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -348,7 +348,7 @@ class TestOcrNamePatternValidation:
         assert result is not None
 
     def test_end_to_end_keywords_no_name_returns_none_from_api(self, monkeypatch):
-        """Full pipeline: API returns keywords-only text → extract_credits_via_vision returns None."""
+        """Full pipeline: keywords-only OCR text should be rejected."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         mock_anthropic = MagicMock()
         mock_client = MagicMock()
@@ -368,9 +368,9 @@ class TestRetryLogic:
         """Return a mock anthropic module with an Anthropic class."""
         mock_anthropic = MagicMock()
         mock_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_anthropic.APIStatusError = type(
-            "APIStatusError", (Exception,), {"status_code": 500}
-        )
+        mock_anthropic.InternalServerError = type("InternalServerError", (Exception,), {})
+        mock_anthropic.APIConnectionError = type("APIConnectionError", (Exception,), {})
+        mock_anthropic.AuthenticationError = type("AuthenticationError", (Exception,), {})
         return mock_anthropic
 
     def test_max_retries_constant_is_3(self):
@@ -427,6 +427,22 @@ class TestRetryLogic:
         with patch.dict(sys.modules, {"anthropic": mock_anthropic}):
             with patch("time.sleep") as mock_sleep:
                 with pytest.raises(ValueError):
+                    extract_credits_via_vision(b"\xff\xd8\x00\x00")
+
+        assert mock_client.messages.create.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_authentication_errors_are_not_retried(self, monkeypatch):
+        """Permanent 4xx auth failures should fail fast without backoff."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        mock_anthropic = self._make_mock_anthropic()
+        mock_client = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_client.messages.create.side_effect = mock_anthropic.AuthenticationError("bad key")
+
+        with patch.dict(sys.modules, {"anthropic": mock_anthropic}):
+            with patch("time.sleep") as mock_sleep:
+                with pytest.raises(mock_anthropic.AuthenticationError, match="bad key"):
                     extract_credits_via_vision(b"\xff\xd8\x00\x00")
 
         assert mock_client.messages.create.call_count == 1
@@ -513,7 +529,7 @@ class TestValidateOcrOutput:
         assert result is not None
 
 
-class TestExtractCreditsViaVision:
+class TestExtractCreditsViaVisionMockedResponses:
     """Tests for the Vision API call with mocked client (#339)."""
 
     def test_returns_none_when_api_says_none(self, monkeypatch):
@@ -525,7 +541,8 @@ class TestExtractCreditsViaVision:
         mock_anthropic = MagicMock()
         mock_anthropic.Anthropic.return_value = mock_client
         mock_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_anthropic.APIStatusError = type("APIStatusError", (Exception,), {})
+        mock_anthropic.InternalServerError = type("InternalServerError", (Exception,), {})
+        mock_anthropic.APIConnectionError = type("APIConnectionError", (Exception,), {})
         monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
         # Re-import to pick up the mock
         result = extract_credits_via_vision(b"\xff\xd8fake-jpeg")
@@ -540,7 +557,8 @@ class TestExtractCreditsViaVision:
         mock_anthropic = MagicMock()
         mock_anthropic.Anthropic.return_value = mock_client
         mock_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
-        mock_anthropic.APIStatusError = type("APIStatusError", (Exception,), {})
+        mock_anthropic.InternalServerError = type("InternalServerError", (Exception,), {})
+        mock_anthropic.APIConnectionError = type("APIConnectionError", (Exception,), {})
         monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
         result = extract_credits_via_vision(b"\xff\xd8fake-jpeg")
         assert result is not None
@@ -550,3 +568,33 @@ class TestExtractCreditsViaVision:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         with pytest.raises(OSError, match="ANTHROPIC_API_KEY"):
             extract_credits_via_vision(b"\xff\xd8fake")
+
+    def test_returns_none_for_empty_content_blocks(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        msg = MagicMock()
+        msg.content = []
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = msg
+        mock_anthropic = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
+        mock_anthropic.InternalServerError = type("InternalServerError", (Exception,), {})
+        mock_anthropic.APIConnectionError = type("APIConnectionError", (Exception,), {})
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+
+        assert extract_credits_via_vision(b"\xff\xd8fake-jpeg") is None
+
+    def test_returns_none_for_non_text_content_blocks(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+        msg = MagicMock()
+        msg.content = [type("Block", (), {"type": "tool_use"})()]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = msg
+        mock_anthropic = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        mock_anthropic.RateLimitError = type("RateLimitError", (Exception,), {})
+        mock_anthropic.InternalServerError = type("InternalServerError", (Exception,), {})
+        mock_anthropic.APIConnectionError = type("APIConnectionError", (Exception,), {})
+        monkeypatch.setitem(sys.modules, "anthropic", mock_anthropic)
+
+        assert extract_credits_via_vision(b"\xff\xd8fake-jpeg") is None

--- a/tests/test_pi_hardening.py
+++ b/tests/test_pi_hardening.py
@@ -67,3 +67,18 @@ class TestSshHardening:
         assert (_PI / "ssh" / "00-hardening.conf").is_file(), (
             "drop-in must be named 00-* to beat 50-cloud-init.conf (first-match-wins)"
         )
+
+
+class TestFail2Ban:
+    """Fail2ban config must exist for the public-service host (#452)."""
+
+    def test_sshd_jail_exists_and_is_enabled(self) -> None:
+        jail = (_PI / "fail2ban" / "jail.d" / "sshd.local").read_text()
+        assert "enabled = true" in jail
+        assert "backend = systemd" in jail
+
+    def test_sshd_jail_sets_retry_and_ban_windows(self) -> None:
+        jail = (_PI / "fail2ban" / "jail.d" / "sshd.local").read_text()
+        assert "maxretry = 5" in jail
+        assert "findtime = 10m" in jail
+        assert "bantime = 1h" in jail

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -57,8 +57,9 @@ class TestReportService:
     def test_web_app_uses_report_service(self):
         """web/app.py _compute_stats delegates to report_service.compute_stats_data."""
         import inspect
-        from worship_catalog.web import app as web_app
+
         from worship_catalog.services import report_service  # noqa: F401
+        from worship_catalog.web import app as web_app
         # The web _compute_stats should either be removed or call report_service
         src = inspect.getsource(web_app)
         assert "report_service" in src or "compute_stats_data" in src
@@ -66,6 +67,7 @@ class TestReportService:
     def test_cli_stats_delegates_to_compute_stats_data(self):
         """cli.py stats command must delegate to report_service.compute_stats_data (#167)."""
         import inspect
+
         from worship_catalog import cli
         # Click wraps the function; get source of the callback or the module
         src = inspect.getsource(cli)
@@ -141,6 +143,15 @@ class TestComputeStatsDataExtended:
         data = compute_stats_data(seeded_db, "2020-01-01", "2030-12-31", "Matt", False)
         leaders = [s["song_leader"] for s in data["services"]]
         assert "John" not in leaders
+
+    def test_leader_filter_with_no_matching_services_returns_empty_report(self, seeded_db):
+        data = compute_stats_data(seeded_db, "2020-01-01", "2030-12-31", "Nobody", False)
+        assert data["services"] == []
+        assert data["events"] == []
+        assert data["sorted_songs"] == []
+        assert data["total_performances"] == 0
+        assert data["leader_breakdown"] == {}
+        assert data["leader_service_counts"] == {}
 
     def test_all_songs_false_limits_to_top_20(self, tmp_path):
         db = Database(tmp_path / "top20.db")

--- a/tests/test_uat_acceptance.py
+++ b/tests/test_uat_acceptance.py
@@ -30,7 +30,7 @@ import pytest
 pytest.importorskip("playwright", reason="playwright not installed -- run: pip install playwright")
 
 # browser_page fixture and BASE_URL come from conftest.py
-from tests.conftest import E2E_BASE_URL as BASE_URL
+from conftest import E2E_BASE_URL as BASE_URL
 
 # ---------------------------------------------------------------------------
 # #242 -- Upload form E2E
@@ -489,8 +489,9 @@ class TestUploadWorkflowE2E:
     def test_upload_valid_pptx_shows_progress_and_completion(self, browser_page: Any) -> None:
         """Upload a valid PPTX and verify the polling shows completion (#324)."""
         # Create a minimal valid PPTX in memory
-        from pptx import Presentation
         import io as _io
+
+        from pptx import Presentation
         prs = Presentation()
         # Add a metadata slide
         slide_layout = prs.slide_layouts[5]  # blank
@@ -541,7 +542,7 @@ class TestUploadWorkflowE2E:
         """Full pipeline (#412): upload a PPTX → wait for the background import to
         complete → confirm its (uniquely-titled) song appears in /songs. Proves the
         upload→thread-pool→SQLite→render path end-to-end, which TestClient can't."""
-        from tests.conftest import UPLOAD_PROBE_SONG_TITLE
+        from conftest import UPLOAD_PROBE_SONG_TITLE
 
         browser_page.goto(f"{BASE_URL}/upload")
         browser_page.wait_for_load_state("networkidle")


### PR DESCRIPTION
## Summary
- fix stats and OCR edge cases from Sprint 4 and make Playwright/UAT modules safe to collect in non-e2e runs
- auto-mark unclassified tests, expand mutation scope, and extend dedicated Playwright coverage for reports, services filters, and upload flows
- add reproducible fail2ban SSH hardening artifacts for pi-songs, document the Python 3.12 asynchat compatibility wrinkle, and apply the host-side hardening live

## Validation
- `uv run pytest tests/test_report_service.py tests/test_ocr.py tests/test_e2e_imports.py`
- `uv run pytest tests/test_markers.py tests/test_e2e_imports.py -q`
- `uv run pytest tests/test_extractor_unit.py -q`
- `uv run pytest tests/test_pi_hardening.py tests/test_pi_deploy_doc.py -q`
- `E2E_BASE_URL=http://127.0.0.1:8000 uv run pytest tests/test_e2e_playwright.py -m e2e -q`
- `uv run pytest -m "not e2e"`
- `uv run mypy src`
- verified on pi-songs: `passwordauthentication no`, `ufw` active, `fail2ban` active with `sshd` jail

Closes #452
Closes #499
Closes #505
Closes #506
Closes #507
Closes #508
Closes #529
Closes #530
