### PR TITLE
fix: close sprint 5 ux, a11y, and docs backlog

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -118,8 +118,21 @@ Open **http://localhost:8000** to access:
 | Services         | `/services`       | Filterable list of all imported services          |
 | Service Detail   | `/services/{id}`  | Setlist and metadata for a service                |
 | Leaders          | `/leaders`        | Song leader directory with top songs              |
-| Reports          | `/reports`        | Generate CCLI CSV or stats report in browser      |
+| Reports          | `/reports`        | Generate stats, CCLI CSV, or missing-services reports |
+| Upload           | `/upload`         | Browser upload flow for importing a PPTX deck     |
+| About            | `/about`          | App overview plus version and build details       |
 | Health           | `/health`         | `{"status": "ok"}` for Docker healthcheck         |
+
+---
+
+### Uploading In The Browser
+
+The `/upload` page is the easiest way for a church volunteer to add a slide deck.
+
+- When `UPLOAD_PASSWORD` is unset, browser upload is open by default.
+- When `UPLOAD_PASSWORD` is set, `/upload` shows a `Log in to upload` button. Opening `/upload?login=1` triggers the browser's HTTP Basic-auth prompt.
+- `UPLOAD_USERNAME` defaults to `highland` if you do not set it explicitly.
+- The same credentials are required for `/jobs` and for editing exclusions in the Missing Services report.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -318,12 +318,23 @@ Open `http://localhost:8000`.
 | Song Detail | `/songs/{id}` | Full service history for a single song |
 | Services | `/services` | Filterable, sortable list of all imported services |
 | Service Detail | `/services/{id}` | Complete setlist and metadata for a single service |
-| Reports | `/reports` | Generate CCLI CSV download or view stats report in browser |
+| Reports | `/reports` | Generate CCLI CSV download, stats report, or missing-services report |
+| Upload | `/upload` | Browser upload flow for importing a PPTX slide deck |
+| About | `/about` | App purpose, version, build metadata, and source link |
 | Health | `/health` | Returns `{"status": "ok"}` — used by Docker healthcheck |
 
 **Songs page:** search filters live as you type; click any column header to sort.
 **Services page:** filter by date range, service name, song leader, preacher, or sermon title; click headers to sort.
-**Reports:** stats report supports date range, song leader filter (partial match), and top-20 vs all-songs toggle.
+**Reports:** stats report supports date range, leader dropdown, and top-20 vs all-songs toggle. Missing Services is available under the same page.
+
+### Browser Uploading
+
+`/upload` is the browser-first path for church volunteers to add a worship deck without using the CLI.
+
+- If `UPLOAD_PASSWORD` is unset, `/upload` stays open and any visitor can submit a `.pptx`.
+- If `UPLOAD_PASSWORD` is set, `/upload` requires HTTP Basic auth. The page shows a `Log in to upload` button that links to `/upload?login=1`, which triggers the browser login prompt.
+- `UPLOAD_USERNAME` defaults to `highland` when unset; set it if you want a different username shown in the Basic-auth dialog.
+- The same auth gate also protects `/jobs` and Missing Services edit actions.
 
 ---
 

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -615,6 +615,11 @@ async def root() -> RedirectResponse:
     return RedirectResponse(url="/songs")
 
 
