### PR TITLE
fix(deploy): preserve non-root Promtail log discovery

### DIFF
--- a/deploy/pi/scripts/prepare-promtail-log-access.sh
+++ b/deploy/pi/scripts/prepare-promtail-log-access.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Allow non-root Promtail (gid 0) to enumerate Docker's log directories.
+
+set -eu
+
+CONTAINERS_DIR=${1:-/var/lib/docker/containers}
+
+if [ ! -d "$CONTAINERS_DIR" ]; then
+    echo "Docker containers directory not found: $CONTAINERS_DIR" >&2
+    exit 1
+fi
+
+# Docker creates each container directory as 0710 root:root.  The execute bit
+# lets gid 0 open a path it already knows, but Promtail's wildcard discovery
+# also needs the read bit to enumerate both this directory and its children.
+chmod g+rx "$CONTAINERS_DIR"
+find "$CONTAINERS_DIR" -mindepth 1 -maxdepth 1 -type d -exec chmod g+rx {} +

--- a/deploy/pi/systemd/promtail-log-access.path
+++ b/deploy/pi/systemd/promtail-log-access.path
@@ -1,0 +1,9 @@
+[Unit]
+Description=Watch for Docker container directories needed by Promtail
+
+[Path]
+PathChanged=/var/lib/docker/containers
+Unit=promtail-log-access.service
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/pi/systemd/promtail-log-access.service
+++ b/deploy/pi/systemd/promtail-log-access.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Allow non-root Promtail to enumerate Docker container logs
+
+[Service]
+Type=oneshot
+ExecStart=/opt/song-history/scripts/prepare-promtail-log-access.sh

