### PR TITLE
fix(web): refresh HTMX CSRF headers per request

### DIFF
--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -13,9 +13,8 @@ Due: 2026-07-31. Focus: restore operational safety and deliver image-only score
 recognition after establishing a reproducible development and CI environment.
 
 - #537 `arch`: recognize songs presented as scanned sheet-music image slides
-- #547 `security`: refresh the HTMX CSRF header after token rotation
 
-Completed: #542, #544, #545, and #546.
+Completed: #542, #544, #545, #546, and #547.
 
 ## Sprint 4 - Data correctness and OCR rollout
 

--- a/src/worship_catalog/web/static/reports.js
+++ b/src/worship_catalog/web/static/reports.js
@@ -21,17 +21,14 @@
   }
 
   /**
-   * Configure htmx to include the CSRF header on every AJAX request.
-   * This covers hx-post forms like the stats "Generate" button.
+   * Source the CSRF header from the current cookie immediately before every
+   * htmx request. The middleware can replace this cookie after a secret
+   * rotation, so caching it in hx-headers would keep replaying a stale token.
    */
   function configureHtmxCsrf() {
-    var token = getCsrfToken();
-    if (token) {
-      document.body.setAttribute(
-        "hx-headers",
-        JSON.stringify({ "X-CSRFToken": token })
-      );
-    }
+    document.body.addEventListener("htmx:configRequest", function (evt) {
+      evt.detail.headers["X-CSRFToken"] = getCsrfToken();
+    });
   }
 
   /**

--- a/tests/test_uat_acceptance.py
+++ b/tests/test_uat_acceptance.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from itsdangerous import URLSafeSerializer
 
 # Skip entire module if playwright is not installed
 pytest.importorskip("playwright", reason="playwright not installed -- run the frozen uv sync")
@@ -141,6 +142,74 @@ class TestReportFormsE2E:
         assert result_text and "Services" in result_text, (
             "Stats result did not render service count"
         )
+
+    def test_htmx_uses_rotated_csrf_cookie_without_reload(
+        self, browser_page: Any
+    ) -> None:
+        """Every HTMX request must source its header from the current cookie."""
+        browser_page.goto(f"{BASE_URL}/reports")
+        browser_page.wait_for_load_state("networkidle")
+        fresh = next(
+            cookie["value"]
+            for cookie in browser_page.context.cookies()
+            if cookie["name"] == "csrftoken"
+        )
+        browser_page.evaluate(
+            "document.body.setAttribute('hx-headers', "
+            "JSON.stringify({'X-CSRFToken': 'stale-token'}))"
+        )
+
+        seen: list[str | None] = []
+        browser_page.on(
+            "request",
+            lambda request: seen.append(request.headers.get("x-csrftoken"))
+            if request.url.endswith("/reports/stats")
+            else None,
+        )
+        browser_page.fill("#stats-from", "2026-01-01")
+        browser_page.fill("#stats-to", "2026-12-31")
+        browser_page.locator(
+            'form[hx-post="/reports/stats"] button[type="submit"]'
+        ).click(force=True)
+        browser_page.wait_for_selector("#stats-result .stat-box", timeout=5000)
+
+        assert seen[-1] == fresh
+
+    def test_htmx_retries_with_replacement_cookie_without_reload(
+        self, browser_page: Any
+    ) -> None:
+        """A stale-token 403 must heal on the next click on the same page."""
+        browser_page.goto(f"{BASE_URL}/reports")
+        browser_page.wait_for_load_state("networkidle")
+        stale = URLSafeSerializer(
+            "an-old-rotated-secret", "csrftoken"
+        ).dumps("old-token-payload")
+        browser_page.context.add_cookies(
+            [{"name": "csrftoken", "value": stale, "url": BASE_URL}]
+        )
+        browser_page.fill("#stats-from", "2026-01-01")
+        browser_page.fill("#stats-to", "2026-12-31")
+        submit = 'form[hx-post="/reports/stats"] button[type="submit"]'
+
+        with browser_page.expect_response(
+            lambda response: response.url.endswith("/reports/stats")
+        ) as first_response:
+            browser_page.locator(submit).click(force=True)
+        assert first_response.value.status == 403
+
+        replacement = next(
+            cookie["value"]
+            for cookie in browser_page.context.cookies()
+            if cookie["name"] == "csrftoken"
+        )
+        assert replacement != stale
+
+        with browser_page.expect_response(
+            lambda response: response.url.endswith("/reports/stats")
+        ) as second_response:
+            browser_page.locator(submit).click(force=True)
+        assert second_response.value.status == 200
+        browser_page.wait_for_selector("#stats-result .stat-box", timeout=5000)
 
     def test_stats_inverted_date_range_shows_error(self, browser_page: Any) -> None:
         """#496: an inverted date range (From after To) must surface an error in

--- a/tests/test_web_security.py
+++ b/tests/test_web_security.py
@@ -890,15 +890,15 @@ class TestReportCsrfTokens:
 
     def test_htmx_csrf_header_configured_via_reports_js(self, client):
         """reports.js must configure htmx to send CSRF headers on all requests."""
-        # reports.js is loaded on the reports page and calls configureHtmxCsrf()
-        # which sets hx-headers on document.body with the X-CSRFToken header.
+        # The configRequest hook must read the cookie for every request so a
+        # token replaced after CSRF_SECRET rotation is used without a reload.
         resp = client.get("/static/reports.js")
         assert resp.status_code == 200
-        assert "hx-headers" in resp.text, (
-            "reports.js must set hx-headers on document.body for htmx CSRF"
+        assert "htmx:configRequest" in resp.text, (
+            "reports.js must refresh the htmx header before every request"
         )
         assert "X-CSRFToken" in resp.text, (
-            "reports.js must include X-CSRFToken in the hx-headers config"
+            "reports.js must populate the X-CSRFToken request header"
         )
 
     def test_stats_csv_download_with_csrf_succeeds(self, client):


### PR DESCRIPTION
## Summary
- source each HTMX CSRF header from the current cookie in htmx:configRequest
- preserve fetch-based report download behavior
- cover both an overwritten cached header and stale-secret 403 recovery in Chromium
- mark Sprint 3 issue #547 complete in the planning mirror

## Tests
- targeted Playwright: stale cached header uses current cookie
- targeted Playwright: stale-token 403 sets a replacement cookie and the second click succeeds without reload
- report CSRF unit slice: 7 passed
- non-E2E suite: 1337 passed, 9 skipped, 59 deselected, 2 xfailed
- node --check reports.js
- Ruff src + import ordering, mypy src, pip-audit

Closes #547