+def _is_htmx_history_restore(request: Request) -> bool:
+    """True when HTMX is replaying browser history and needs the full page shell."""
+    return request.headers.get("HX-History-Restore-Request", "").lower() == "true"
+
+
 @app.get("/songs", response_class=HTMLResponse)
 async def songs(
     request: Request,
@@ -641,16 +646,24 @@ async def songs(
     }
     # HTMX search/sort swaps the whole #songs-results region (table + footer)
     # so the pagination footer never drifts from the rows shown (#386).
-    template = "_songs_results.html" if request.headers.get("HX-Request") else "songs.html"
+    template = (
+        "songs.html"
+        if _is_htmx_history_restore(request) or not request.headers.get("HX-Request")
+        else "_songs_results.html"
+    )
     return templates.TemplateResponse(request, template, context)
 
 
 @app.get("/reports", response_class=HTMLResponse)
-async def reports_page(request: Request) -> HTMLResponse:
+async def reports_page(
+    request: Request,
+    db: Database = Depends(get_db),  # noqa: B008
+) -> HTMLResponse:
     return templates.TemplateResponse(
         request,
         "reports.html",
         {
+            "leaders": db.query_distinct_song_leaders(),
             "window_options": WINDOW_OPTIONS,
             "default_window": str(DEFAULT_WINDOW_DAYS),
         },
@@ -1029,7 +1042,7 @@ async def services_list(
         "q_sermon": q_sermon, "start_date": start_date, "end_date": end_date,
         "page": page, "per_page": per_page, "total_pages": total_pages, "total": total,
     }
-    if request.headers.get("HX-Request"):
+    if request.headers.get("HX-Request") and not _is_htmx_history_restore(request):
         return templates.TemplateResponse(request, "_services_results.html", ctx)
     ctx["service_names"] = db.query_distinct_service_names()
     ctx["leaders"] = db.query_distinct_song_leaders()
@@ -1425,5 +1438,3 @@ async def get_job(
     if job is None:
         raise HTTPException(status_code=404, detail="Job not found")
     return JSONResponse(content=job)
-
-

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -620,6 +620,12 @@ def _is_htmx_history_restore(request: Request) -> bool:
     return request.headers.get("HX-History-Restore-Request", "").lower() == "true"
 
 
+def _set_htmx_vary_headers(response: HTMLResponse) -> HTMLResponse:
+    """Separate HTMX fragment responses from full-page browser navigations in caches."""
+    response.headers["Vary"] = "HX-Request, HX-History-Restore-Request"
+    return response
+
+
 @app.get("/songs", response_class=HTMLResponse)
 async def songs(
     request: Request,
@@ -651,7 +657,7 @@ async def songs(
         if _is_htmx_history_restore(request) or not request.headers.get("HX-Request")
         else "_songs_results.html"
     )
-    return templates.TemplateResponse(request, template, context)
+    return _set_htmx_vary_headers(templates.TemplateResponse(request, template, context))
 
 
 @app.get("/reports", response_class=HTMLResponse)
@@ -1043,11 +1049,13 @@ async def services_list(
         "page": page, "per_page": per_page, "total_pages": total_pages, "total": total,
     }
     if request.headers.get("HX-Request") and not _is_htmx_history_restore(request):
-        return templates.TemplateResponse(request, "_services_results.html", ctx)
+        return _set_htmx_vary_headers(
+            templates.TemplateResponse(request, "_services_results.html", ctx)
+        )
     ctx["service_names"] = db.query_distinct_service_names()
     ctx["leaders"] = db.query_distinct_song_leaders()
     ctx["preachers"] = db.query_distinct_preachers()
-    return templates.TemplateResponse(request, "services.html", ctx)
+    return _set_htmx_vary_headers(templates.TemplateResponse(request, "services.html", ctx))
 
 
 @app.get("/services/{service_id}", response_class=HTMLResponse)

--- a/src/worship_catalog/web/static/nav.js
+++ b/src/worship_catalog/web/static/nav.js
@@ -1,0 +1,26 @@
+/**
+ * Keep the mobile nav checkbox's aria-expanded state synchronized with its
+ * actual checked state. External file preserves CSP script-src 'self'.
+ */
+(function () {
+  "use strict";
+
+  function syncExpanded(toggle) {
+    toggle.setAttribute("aria-expanded", toggle.checked ? "true" : "false");
+  }
+
+  function init() {
+    var toggle = document.getElementById("nav-toggle");
+    if (!toggle) return;
+    syncExpanded(toggle);
+    toggle.addEventListener("change", function () {
+      syncExpanded(toggle);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/src/worship_catalog/web/templates/about.html
+++ b/src/worship_catalog/web/templates/about.html
@@ -16,10 +16,11 @@
 <div class="card">
   <h2>Version and Build Info</h2>
   <table>
-    <tr><td><strong>Version</strong></td><td>{{ version }}</td></tr>
-    <tr><td><strong>Build Date</strong></td><td>{{ build_date }}</td></tr>
-    <tr><td><strong>Python</strong></td><td>{{ python_version }}</td></tr>
-    <tr><td><strong>Database</strong></td><td>{{ db_path }}</td></tr>
+    <caption class="sr-only">Version and build details for this deployment</caption>
+    <tr><th scope="row">Version</th><td>{{ version }}</td></tr>
+    <tr><th scope="row">Build Date</th><td>{{ build_date }}</td></tr>
+    <tr><th scope="row">Python</th><td>{{ python_version }}</td></tr>
+    <tr><th scope="row">Database</th><td>{{ db_path }}</td></tr>
   </table>
 </div>
 

--- a/src/worship_catalog/web/templates/base.html
+++ b/src/worship_catalog/web/templates/base.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="htmx-config" content='{"historyCacheSize":0,"refreshOnHistoryMiss":true}'>
   <title>{% block title %}Highland Worship Catalog{% endblock %}</title>
   <script src="/static/htmx.min.js"></script>
   <style>

--- a/src/worship_catalog/web/templates/base.html
+++ b/src/worship_catalog/web/templates/base.html
@@ -6,6 +6,11 @@
   <title>{% block title %}Highland Worship Catalog{% endblock %}</title>
   <script src="/static/htmx.min.js"></script>
   <style>
+    :root {
+      --text-muted: #5c636a;
+      --text-subtle: #495057;
+    }
+
     *, *::before, *::after { box-sizing: border-box; }
 
     body {
@@ -30,7 +35,7 @@
     nav a { color: #ccc; text-decoration: none; font-size: 0.95rem; }
     nav a:hover, nav a.active { color: #fff; }
 
-    /* CSS-only hamburger: hidden checkbox toggles .nav-links on small screens (no JS, CSP-safe). */
+    /* Checkbox controls the mobile nav; nav.js mirrors its state to aria-expanded. */
     #nav-toggle { position: absolute; opacity: 0; width: 1px; height: 1px; }
     .nav-burger { display: none; cursor: pointer; color: #fff; font-size: 1.5rem; line-height: 1; padding: 0.25rem 0.5rem; margin-left: auto; }
     #nav-toggle:focus-visible + .nav-burger { outline: 2px solid #fff; outline-offset: 2px; }
@@ -148,7 +153,7 @@
 <nav>
   <img src="/static/highland-logo.png" alt="Highland logo" class="brand-logo">
   <span class="brand">Highland Worship Catalog</span>
-  <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation menu">
+  <input type="checkbox" id="nav-toggle" aria-label="Toggle navigation menu" aria-expanded="false">
   <label class="nav-burger" for="nav-toggle"><span aria-hidden="true">&#9776;</span><span class="sr-only">Menu</span></label>
   <div class="nav-links">
     <a href="/songs" {% if request.url.path.startswith('/songs') %}class="active"{% endif %}>Songs</a>
@@ -163,5 +168,6 @@
 <main id="main">
   {% block content %}{% endblock %}
 </main>
+<script src="/static/nav.js"></script>
 </body>
 </html>

--- a/src/worship_catalog/web/templates/leader_top_songs.html
+++ b/src/worship_catalog/web/templates/leader_top_songs.html
@@ -2,7 +2,7 @@
 {% block title %}{{ leader }} — Top Songs — Highland Worship Catalog{% endblock %}
 {% block content %}
 <h1>{{ leader }}</h1>
-<p style="color:#6c757d;">{{ service_count }} service{{ 's' if service_count != 1 else '' }} led</p>
+<p style="color:var(--text-muted);">{{ service_count }} service{{ 's' if service_count != 1 else '' }} led</p>
 
 {% if warning_few_services %}
 <div style="background:#fff3cd;border:1px solid #ffc107;border-radius:4px;padding:0.75rem 1rem;margin-bottom:1rem;font-size:0.9rem;">
@@ -18,18 +18,19 @@
 <div class="card" style="padding:0;">
   <div class="table-wrap">
   <table>
+    <caption class="sr-only">Top songs led by {{ leader }}</caption>
     <thead>
       <tr>
-        <th>#</th>
-        <th>Title</th>
-        <th>Credits</th>
-        <th style="text-align:right;">Count</th>
+        <th scope="col">#</th>
+        <th scope="col">Title</th>
+        <th scope="col">Credits</th>
+        <th scope="col" style="text-align:right;">Count</th>
       </tr>
     </thead>
     <tbody>
       {% for song in top_songs %}
       <tr>
-        <td style="color:#6c757d;">{{ loop.index }}</td>
+        <td style="color:var(--text-muted);">{{ loop.index }}</td>
         <td><a href="/songs/{{ song.song_id }}">{{ song.display_title }}</a></td>
         <td style="font-size:0.85rem;color:#495057;">
           {%- set parts = [] -%}
@@ -45,7 +46,7 @@
   </div>
 </div>
 {% else %}
-<p style="color:#6c757d;">No songs have been led at {{ min_count }}+ services.</p>
+<p style="color:var(--text-muted);">No songs have been led at {{ min_count }}+ services.</p>
 {% endif %}
 
 <div style="margin-top:1.5rem;">

--- a/src/worship_catalog/web/templates/leaders.html
+++ b/src/worship_catalog/web/templates/leaders.html
@@ -7,11 +7,12 @@
 <div class="card" style="padding:0;">
   <div class="table-wrap">
   <table>
+    <caption class="sr-only">Song leaders with service counts and links to leader-specific top songs</caption>
     <thead>
       <tr>
-        <th>Leader</th>
-        <th style="text-align:right;">Services</th>
-        <th></th>
+        <th scope="col">Leader</th>
+        <th scope="col" style="text-align:right;">Services</th>
+        <th scope="col"><span class="sr-only">Actions</span></th>
       </tr>
     </thead>
     <tbody>
@@ -29,6 +30,6 @@
   </div>
 </div>
 {% else %}
-<p style="color:#6c757d;">No leaders found. Import some services first.</p>
+<p style="color:var(--text-muted);">No leaders found. Import some services first.</p>
 {% endif %}
 {% endblock %}

--- a/src/worship_catalog/web/templates/reports.html
+++ b/src/worship_catalog/web/templates/reports.html
@@ -15,7 +15,7 @@
 <!-- Song Statistics (default tab) -->
 <section role="tabpanel" id="panel-stats" aria-labelledby="tab-stats" tabindex="0">
   <div class="card">
-    <h2>Song Statistics <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(view in browser)</small></h2>
+    <h2><span>Song Statistics</span> <small style="font-weight:400;color:var(--text-muted);font-size:0.85rem">(view in browser)</small></h2>
     <form
       method="post"
       action="/reports/stats"
@@ -37,15 +37,20 @@
         <label for="stats-leader" style="display:block;font-size:0.8rem;font-weight:600;color:#495057;margin-bottom:0.25rem;">
           Filter by Song Leader
         </label>
-        <input type="text" id="stats-leader" name="leader" placeholder="e.g. Matt" style="width:100%;max-width:320px;" aria-describedby="leader-help">
-        <span id="leader-help" style="font-size:0.75rem;color:#6c757d;">Optional — partial match</span>
+        <select id="stats-leader" name="leader" style="width:100%;max-width:320px;" aria-describedby="leader-help">
+          <option value="">All leaders</option>
+          {% for leader_name in leaders %}
+          <option value="{{ leader_name }}">{{ leader_name }}</option>
+          {% endfor %}
+        </select>
+        <span id="leader-help" style="font-size:0.75rem;color:var(--text-muted);">Optional — choose one leader</span>
       </div>
       <div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap;">
         <button type="submit">Generate</button>
         <label for="all-songs" style="font-size:0.85rem;display:flex;align-items:center;gap:0.4rem;">
           <input type="checkbox" id="all-songs" name="all_songs" value="true"> Show all songs (not just top 20)
         </label>
-        <span id="stats-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
+        <span id="stats-spinner" class="htmx-indicator" style="color:var(--text-muted);font-size:0.85rem;">loading…</span>
       </div>
     </form>
     <div id="stats-result" style="margin-top:1.25rem;" aria-live="polite"></div>
@@ -55,7 +60,7 @@
 <!-- CCLI Compliance (secondary tab) -->
 <section role="tabpanel" id="panel-ccli" aria-labelledby="tab-ccli" tabindex="0" hidden>
   <div class="card">
-    <h2>CCLI Compliance Report <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(CSV download)</small></h2>
+    <h2>CCLI Compliance Report <small style="font-weight:400;color:var(--text-muted);font-size:0.85rem">(CSV download)</small></h2>
     <p style="font-size:0.85rem;color:#495057;margin-bottom:0.75rem;">
       Generate the CSV report of song reproductions required for CCLI licence compliance.
     </p>
@@ -81,7 +86,7 @@
                 hx-include="#ccli-form"
                 hx-target="#ccli-result"
                 hx-indicator="#ccli-spinner">Preview</button>
-        <span id="ccli-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
+        <span id="ccli-spinner" class="htmx-indicator" style="color:var(--text-muted);font-size:0.85rem;">loading…</span>
       </div>
     </form>
     <div id="ccli-result" style="margin-top:0.5rem;"></div>
@@ -91,7 +96,7 @@
 <!-- Missing Services (tertiary tab) -->
 <section role="tabpanel" id="panel-missing" aria-labelledby="tab-missing" tabindex="0" hidden>
   <div class="card">
-    <h2>Missing Services <small style="font-weight:400;color:#6c757d;font-size:0.85rem">(view in browser)</small></h2>
+    <h2>Missing Services <small style="font-weight:400;color:var(--text-muted);font-size:0.85rem">(view in browser)</small></h2>
     <p style="font-size:0.85rem;color:#495057;margin-bottom:0.75rem;">
       Sundays normally have a morning and an evening service. This lists slots with no
       service in the catalog over the selected time frame; mark intentional gaps as excluded.
@@ -108,7 +113,7 @@
         <option value="{{ value }}"{% if value == default_window %} selected{% endif %}>{{ label }}</option>
         {% endfor %}
       </select>
-      <span id="missing-spinner" class="htmx-indicator" style="color:#6c757d;font-size:0.85rem;">loading…</span>
+      <span id="missing-spinner" class="htmx-indicator" style="color:var(--text-muted);font-size:0.85rem;">loading…</span>
     </form>
     <div id="missing-result" style="margin-top:0.5rem;" aria-live="polite"></div>
   </div>

--- a/src/worship_catalog/web/templates/services.html
+++ b/src/worship_catalog/web/templates/services.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h1>Services</h1>
 
+<div hx-history-elt>
 {# Filter bar — wrapped in a form so HTMX serializes all fields once (no stale hidden duplicates) #}
 <form id="filter-form" autocomplete="off">
   <input type="hidden" name="sort"     value="{{ sort }}">
@@ -74,5 +75,6 @@
    footer and screen-reader count never drift from the rows shown (#431). #}
 <div id="services-results">
 {% include "_services_results.html" %}
+</div>
 </div>
 {% endblock %}

--- a/src/worship_catalog/web/templates/services.html
+++ b/src/worship_catalog/web/templates/services.html
@@ -11,26 +11,26 @@
   <div class="card" style="margin-bottom:1rem;">
     {% if start_date or end_date or q_service or q_leader or q_preacher or q_sermon %}
     <div style="text-align:right;margin-bottom:0.5rem;">
-      <a href="/services" style="font-size:0.85rem;color:#6c757d;">Clear all filters</a>
+      <a href="/services" style="font-size:0.85rem;color:var(--text-muted);">Clear all filters</a>
     </div>
     {% endif %}
     <div class="form-grid">
       <div>
         <label for="filter-start-date" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Date From</label>
         <input type="date" id="filter-start-date" name="start_date" value="{{ start_date }}"
-          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-push-url="true" hx-swap="innerHTML"
           hx-include="#filter-form">
       </div>
       <div>
         <label for="filter-end-date" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Date To</label>
         <input type="date" id="filter-end-date" name="end_date" value="{{ end_date }}"
-          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-push-url="true" hx-swap="innerHTML"
           hx-include="#filter-form">
       </div>
       <div>
         <label for="filter-service" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Service</label>
         <select id="filter-service" name="q_service"
-          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-push-url="true" hx-swap="innerHTML"
           hx-include="#filter-form">
           <option value="">All services</option>
           {% for name in service_names %}
@@ -41,7 +41,7 @@
       <div>
         <label for="filter-leader" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Song Leader</label>
         <select id="filter-leader" name="q_leader"
-          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-push-url="true" hx-swap="innerHTML"
           hx-include="#filter-form">
           <option value="">All leaders</option>
           {% for leader in leaders %}
@@ -52,7 +52,7 @@
       <div>
         <label for="filter-preacher" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Preacher</label>
         <select id="filter-preacher" name="q_preacher"
-          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-swap="innerHTML"
+          hx-get="/services" hx-trigger="change" hx-target="#services-results" hx-push-url="true" hx-swap="innerHTML"
           hx-include="#filter-form">
           <option value="">All preachers</option>
           {% for preacher in preachers %}
@@ -63,7 +63,7 @@
       <div>
         <label for="filter-sermon" style="font-size:0.8rem;font-weight:600;color:#495057;display:block;margin-bottom:0.2rem;">Sermon</label>
         <input type="text" id="filter-sermon" name="q_sermon" value="{{ q_sermon }}" placeholder="filter…"
-          hx-get="/services" hx-trigger="input changed delay:300ms" hx-target="#services-results" hx-swap="innerHTML"
+          hx-get="/services" hx-trigger="input changed delay:300ms" hx-target="#services-results" hx-push-url="true" hx-swap="innerHTML"
           hx-include="#filter-form">
       </div>
     </div>

--- a/src/worship_catalog/web/templates/song_detail.html
+++ b/src/worship_catalog/web/templates/song_detail.html
@@ -3,12 +3,12 @@
 {% block content %}
 
 <div style="margin-bottom:1rem;">
-  <a href="/songs" style="color:#6c757d;font-size:0.85rem;text-decoration:none;">← All Songs</a>
+  <a href="/songs" style="color:var(--text-muted);font-size:0.85rem;text-decoration:none;">← All Songs</a>
 </div>
 
 <h1 style="margin-bottom:0.25rem;">{{ song.display_title }}</h1>
 {% if song.canonical_title != song.display_title %}
-<p style="color:#6c757d;font-size:0.85rem;margin:0 0 1.25rem;">
+<p style="color:var(--text-muted);font-size:0.85rem;margin:0 0 1.25rem;">
   Canonical: <em>{{ song.canonical_title }}</em>
 </p>
 {% else %}
@@ -22,31 +22,31 @@
   <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:0.75rem 1.5rem;">
     {% if ed.words_by %}
     <div>
-      <div style="font-size:0.75rem;font-weight:600;color:#6c757d;text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Words By</div>
+      <div style="font-size:0.75rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Words By</div>
       <div>{{ ed.words_by }}</div>
     </div>
     {% endif %}
     {% if ed.music_by %}
     <div>
-      <div style="font-size:0.75rem;font-weight:600;color:#6c757d;text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Music By</div>
+      <div style="font-size:0.75rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Music By</div>
       <div>{{ ed.music_by }}</div>
     </div>
     {% endif %}
     {% if ed.arranger %}
     <div>
-      <div style="font-size:0.75rem;font-weight:600;color:#6c757d;text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Arranger</div>
+      <div style="font-size:0.75rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Arranger</div>
       <div>{{ ed.arranger }}</div>
     </div>
     {% endif %}
     {% if ed.publisher %}
     <div>
-      <div style="font-size:0.75rem;font-weight:600;color:#6c757d;text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Publisher</div>
+      <div style="font-size:0.75rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Publisher</div>
       <div style="font-size:0.85rem;">{{ ed.publisher }}</div>
     </div>
     {% endif %}
     {% if ed.copyright_notice %}
     <div style="grid-column:1/-1;">
-      <div style="font-size:0.75rem;font-weight:600;color:#6c757d;text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Copyright</div>
+      <div style="font-size:0.75rem;font-weight:600;color:var(--text-muted);text-transform:uppercase;letter-spacing:.05em;margin-bottom:0.2rem;">Copyright</div>
       <div style="font-size:0.85rem;color:#495057;">{{ ed.copyright_notice }}</div>
     </div>
     {% endif %}
@@ -57,24 +57,25 @@
 <!-- Performance summary -->
 <h2 style="font-size:1.1rem;margin-bottom:0.75rem;">
   Service History
-  <span style="font-weight:400;color:#6c757d;font-size:0.9rem;">
+  <span style="font-weight:400;color:var(--text-muted);font-size:0.9rem;">
     — sung {{ service_history | length }} time{{ 's' if service_history | length != 1 else '' }}
   </span>
 </h2>
 
 {% if not service_history %}
-<p style="color:#6c757d;">No services recorded for this song.</p>
+<p style="color:var(--text-muted);">No services recorded for this song.</p>
 {% else %}
 <div class="card" style="padding:0;">
   <div class="table-wrap">
   <table>
+    <caption class="sr-only">Service history for {{ song.display_title }}</caption>
     <thead>
       <tr>
-        <th>Date</th>
-        <th>Service</th>
-        <th>Song Leader</th>
-        <th style="text-align:center;">#</th>
-        <th>Reproductions</th>
+        <th scope="col">Date</th>
+        <th scope="col">Service</th>
+        <th scope="col">Song Leader</th>
+        <th scope="col" style="text-align:center;">#</th>
+        <th scope="col">Reproductions</th>
       </tr>
     </thead>
     <tbody>
@@ -87,7 +88,7 @@
         </td>
         <td>{{ svc.service_name }}</td>
         <td>{{ svc.song_leader or '—' }}</td>
-        <td style="text-align:center;color:#6c757d;">{{ svc.ordinal }}</td>
+        <td style="text-align:center;color:var(--text-muted);">{{ svc.ordinal }}</td>
         <td style="font-size:0.85rem;color:#495057;">{{ svc.copy_types or '—' }}</td>
       </tr>
       {% endfor %}

--- a/src/worship_catalog/web/templates/songs.html
+++ b/src/worship_catalog/web/templates/songs.html
@@ -6,6 +6,7 @@
   {{ library_size }} unique song{{ "s" if library_size != 1 else "" }} in the library
 </p>
 
+<div hx-history-elt>
 {# Hidden inputs carry sort state into HTMX search requests #}
 <input type="hidden" name="sort" value="{{ sort }}">
 <input type="hidden" name="sort_dir" value="{{ sort_dir }}">
@@ -35,5 +36,6 @@
    drifts from the rows shown (#386). #}
 <div id="songs-results">
 {% include "_songs_results.html" %}
+</div>
 </div>
 {% endblock %}

--- a/src/worship_catalog/web/templates/songs.html
+++ b/src/worship_catalog/web/templates/songs.html
@@ -2,7 +2,7 @@
 {% block title %}Songs — Highland Worship Catalog{% endblock %}
 {% block content %}
 <h1>Song Library</h1>
-<p style="color:#6c757d;margin-top:-0.75rem;margin-bottom:1rem;">
+<p style="color:var(--text-muted);margin-top:-0.75rem;margin-bottom:1rem;">
   {{ library_size }} unique song{{ "s" if library_size != 1 else "" }} in the library
 </p>
 
@@ -22,12 +22,13 @@
     hx-get="/songs"
     hx-trigger="input changed delay:300ms, search"
     hx-target="#songs-results"
+    hx-push-url="true"
     hx-swap="innerHTML"
     hx-include="[name='q'],[name='sort'],[name='sort_dir']"
     hx-indicator="#spinner"
     autofocus
   >
-  <span id="spinner" class="htmx-indicator" style="align-self:center;color:#6c757d;font-size:0.85rem;">searching…</span>
+  <span id="spinner" class="htmx-indicator" style="align-self:center;color:var(--text-muted);font-size:0.85rem;">searching…</span>
 </div>
 
 {# Search/sort swaps this whole region (table + footer) so pagination never

--- a/tests/test_e2e_playwright.py
+++ b/tests/test_e2e_playwright.py
@@ -89,6 +89,24 @@ class TestSongsPageHTMX:
         assert browser_page.locator("tbody").count() > 0
         assert browser_page.url  # no crash/redirect
 
+    def test_songs_search_survives_back_button(self, browser_page) -> None:
+        """HTMX search should push URL state so browser Back restores the filter."""
+        browser_page.goto(f"{BASE_URL}/songs")
+        browser_page.wait_for_load_state("networkidle")
+
+        browser_page.fill('input[name="q"]', "grace")
+        browser_page.wait_for_timeout(500)
+
+        link = browser_page.locator("#song-tbody tr td a").first
+        if link.count() == 0:
+            pytest.skip("No song rows in the DB to open")
+        link.click()
+        browser_page.wait_for_load_state("networkidle")
+        browser_page.go_back()
+        browser_page.wait_for_load_state("networkidle")
+
+        assert browser_page.input_value('input[name="q"]') == "grace"
+
 
 @pytest.mark.e2e
 class TestServicesPageHTMX:
@@ -259,7 +277,7 @@ class TestMobileResponsive:
         assert "/songs/" in browser_page.url, "Tapping a song row did not open the detail page"
 
     def test_nav_toggle_reveals_links_mobile(self, browser_page) -> None:
-        """Nav links are hidden until the CSS-only hamburger is toggled (no JS)."""
+        """Nav links are hidden until the hamburger is toggled."""
         browser_page.set_viewport_size(self.MOBILE)
         browser_page.goto(f"{BASE_URL}/songs")
         browser_page.wait_for_load_state("networkidle")
@@ -270,3 +288,14 @@ class TestMobileResponsive:
 
         browser_page.click("label[for='nav-toggle']")
         assert services_link.is_visible(), "Hamburger toggle did not reveal the nav links"
+
+    def test_nav_toggle_exposes_expanded_state(self, browser_page) -> None:
+        """The nav toggle should expose open/closed state to assistive tech."""
+        browser_page.set_viewport_size(self.MOBILE)
+        browser_page.goto(f"{BASE_URL}/songs")
+        browser_page.wait_for_load_state("networkidle")
+
+        toggle = browser_page.locator("#nav-toggle")
+        assert toggle.get_attribute("aria-expanded") == "false"
+        browser_page.click("label[for='nav-toggle']")
+        assert toggle.get_attribute("aria-expanded") == "true"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3,6 +3,7 @@
 import io
 import json
 import os
+import re
 import sqlite3
 import uuid as _uuid_mod
 from pathlib import Path
@@ -81,6 +82,16 @@ class TestSongsPage:
         # stays in sync with the rows (#386).
         assert "<tbody" in response.text
 
+    def test_songs_history_restore_returns_full_page(self, client):
+        """HTMX history restoration must receive the full songs page shell."""
+        response = client.get(
+            "/songs?q=Amazing",
+            headers={"HX-Request": "true", "HX-History-Restore-Request": "true"},
+        )
+        assert response.status_code == 200
+        assert "<html" in response.text.lower() or "<!doctype" in response.text.lower()
+        assert 'name="q"' in response.text
+
     def test_songs_empty_search_returns_all(self, client):
         response = client.get("/songs?q=")
         assert response.status_code == 200
@@ -126,6 +137,31 @@ class TestReportsPage:
         response = client.get("/reports")
         assert "stats" in response.text.lower()
         assert "/reports/stats" in response.text
+
+    def test_reports_page_uses_leader_select_not_text_input(self, client):
+        body = client.get("/reports").text
+        assert '<input type="text" id="stats-leader"' not in body
+        assert re.search(r'<select[^>]*name="leader"', body)
+
+    def test_reports_page_leader_select_has_all_leaders_default(self, client):
+        body = client.get("/reports").text
+        assert re.search(r'<option value="">\s*All leaders\s*</option>', body)
+
+    def test_reports_page_leader_select_is_populated(self, client, db_with_songs):
+        body = client.get("/reports").text
+        db = Database(db_with_songs)
+        db.connect()
+        for leader in db.query_distinct_song_leaders():
+            assert f'<option value="{leader}">' in body
+        db.close()
+
+    def test_reports_page_leader_select_has_associated_label(self, client):
+        body = client.get("/reports").text
+        match = re.search(r'<select[^>]*id="([^"]+)"[^>]*name="leader"', body) or re.search(
+            r'<select[^>]*name="leader"[^>]*id="([^"]+)"', body,
+        )
+        assert match, "leader select needs an id for label association"
+        assert f'for="{match.group(1)}"' in body
 
 
 class TestMissingServicesReport:
@@ -285,6 +321,7 @@ class TestStatsReport:
         )
         assert response.status_code == 200
         assert "Amazing Grace" in response.text  # Matt led this service
+        assert "Matt" in response.text
 
     def test_stats_leader_filter_no_match(self, client):
         """Leader filter with no matching services shows empty state."""
@@ -376,6 +413,16 @@ class TestServicesListPage:
     def test_services_page_links_to_detail(self, client, db_with_songs):
         response = client.get("/services")
         assert "/services/" in response.text
+
+    def test_services_history_restore_returns_full_page(self, client):
+        """HTMX history restoration must receive the full services page shell."""
+        response = client.get(
+            "/services?q_leader=Matt",
+            headers={"HX-Request": "true", "HX-History-Restore-Request": "true"},
+        )
+        assert response.status_code == 200
+        assert "<html" in response.text.lower() or "<!doctype" in response.text.lower()
+        assert 'id="filter-form"' in response.text
 
     def test_services_empty_db_shows_message(self, client, tmp_path, monkeypatch):
         empty_db = tmp_path / "empty.db"
@@ -3215,19 +3262,48 @@ class TestResponsiveLayout:
             "Services table is not wrapped in a .table-wrap scroll container"
         )
 
-    def test_nav_has_css_only_toggle(self, client):
-        """Mobile nav must collapse via a CSS-only checkbox toggle (no JS, CSP-safe)."""
+    def test_nav_has_mobile_toggle(self, client):
+        """Mobile nav must keep the checkbox toggle and remain CSP-safe."""
         resp = client.get("/songs")
         assert resp.status_code == 200
         html = resp.text
         assert 'id="nav-toggle"' in html, "No #nav-toggle checkbox for the hamburger menu"
         assert 'for="nav-toggle"' in html, "No <label for=nav-toggle> hamburger control"
+        assert 'aria-expanded="false"' in html, "Nav toggle must expose collapsed state"
+        assert "/static/nav.js" in html, "Nav toggle state script must be loaded from /static/"
         # The toggle must not introduce any new inline script (CSP blocks inline JS).
-        import re
         inline_scripts = re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", html)
         assert not inline_scripts, (
             f"Nav added {len(inline_scripts)} inline <script> tag(s) blocked by CSP"
         )
+
+    def test_songs_search_pushes_url_state(self, client):
+        html = client.get("/songs").text
+        assert 'hx-push-url="true"' in html
+
+    def test_services_filters_push_url_state(self, client):
+        html = client.get("/services").text
+        assert html.count('hx-push-url="true"') >= 6
+
+    def test_leaders_table_headers_have_scope(self, client):
+        body = client.get("/leaders").text
+        assert "<th></th>" not in body
+        assert 'scope="col"' in body
+        assert "<caption" in body
+
+    def test_about_build_table_uses_row_headers_and_caption(self, client):
+        body = client.get("/about").text
+        assert "<caption" in body
+        assert 'scope="row"' in body
+
+    def test_song_detail_history_table_has_caption(self, client):
+        body = client.get("/songs/1").text
+        assert "<caption" in body
+
+    def test_top_songs_table_has_caption(self, client):
+        body = client.get("/leaders/Matt/top-songs").text
+        if "<table" in body:
+            assert "<caption" in body
 
 
 class TestHtmxSelfHosted:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -73,6 +73,7 @@ class TestSongsPage:
         """HTMX requests return the results region only (no full-page chrome)."""
         response = client.get("/songs?q=Amazing", headers={"HX-Request": "true"})
         assert response.status_code == 200
+        assert response.headers["Vary"] == "HX-Request, HX-History-Restore-Request"
         assert "Amazing Grace" in response.text
         # Partial must not include the base layout chrome.
         lowered = response.text.lower()
@@ -89,6 +90,7 @@ class TestSongsPage:
             headers={"HX-Request": "true", "HX-History-Restore-Request": "true"},
         )
         assert response.status_code == 200
+        assert response.headers["Vary"] == "HX-Request, HX-History-Restore-Request"
         assert "<html" in response.text.lower() or "<!doctype" in response.text.lower()
         assert 'name="q"' in response.text
 
@@ -421,6 +423,7 @@ class TestServicesListPage:
             headers={"HX-Request": "true", "HX-History-Restore-Request": "true"},
         )
         assert response.status_code == 200
+        assert response.headers["Vary"] == "HX-Request, HX-History-Restore-Request"
         assert "<html" in response.text.lower() or "<!doctype" in response.text.lower()
         assert 'id="filter-form"' in response.text
 
@@ -3280,10 +3283,14 @@ class TestResponsiveLayout:
     def test_songs_search_pushes_url_state(self, client):
         html = client.get("/songs").text
         assert 'hx-push-url="true"' in html
+        assert "hx-history-elt" in html
+        assert '"historyCacheSize":0' in html
+        assert '"refreshOnHistoryMiss":true' in html
 
     def test_services_filters_push_url_state(self, client):
         html = client.get("/services").text
         assert html.count('hx-push-url="true"') >= 6
+        assert "hx-history-elt" in html
 
     def test_leaders_table_headers_have_scope(self, client):
         body = client.get("/leaders").text


### PR DESCRIPTION
## Summary
- replace the reports leader text input with a populated dropdown
- push HTMX song/service filter state into the URL so browser Back restores filters
- finish the remaining WCAG polish for nav state and table semantics
- document /upload, /about, missing-services, and the UPLOAD_PASSWORD login flow

## Validation
- `uv run pytest tests/test_web.py -q`
- `uv run pytest -m "not e2e"`
- `uv run mypy src`
- `uv run ruff check src/worship_catalog/web/app.py`

Closes #470
Closes #504
Closes #516
Closes #517