--- a/docs/pi-deploy.md
+++ b/docs/pi-deploy.md
@@ -62,12 +62,14 @@ Because the host serves a public tunnel, lock it down. Codified in the repo:
 - **Token rotation** — if `.env` was ever world-readable, rotate the Cloudflare
   API token and tunnel token in the Cloudflare dashboard (#446).
 - **promtail runs non-root** (`user: "10001:0"`, #514) — least privilege on the
-  public host. It reads container logs as gid 0 (root group) instead of root, so
-  the host needs two one-time prep steps:
-  1. Docker json logs must stay group-readable. The daemon default is `0640
-     root:root` (group can read). If a hardened `daemon.json` sets `0600`, grant
-     an ACL: `sudo setfacl -R -m g:0:rX -d -m g:0:rX /var/lib/docker/containers`.
-  2. promtail writes `positions.yaml` into the mounted positions dir, so make it
+  public host. It reads container logs as gid 0 (root group) instead of root.
+  The host needs two prep steps:
+  1. Docker json logs are `0640 root:root`, but their container directories are
+     `0710`: gid 0 can open a known file but cannot enumerate Promtail's wildcard.
+     Install and enable `promtail-log-access.path`; it runs the least-privilege
+     `prepare-promtail-log-access.sh` helper whenever Docker creates a container
+     directory, adding only group read/traverse to the directory tree.
+  2. Promtail writes `positions.yaml` into the mounted positions dir, so make it
      writable by the uid/gid: `sudo chown -R 10001:0 /opt/song-history/promtail
      && sudo chmod -R g+rwX /opt/song-history/promtail`.
   If promtail logs `permission denied` on the log path or positions file, one of
@@ -116,8 +118,8 @@ ssh pi@<PI_IP> "sudo mkdir -p /opt/song-history/traefik && sudo chown \$USER /op
 # Copy the deployment config — this is everything the Pi needs
 rsync -av deploy/pi/ pi@<PI_IP>:/opt/song-history/
 
-# Make backup script executable
-ssh pi@<PI_IP> "chmod +x /opt/song-history/scripts/backup.sh"
+# Make host scripts executable
+ssh pi@<PI_IP> "chmod +x /opt/song-history/scripts/*.sh"
 ```
 
 **What gets transferred:**
@@ -127,10 +129,14 @@ ssh pi@<PI_IP> "chmod +x /opt/song-history/scripts/backup.sh"
 ├── docker-compose.yml            # Pi-specific stack (Traefik + app)
 ├── .env.example                  # template — copy to .env and fill in
 ├── worship-catalog.service       # systemd unit for auto-start on boot
+├── systemd/
+│   ├── promtail-log-access.path  # notices newly-created container directories
+│   └── promtail-log-access.service # restores non-root directory enumeration
 ├── traefik/
 │   └── traefik.yml               # Traefik static config (Cloudflare DNS-01)
 └── scripts/
-    └── backup.sh                 # nightly backup script (run via cron)
+    ├── backup.sh                 # nightly backup script (run via cron)
+    └── prepare-promtail-log-access.sh # grants directory-only log discovery
 ```
 
 That's it. No source code, no tests, no docs on the Pi.
@@ -317,9 +323,16 @@ automatically on boot — critical for a headless Pi in a utility closet.
 ```bash
 # Copy the unit file
 sudo cp /opt/song-history/worship-catalog.service /etc/systemd/system/
+sudo cp /opt/song-history/systemd/promtail-log-access.* /etc/systemd/system/
+
+# Prepare existing Docker directories and keep future ones discoverable
+sudo /opt/song-history/scripts/prepare-promtail-log-access.sh
+sudo chown -R 10001:0 /opt/song-history/promtail
+sudo chmod -R g+rwX /opt/song-history/promtail
 
 # Reload systemd, enable and start the service
 sudo systemctl daemon-reload
+sudo systemctl enable --now promtail-log-access.path
 sudo systemctl enable --now worship-catalog
 ```
 
@@ -373,6 +386,32 @@ curl -sf https://songs.highland-coc.com/health | grep -q "ok" && echo "PASS" || 
 
 # 6. Backup log writable
 touch /home/songs/backup.log && echo "PASS" || echo "FAIL"
+
+# 7. Promtail is configured and running as the dedicated non-root uid
+compose_user="$(docker compose config --format json | jq -r '.services.promtail.user')"
+promtail_id="$(docker compose ps -q promtail)"
+runtime_user="$(docker inspect --format '{{.Config.User}}' "$promtail_id")"
+test "$compose_user" = "10001:0" && test "$runtime_user" = "10001:0" \
+    && echo "PASS" || echo "FAIL"
+
+# 8. Promtail can persist positions for its newly-created Docker log file
+promtail_log="$(docker inspect --format '{{.LogPath}}' "$promtail_id")"
+sudo grep -Fq "$promtail_log" /opt/song-history/promtail/positions.yaml \
+    && echo "PASS" || echo "FAIL"
+
+# 9. A known application log line reaches Loki and advances positions
+positions_before="$(stat -c %Y /opt/song-history/promtail/positions.yaml)"
+marker="promtail-verify-$(date +%s)"
+curl -sS -o /dev/null "http://localhost/$marker"  # expected HTTP 404
+sleep 10
+positions_after="$(stat -c %Y /opt/song-history/promtail/positions.yaml)"
+loki_hits="$(curl -fsSG 'http://10.20.100.249:3100/loki/api/v1/query_range' \
+    --data-urlencode 'query={host="pi-songs"} |= "'"$marker"'"' \
+    --data-urlencode "start=$(date -d '2 minutes ago' +%s%N)" \
+    --data-urlencode "end=$(date +%s%N)" \
+    --data-urlencode 'limit=10' | jq '[.data.result[].values[]] | length')"
+test "$positions_after" -gt "$positions_before" && test "$loki_hits" -ge 1 \
+    && echo "PASS" || echo "FAIL"
 ```
 
 | Check | Expected |
@@ -383,6 +422,9 @@ touch /home/songs/backup.log && echo "PASS" || echo "FAIL"
 | Backup file | `worship-YYYYMMDD-HHMMSS.sql.gz` present |
 | HTTPS cert | no browser cert warning |
 | Backup log | `~/backup.log` writable |
+| Promtail user | Compose and container runtime both report `10001:0` |
+| Promtail positions | new container log path appears in `positions.yaml` |
+| Loki delivery | unique 404 request line appears in Loki and positions advance |
 
 ---
 

--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -13,10 +13,9 @@ Due: 2026-07-31. Focus: restore operational safety and deliver image-only score
 recognition after establishing a reproducible development and CI environment.
 
 - #537 `arch`: recognize songs presented as scanned sheet-music image slides
-- #545 `devops`: deploy the non-root Promtail configuration to `pi-songs`
 - #547 `security`: refresh the HTMX CSRF header after token rotation
 
-Completed: #542, #544, and #546.
+Completed: #542, #544, #545, and #546.
 
 ## Sprint 4 - Data correctness and OCR rollout
 

--- a/tests/test_pi_deploy_doc.py
+++ b/tests/test_pi_deploy_doc.py
@@ -28,3 +28,18 @@ class TestPiDeployDocAccuracy:
         assert "ufw" in doc or "firewall" in doc          # host firewall step
         assert "chmod 600" in doc and ".env" in doc        # secret perms step
         assert "passwordauthentication no" in doc or "key-only" in doc  # SSH hardening
+
+    def test_verifies_promtail_compose_and_runtime_users(self) -> None:
+        doc = self._text()
+        checklist = doc.split("## 14. go/no-go verification checklist", 1)[1]
+        assert "docker compose config --format json" in checklist
+        assert ".services.promtail.user" in checklist
+        assert "{{.config.user}}" in checklist
+        assert "10001:0" in checklist
+
+    def test_verifies_promtail_positions_and_loki_delivery(self) -> None:
+        doc = self._text()
+        checklist = doc.split("## 14. go/no-go verification checklist", 1)[1]
+        assert "positions.yaml" in checklist
+        assert "promtail-verify-" in checklist
+        assert "/loki/api/v1/query_range" in checklist

--- a/tests/test_promtail_log_access_sh.py
+++ b/tests/test_promtail_log_access_sh.py
@@ -1,0 +1,41 @@
+"""Tests for the non-root Promtail Docker-log access helper."""
+
+import stat
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path("deploy/pi/scripts/prepare-promtail-log-access.sh")
+PATH_UNIT = Path("deploy/pi/systemd/promtail-log-access.path")
+SERVICE_UNIT = Path("deploy/pi/systemd/promtail-log-access.service")
+
+
+def test_grants_group_enumeration_without_changing_log_mode(tmp_path: Path) -> None:
+    containers = tmp_path / "containers"
+    container = containers / ("a" * 64)
+    container.mkdir(parents=True)
+    log = container / f"{'a' * 64}-json.log"
+    log.write_text("one line\n")
+    containers.chmod(0o710)
+    container.chmod(0o710)
+    log.chmod(0o640)
+
+    subprocess.run([str(SCRIPT), str(containers)], check=True)
+
+    assert stat.S_IMODE(containers.stat().st_mode) == 0o750
+    assert stat.S_IMODE(container.stat().st_mode) == 0o750
+    assert stat.S_IMODE(log.stat().st_mode) == 0o640
+
+
+def test_rejects_missing_container_directory(tmp_path: Path) -> None:
+    result = subprocess.run([str(SCRIPT), str(tmp_path / "missing")], check=False)
+
+    assert result.returncode != 0
+
+
+def test_systemd_path_reapplies_access_for_new_containers() -> None:
+    path_unit = PATH_UNIT.read_text()
+    service_unit = SERVICE_UNIT.read_text()
+
+    assert "PathChanged=/var/lib/docker/containers" in path_unit
+    assert "promtail-log-access.service" in path_unit
+    assert "/opt/song-history/scripts/prepare-promtail-log-access.sh" in service_unit


### PR DESCRIPTION
## Summary
- deploy and verify Promtail as UID 10001/GID 0 on pi-songs
- add a systemd path guard so new Docker container directories remain discoverable without root
- add executable runtime, positions, and Loki delivery checks to the Pi runbook
- mark Sprint 3 issue #545 complete in the planning mirror

## Production verification
- compose and runtime user: 10001:0
- container state: running; no permission or push errors
- a brand-new container directory was automatically changed from 0710 to 0750
- its new Docker log appeared in positions.yaml
- a unique promtail-verify marker reached Loki and positions advanced

## Tests
- uv run --frozen pytest -m 'not e2e' (1337 passed, 9 skipped, 57 deselected, 2 xfailed)
- uv run --frozen ruff check src tests/test_pi_deploy_doc.py tests/test_promtail_log_access_sh.py
- uv run --frozen mypy src
- uv run --frozen pip-audit
- shellcheck + sh -n on the host helper
- systemd-analyze verify on both new units

Closes #545