### PR TITLE
[codex] fail backups on sqlite dump errors

### DIFF
--- a/deploy/pi/scripts/backup.sh
+++ b/deploy/pi/scripts/backup.sh
@@ -20,9 +20,13 @@
 set -eu
 
 # Trap EXIT to guarantee temp file cleanup and Pushover failure notifications.
+_DUMPFILE=""
 _TMPFILE=""
 _cleanup() {
     _rc=$?
+    if [ -n "$_DUMPFILE" ]; then
+        rm -f "$_DUMPFILE"
+    fi
     if [ -n "$_TMPFILE" ]; then
         rm -f "$_TMPFILE"
     fi
@@ -56,13 +60,22 @@ if [ ! -f "$DB_PATH" ]; then
 fi
 
 STAMP="$(date +%Y%m%d-%H%M%S)"
+_DUMPFILE="$(mktemp /tmp/backup-XXXXXX.sql)"
 _TMPFILE="$(mktemp /tmp/backup-XXXXXX.sql.gz)"
 
-# Dump + compress into a temp file so a partial write is never mistaken for valid
-if ! sqlite3 "$DB_PATH" '.dump' | gzip > "$_TMPFILE"; then
-    echo "[backup] ERROR: dump/compress failed for $DB_PATH" >&2
+# Keep dump and compression separate: POSIX pipelines report only the final
+# command's status, which can hide a failed sqlite3 behind a successful gzip.
+if ! sqlite3 "$DB_PATH" '.dump' > "$_DUMPFILE"; then
+    echo "[backup] ERROR: SQLite dump failed for $DB_PATH" >&2
     exit 1
 fi
+
+if ! gzip -c "$_DUMPFILE" > "$_TMPFILE"; then
+    echo "[backup] ERROR: compression failed for $DB_PATH" >&2
+    exit 1
+fi
+rm -f "$_DUMPFILE"
+_DUMPFILE=""
 
 # Integrity check before promoting to the final location
 if ! gzip -t "$_TMPFILE"; then

--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -13,11 +13,10 @@ Due: 2026-07-31. Focus: restore operational safety and deliver image-only score
 recognition after establishing a reproducible development and CI environment.
 
 - #537 `arch`: recognize songs presented as scanned sheet-music image slides
-- #544 `devops`: fail backups when the SQLite dump fails
 - #545 `devops`: deploy the non-root Promtail configuration to `pi-songs`
 - #547 `security`: refresh the HTMX CSRF header after token rotation
 
-Completed by the dependency-authority change: #542 and #546.
+Completed: #542, #544, and #546.
 
 ## Sprint 4 - Data correctness and OCR rollout
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -20,9 +20,13 @@
 set -eu
 
 # Trap EXIT to guarantee temp file cleanup and Pushover failure notifications.
+_DUMPFILE=""
 _TMPFILE=""
 _cleanup() {
     _rc=$?
+    if [ -n "$_DUMPFILE" ]; then
+        rm -f "$_DUMPFILE"
+    fi
     if [ -n "$_TMPFILE" ]; then
         rm -f "$_TMPFILE"
     fi
@@ -56,13 +60,22 @@ if [ ! -f "$DB_PATH" ]; then
 fi
 
 STAMP="$(date +%Y%m%d-%H%M%S)"
+_DUMPFILE="$(mktemp /tmp/backup-XXXXXX.sql)"
 _TMPFILE="$(mktemp /tmp/backup-XXXXXX.sql.gz)"
 
-# Dump + compress into a temp file so a partial write is never mistaken for valid
-if ! sqlite3 "$DB_PATH" '.dump' | gzip > "$_TMPFILE"; then
-    echo "[backup] ERROR: dump/compress failed for $DB_PATH" >&2
+# Keep dump and compression separate: POSIX pipelines report only the final
+# command's status, which can hide a failed sqlite3 behind a successful gzip.
+if ! sqlite3 "$DB_PATH" '.dump' > "$_DUMPFILE"; then
+    echo "[backup] ERROR: SQLite dump failed for $DB_PATH" >&2
     exit 1
 fi
+
+if ! gzip -c "$_DUMPFILE" > "$_TMPFILE"; then
+    echo "[backup] ERROR: compression failed for $DB_PATH" >&2
+    exit 1
+fi
+rm -f "$_DUMPFILE"
+_DUMPFILE=""
 
 # Integrity check before promoting to the final location
 if ! gzip -t "$_TMPFILE"; then

--- a/tests/test_backup_sh.py
+++ b/tests/test_backup_sh.py
@@ -1,12 +1,19 @@
 """Tests for scripts/backup.sh — integrity check and sentinel file (#28)."""
 
 import gzip
+import http.server
+import os
+import sqlite3
 import subprocess
 from pathlib import Path
 
 import pytest
 
 BACKUP_SCRIPT = Path(__file__).parent.parent / "scripts" / "backup.sh"
+DEPLOY_BACKUP_SCRIPT = (
+    Path(__file__).parent.parent / "deploy" / "pi" / "scripts" / "backup.sh"
+)
+BACKUP_SCRIPTS = (BACKUP_SCRIPT, DEPLOY_BACKUP_SCRIPT)
 
 
 def run_backup(
@@ -146,14 +153,14 @@ def _run_backup_with_env(
     db_path: Path,
     backup_dir: Path,
     extra_env: dict[str, str] | None = None,
+    backup_script: Path = BACKUP_SCRIPT,
 ) -> subprocess.CompletedProcess[str]:
     """Run backup.sh with optional extra environment variables."""
-    import os
     env = os.environ.copy()
     if extra_env:
         env.update(extra_env)
     return subprocess.run(
-        ["bash", str(BACKUP_SCRIPT), str(db_path), str(backup_dir)],
+        ["sh", str(backup_script), str(db_path), str(backup_dir)],
         capture_output=True,
         text=True,
         env=env,
@@ -162,7 +169,6 @@ def _run_backup_with_env(
 
 def _make_db(tmp_path: Path) -> Path:
     """Create a minimal SQLite DB for testing."""
-    import sqlite3
     db_path = tmp_path / "worship.db"
     conn = sqlite3.connect(db_path)
     conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
@@ -172,13 +178,73 @@ def _make_db(tmp_path: Path) -> Path:
 
 
 @pytest.mark.slow
+class TestBackupDumpFailure:
+    """A failed sqlite3 dump must never be promoted as a successful backup (#544)."""
+
+    @pytest.mark.parametrize("backup_script", BACKUP_SCRIPTS)
+    def test_sqlite_dump_failure_is_not_promoted(
+        self,
+        tmp_path: Path,
+        backup_script: Path,
+    ) -> None:
+        db_path = _make_db(tmp_path)
+        backup_dir = tmp_path / "backups"
+        backup_dir.mkdir()
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_sqlite = fake_bin / "sqlite3"
+        fake_sqlite.write_text("#!/bin/sh\nexit 7\n")
+        fake_sqlite.chmod(0o755)
+
+        result = _run_backup_with_env(
+            db_path,
+            backup_dir,
+            {"PATH": f"{fake_bin}:{os.environ['PATH']}"},
+            backup_script,
+        )
+
+        assert result.returncode != 0
+        assert not list(backup_dir.glob("worship-*.sql.gz"))
+        assert not (backup_dir / ".last_success").exists()
+        assert "ERROR" in result.stderr
+
+    @pytest.mark.parametrize("backup_script", BACKUP_SCRIPTS)
+    def test_backup_sql_restores_known_row(
+        self,
+        tmp_path: Path,
+        backup_script: Path,
+    ) -> None:
+        db_path = tmp_path / "worship.db"
+        backup_dir = tmp_path / "backups"
+        backup_dir.mkdir()
+        source = sqlite3.connect(db_path)
+        source.execute("CREATE TABLE known_data (value TEXT NOT NULL)")
+        source.execute("INSERT INTO known_data VALUES ('restored')")
+        source.commit()
+        source.close()
+
+        result = _run_backup_with_env(
+            db_path,
+            backup_dir,
+            backup_script=backup_script,
+        )
+        assert result.returncode == 0, result.stderr
+        backup = next(backup_dir.glob("worship-*.sql.gz"))
+
+        restored = sqlite3.connect(":memory:")
+        with gzip.open(backup, "rt") as sql_dump:
+            restored.executescript(sql_dump.read())
+        row = restored.execute("SELECT value FROM known_data").fetchone()
+        restored.close()
+        assert row == ("restored",)
+
+
+@pytest.mark.slow
 class TestBackupPushoverNotification:
     """backup.sh sends a Pushover notification on failure — closes #136."""
 
-    def _make_post_server(self) -> tuple["http.server.HTTPServer", "list[dict[str, str]]"]:
+    def _make_post_server(self) -> tuple[http.server.HTTPServer, list[dict[str, str]]]:
         """Start a local HTTP server that records POST requests."""
-        import http.server
-
         posts_received: list[dict[str, str]] = []
 
         class _Handler(http.server.BaseHTTPRequestHandler):
@@ -309,7 +375,7 @@ class TestBackupPushoverNotification:
         assert not posts_received, "backup.sh must not notify when USER_KEY is missing"
 
     def test_notification_failure_is_non_fatal(self, tmp_path: Path) -> None:
-        """If the Pushover POST fails, backup.sh exits with the backup exit code, not a curl error."""
+        """A failed Pushover POST must not replace the backup's failure status."""
         db_path = tmp_path / "nonexistent.db"
         backup_dir = tmp_path / "backups"
         backup_dir.mkdir()


### PR DESCRIPTION
## Summary

- separate SQLite dump creation from gzip compression in both backup script copies
- clean up both raw and compressed temporary files on every exit
- test failed dumps and successful restore of a known row against both scripts
- update the Sprint 3 mirror

## Root cause

POSIX pipelines report the last command's status, so a failed `sqlite3` process was hidden by a successful `gzip` process. The resulting empty gzip was promoted and `.last_success` was written.

## Validation

- regression tests failed against the old scripts and pass with the fix
- `uv run --frozen pytest tests/test_backup_sh.py tests/test_backup_restore.py -q` (21 passed)
- `uv run --frozen pytest -m 'not e2e'` (1332 passed, 9 skipped, 2 xfailed)
- ShellCheck and `sh -n` on both script copies
- Ruff, mypy, and pip-audit passed

Closes #544