### PR TITLE
feat(ocr): recognize scanned score-image songs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,13 @@ LOG_LEVEL=INFO
 # flags gaps before this date, even for wide lookback windows.
 # DATA_COLLECTION_START=2026-03-01
 
-# Optional: Claude Vision API key, required only when using --ocr
-# Used by: worship-catalog import --ocr, repair-credits --ocr
-# Leave blank (or omit) if you never use OCR credit extraction.
+# Optional: Vision OCR configuration. OpenRouter is the default provider.
+# A configured key also enables score-image OCR for browser uploads.
+# WORSHIP_OCR_PROVIDER=openrouter
+# WORSHIP_OCR_MODEL=google/gemini-2.5-flash-lite
+# WORSHIP_MAX_OCR_CALLS=25
+# OPENROUTER_API_KEY=...
+# Legacy fallback: set WORSHIP_OCR_PROVIDER=anthropic and ANTHROPIC_API_KEY.
 # ANTHROPIC_API_KEY=sk-ant-...
 
 # Optional: Pushover credentials for backup failure alerts.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ source venv/bin/activate
 pip install -e .
 ```
 
-For Claude Vision OCR support (optional):
+For Vision OCR support through OpenRouter (optional):
 
 ```bash
 pip install -e ".[ocr]"
-export ANTHROPIC_API_KEY=sk-ant-...
+export OPENROUTER_API_KEY=...
 ```
 
 For the web UI (optional):
@@ -85,7 +85,7 @@ worship-catalog import "data/AM Worship 2026.02.15.pptx"
 worship-catalog import "data/" --library-index /path/to/my_index.json
 ```
 
-**Use Claude Vision API** as a further fallback for credits not in the library:
+**Use the configured Vision provider** for image-only scores and credits:
 
 ```bash
 worship-catalog import "data/" --ocr
@@ -99,7 +99,7 @@ Options:
 | `--recurse` | off | Recurse into subdirectories |
 | `--non-interactive` | off | Skip interactive prompts |
 | `--library-index` | bundled | Pre-scraped credits index (overrides bundled default) |
-| `--ocr` | off | Fall back to Claude Vision API |
+| `--ocr` | off | Enable the configured Vision OCR provider |
 
 ---
 
@@ -172,7 +172,7 @@ to backfill credits from the library index or via Vision OCR.
 worship-catalog repair-credits
 ```
 
-**With Claude Vision OCR fallback for songs not in the library:**
+**With Vision OCR fallback for songs not in the library:**
 
 ```bash
 worship-catalog repair-credits --ocr
@@ -190,7 +190,7 @@ Options:
 |------|---------|-------------|
 | `--db` | `data/worship.db` | SQLite database path |
 | `--library-index` | bundled | Pre-scraped credits index (overrides bundled default) |
-| `--ocr` | off | Fall back to Claude Vision API |
+| `--ocr` | off | Enable the configured Vision OCR provider |
 | `--dry-run` | off | Show what would change without writing |
 
 ---
@@ -335,13 +335,18 @@ Open `http://localhost:8000`.
 - If `UPLOAD_PASSWORD` is set, `/upload` requires HTTP Basic auth. The page shows a `Log in to upload` button that links to `/upload?login=1`, which triggers the browser login prompt.
 - `UPLOAD_USERNAME` defaults to `highland` when unset; set it if you want a different username shown in the Basic-auth dialog.
 - The same auth gate also protects `/jobs` and Missing Services edit actions.
+- When `OPENROUTER_API_KEY` is set, uploads OCR image-only slides with
+  `google/gemini-2.5-flash-lite` and a 25-call per-deck cap by default. Configure
+  these with `WORSHIP_OCR_MODEL` and `WORSHIP_MAX_OCR_CALLS`; omit the key to
+  keep uploads text-only. Anthropic remains available by setting
+  `WORSHIP_OCR_PROVIDER=anthropic` and `ANTHROPIC_API_KEY`.
 
 ---
 
 ## Features
 
 - **Song Extraction**: Parses PowerPoint slides to extract song titles, credits, and slide positions
-- **Credit Sources**: Text-based parsing → bundled library index → Claude Vision OCR (cascading fallback)
+- **Credit Sources**: Text-based parsing → bundled library index → Vision OCR (cascading fallback)
 - **Bundled Library Index**: ~3,800 song credits shipped with the package; no setup required
 - **Duplicate Handling**: Songs appearing multiple times in a service are counted once for reporting
 - **CCLI Reporting**: CSV reports for CCLI license compliance (projection + recording)
@@ -449,5 +454,6 @@ The publish job only fires when `Dockerfile`, `pyproject.toml`, `src/`, `config/
 - PPTX files must have metadata in standard locations (title slide table or filename)
 - Song credits are parsed from text patterns (Words by, Music by, Arranger, Publisher)
 - Taylor Publications / sheet-music slides store credits in images — use `repair-credits` with `--library-index` or `--ocr` to fill these in
-- Vision OCR requires `ANTHROPIC_API_KEY` and `pip install -e ".[ocr]"`
+- Vision OCR uses OpenRouter by default (`OPENROUTER_API_KEY`) and requires
+  `pip install -e ".[ocr]"`; Anthropic is available as a legacy fallback
 - Requires Python 3.10+

--- a/deploy/pi/.env.example
+++ b/deploy/pi/.env.example
@@ -19,8 +19,14 @@ HTTPS_ONLY=1
 # tunnel container. Compose defaults this to 1.
 TRUSTED_PROXY=1
 
-# Anthropic API key — required only if using --ocr in repair-credits.
-# Leave blank to disable OCR fallback.
+# Vision OCR — browser imports use OpenRouter by default and make at most 25
+# calls per uploaded deck. Leave the provider key blank for text-only imports.
+WORSHIP_OCR_PROVIDER=openrouter
+WORSHIP_OCR_MODEL=google/gemini-2.5-flash-lite
+WORSHIP_MAX_OCR_CALLS=25
+OPENROUTER_API_KEY=
+
+# Legacy provider fallback. Set WORSHIP_OCR_PROVIDER=anthropic to use this key.
 ANTHROPIC_API_KEY=
 
 # Pushover credentials — used for backup failure alerts and import notifications.

--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -70,6 +70,10 @@ services:
     environment:
       DB_PATH: /data/worship.db
       INBOX_DIR: /inbox
+      WORSHIP_OCR_PROVIDER: "${WORSHIP_OCR_PROVIDER:-openrouter}"
+      WORSHIP_OCR_MODEL: "${WORSHIP_OCR_MODEL:-google/gemini-2.5-flash-lite}"
+      WORSHIP_MAX_OCR_CALLS: "${WORSHIP_MAX_OCR_CALLS:-25}"
+      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
     volumes:
       - /opt/song-history/data:/data
@@ -93,6 +97,10 @@ services:
     environment:
       DB_PATH: /data/worship.db
       INBOX_DIR: /inbox
+      WORSHIP_OCR_PROVIDER: "${WORSHIP_OCR_PROVIDER:-openrouter}"
+      WORSHIP_OCR_MODEL: "${WORSHIP_OCR_MODEL:-google/gemini-2.5-flash-lite}"
+      WORSHIP_MAX_OCR_CALLS: "${WORSHIP_MAX_OCR_CALLS:-25}"
+      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
       ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       CSRF_SECRET: "${CSRF_SECRET}"
       PUSHOVER_USER_KEY: "${PUSHOVER_USER_KEY:-}"

--- a/docs/sprint-plan.md
+++ b/docs/sprint-plan.md
@@ -12,9 +12,9 @@ Current sprint planning mirror for `mshirel/song-history`, synchronized on
 Due: 2026-07-31. Focus: restore operational safety and deliver image-only score
 recognition after establishing a reproducible development and CI environment.
 
-- #537 `arch`: recognize songs presented as scanned sheet-music image slides
+No non-deferred open items remain in this sprint.
 
-Completed: #542, #544, #545, #546, and #547.
+Completed: #537, #542, #544, #545, #546, and #547.
 
 ## Sprint 4 - Data correctness and OCR rollout
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 dependencies = [
     "python-pptx>=0.6.21,<2",
     "click>=8.0,<9",
+    "httpx>=0.27,<1",
     "pydantic>=2.13.0,<3",
     "pyyaml>=6.0.3,<7",
 ]
@@ -45,7 +46,6 @@ dev = [
     "ruff>=0.1,<1",
     "mypy>=1.0,<3",
     "types-PyYAML>=6.0,<7",
-    "httpx>=0.27,<1",
     "fastapi>=0.110,<1,!=0.136.3",  # 0.136.3 is malicious (MAL-2026-4750)
     "starlette>=0.36,<2",
     "bandit>=1.7,<2",

--- a/requirements.lock
+++ b/requirements.lock
@@ -36,7 +36,9 @@ h11==0.16.0
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
-    # via anthropic
+    # via
+    #   anthropic
+    #   worship-catalog
 idna==3.18
     # via
     #   anyio

--- a/src/worship_catalog/cli.py
+++ b/src/worship_catalog/cli.py
@@ -191,8 +191,8 @@ def _echo_import_summary(result: ImportResult) -> None:
     "--ocr",
     is_flag=True,
     help=(
-        "Fall back to Claude Vision API for credits not found in library"
-        " (requires ANTHROPIC_API_KEY)"
+        "Use the configured Vision provider for image-only scores and credits"
+        " (requires OPENROUTER_API_KEY by default)"
     ),
 )
 @click.option(
@@ -557,8 +557,8 @@ def stats(
     "--ocr",
     is_flag=True,
     help=(
-        "Fall back to Claude Vision API for any songs not in the library index"
-        " (requires ANTHROPIC_API_KEY)"
+        "Use the configured Vision provider for songs not in the library index"
+        " (requires OPENROUTER_API_KEY by default)"
     ),
 )
 @click.option(
@@ -592,7 +592,7 @@ def repair_credits(
 
     \b
     1. Library index (default): fast JSON lookup, no library mount needed.
-    2. --ocr: Claude Vision API fallback for songs not in the index.
+    2. --ocr: configured Vision provider fallback for songs not in the index.
 
     To build or refresh the library index, run:
       worship-catalog library index --path tph_libarary/

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -17,7 +17,7 @@ _log = logging.getLogger("worship_catalog.db")
 # Bump this integer whenever the schema changes.  Each new version must have a
 # corresponding entry in _MIGRATIONS.  connect() raises SchemaVersionError if the
 # on-disk version is *higher* than this value (DB created by a newer release).
-_SCHEMA_VERSION: int = 6
+_SCHEMA_VERSION: int = 7
 
 # Ordered dict of version → list of SQL statements.  Each migration brings the
 # DB from version (N-1) to version N.  Migration 1 is the baseline — it
@@ -191,6 +191,12 @@ _MIGRATIONS: dict[int, list[str]] = {
         "CREATE INDEX IF NOT EXISTS idx_service_exclusions_date "
         "ON service_exclusions(service_date)",
     ],
+    7: [
+        # Persist OCR audit details for completed web imports (#537).
+        "ALTER TABLE import_jobs ADD COLUMN anomalies_json TEXT",
+        "ALTER TABLE import_jobs ADD COLUMN ocr_model TEXT",
+        "ALTER TABLE import_jobs ADD COLUMN ocr_calls INTEGER NOT NULL DEFAULT 0",
+    ],
 }
 
 # Whitelist of column names that update_import_job is allowed to SET.
@@ -200,7 +206,8 @@ _IMPORT_JOB_MUTABLE_FIELDS: frozenset[str] = frozenset(
     {
         "status", "completed_at", "songs_imported", "error_message",
         "service_date", "service_name", "song_leader", "preacher",
-        "sermon_title", "songs_json",
+        "sermon_title", "songs_json", "anomalies_json", "ocr_model",
+        "ocr_calls",
     }
 )
 
@@ -1174,6 +1181,9 @@ class Database:
         preacher: str | None = None,
         sermon_title: str | None = None,
         songs_json: str | None = None,
+        anomalies_json: str | None = None,
+        ocr_model: str | None = None,
+        ocr_calls: int | None = None,
         **_extra_kwargs: Any,
     ) -> None:
         """Update mutable fields on an import job record.
@@ -1220,6 +1230,15 @@ class Database:
         if songs_json is not None:
             sets.append("songs_json = ?")
             params.append(songs_json)
+        if anomalies_json is not None:
+            sets.append("anomalies_json = ?")
+            params.append(anomalies_json)
+        if ocr_model is not None:
+            sets.append("ocr_model = ?")
+            params.append(ocr_model)
+        if ocr_calls is not None:
+            sets.append("ocr_calls = ?")
+            params.append(ocr_calls)
         if not sets:
             return
         # Build the SET clause from whitelisted column names only.

--- a/src/worship_catalog/extractor.py
+++ b/src/worship_catalog/extractor.py
@@ -17,7 +17,11 @@ from worship_catalog.normalize import (
     select_best_title,
     strip_title_prefix,
 )
-from worship_catalog.ocr import extract_credits_via_vision
+from worship_catalog.ocr import (
+    ScoreHeader,
+    extract_credits_via_vision,
+    extract_score_header_via_vision,
+)
 from worship_catalog.pptx_reader import (
     Slide,
     compute_file_hash,
@@ -95,7 +99,7 @@ _FOOTER_MARKERS: tuple[str, ...] = (
 
 @dataclass
 class OcrBudget:
-    """Call cap for the Claude Vision API during a single extraction run.
+    """Call cap for the configured Vision API during a single extraction run.
 
     Pass an instance to :func:`extract_songs` so that the number of
     Vision API calls is bounded.  ``max_calls=None`` means unlimited.
@@ -248,6 +252,29 @@ class ExtractionResult:
     songs: list[SongOccurrence] = field(default_factory=list)
     anomalies: list[dict[str, Any]] = field(default_factory=list)
     """List of extraction anomalies and low-confidence items."""
+    ocr_model: str | None = None
+    """Vision model used to recover score-image titles, if any."""
+    ocr_calls: int = 0
+    """Number of billed vision calls made during this extraction."""
+
+
+@dataclass
+class ScoreGroupInfo:
+    """OCR metadata attached to a recovered score-image song group."""
+
+    display_title: str
+    credits: str | None
+    model: str
+
+
+@dataclass
+class ScoreGroupingResult:
+    """OCR-aware groups plus metadata keyed by each group's first slide."""
+
+    groups: list[tuple[str, list[Slide]]] = field(default_factory=list)
+    score_groups: dict[int, ScoreGroupInfo] = field(default_factory=dict)
+    anomalies: list[dict[str, Any]] = field(default_factory=list)
+    models_used: set[str] = field(default_factory=set)
 
 
 def extract_songs(
@@ -351,7 +378,17 @@ def _extract_songs_impl(
         s for i, s in enumerate(slides)
         if i != metadata_slide_idx and not s.hidden
     ]
-    song_groups = _group_song_slides(song_slides)
+    score_grouping: ScoreGroupingResult | None = None
+    effective_budget = ocr_budget
+    if use_ocr:
+        # Preserve ``None`` as unlimited while still counting calls for audit.
+        effective_budget = ocr_budget or OcrBudget(max_calls=None)
+        score_grouping = _group_song_slides_with_score_ocr(
+            song_slides, effective_budget
+        )
+        song_groups = score_grouping.groups
+    else:
+        song_groups = _group_song_slides(song_slides)
 
     _log.debug(
         "Identified %d song group(s) in %s", len(song_groups), file_path.name
@@ -364,11 +401,25 @@ def _extract_songs_impl(
     # scripture quotes, verse/stanza markers, and lyric fragments that the
     # grouping step mistakenly split out. Filtering on the FINAL title (rather
     # than during candidate selection) avoids perturbing slide grouping.
-    resolver = CreditResolver(library_index=library_index, ocr_budget=ocr_budget, use_ocr=use_ocr)
+    resolver = CreditResolver(
+        library_index=library_index,
+        ocr_budget=effective_budget,
+        use_ocr=use_ocr,
+    )
     songs: list[SongOccurrence] = []
     for canonical, group in song_groups:
+        score_info = (
+            score_grouping.score_groups.get(group[0].index)
+            if score_grouping and group
+            else None
+        )
         song = _create_song_occurrence(
-            len(songs) + 1, canonical, group, resolver=resolver,
+            len(songs) + 1,
+            canonical,
+            group,
+            resolver=resolver,
+            display_title_override=(score_info.display_title if score_info else None),
+            credits_text_override=(score_info.credits if score_info else None),
         )
         if is_non_song_title(song.display_title):
             _log.debug(
@@ -392,6 +443,13 @@ def _extract_songs_impl(
         preacher=metadata.preacher if metadata else None,
         sermon_title=metadata.sermon_title if metadata else None,
         songs=songs,
+        anomalies=score_grouping.anomalies if score_grouping else [],
+        ocr_model=(
+            ", ".join(sorted(score_grouping.models_used))
+            if score_grouping and score_grouping.models_used
+            else None
+        ),
+        ocr_calls=effective_budget.calls_made if effective_budget else 0,
     )
 
     return result
@@ -489,6 +547,142 @@ def _group_song_slides(slides: list[Slide]) -> list[tuple[str, list[Slide]]]:
         groups.append((current_canonical, current_group))
 
     return _merge_bracketed_refrains(groups)
+
+
+def _image_blob_for_ocr(slide: Slide) -> bytes | None:
+    """Return the first usable embedded image from an image-only slide."""
+    for image in slide.images:
+        if image.blob:
+            return image.blob
+    return None
+
+
+def _try_ocr_score_header(slide: Slide) -> ScoreHeader | None:
+    """Classify one slide without allowing provider failures to abort an import."""
+    blob = _image_blob_for_ocr(slide)
+    if blob is None:
+        return None
+    try:
+        return extract_score_header_via_vision(blob)
+    except (OSError, ImportError) as exc:
+        _log.warning("Score OCR unavailable: %s", exc)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("Score OCR failed (%s): %s", type(exc).__name__, exc)
+    return None
+
+
+def _group_song_slides_with_score_ocr(
+    slides: list[Slide],
+    ocr_budget: OcrBudget,
+) -> ScoreGroupingResult:
+    """Classify image-only slides and segment score songs by title transitions.
+
+    Text-bearing spans continue to use the established grouping algorithm. Each
+    image-only slide is classified independently while budget remains. A new
+    validated title starts a score group; title-less score pages continue the
+    current group. Non-score images form hard boundaries and are excluded.
+    """
+    result = ScoreGroupingResult()
+    ordinary: list[Slide] = []
+    pending_score: list[Slide] = []
+    score_canonical: str | None = None
+    score_slides: list[Slide] = []
+    score_info: ScoreGroupInfo | None = None
+
+    def flush_ordinary() -> None:
+        nonlocal ordinary
+        if ordinary:
+            result.groups.extend(_group_song_slides(ordinary))
+            ordinary = []
+
+    def flush_score() -> None:
+        nonlocal score_canonical, score_slides, score_info
+        if score_canonical and score_slides and score_info:
+            result.groups.append((score_canonical, score_slides))
+            first_index = score_slides[0].index
+            result.score_groups[first_index] = score_info
+            result.anomalies.append(
+                {
+                    "type": "score_image_ocr",
+                    "message": "title recovered from score image via OCR",
+                    "title": score_info.display_title,
+                    "first_slide_index": first_index,
+                    "model": score_info.model,
+                }
+            )
+        score_canonical = None
+        score_slides = []
+        score_info = None
+
+    for slide in slides:
+        is_image_only = bool(slide.images) and not any(
+            line.strip() for line in slide.text.text_lines
+        )
+        if not is_image_only:
+            flush_score()
+            pending_score = []
+            ordinary.append(slide)
+            continue
+
+        if not ocr_budget.consume():
+            # Once a score is confirmed, retain its tail even if a conservative
+            # cap is reached mid-song. Otherwise preserve legacy gap handling.
+            if score_canonical:
+                score_slides.append(slide)
+            elif pending_score:
+                pending_score.append(slide)
+            else:
+                ordinary.append(slide)
+            continue
+
+        header = _try_ocr_score_header(slide)
+        if header is None:
+            if score_canonical:
+                score_slides.append(slide)
+            elif pending_score:
+                pending_score.append(slide)
+            continue
+
+        result.models_used.add(header.model)
+        if not header.is_score:
+            flush_ordinary()
+            flush_score()
+            pending_score = []
+            continue
+
+        flush_ordinary()
+        if header.title is None:
+            if score_canonical:
+                score_slides.append(slide)
+                if header.credits and score_info and not score_info.credits:
+                    score_info.credits = header.credits
+            else:
+                pending_score.append(slide)
+            continue
+
+        canonical = canonicalize_title(header.title)
+        if not canonical:
+            pending_score.append(slide)
+            continue
+        if score_canonical and canonical != score_canonical:
+            flush_score()
+        if score_canonical is None:
+            score_canonical = canonical
+            score_slides = pending_score + [slide]
+            pending_score = []
+            score_info = ScoreGroupInfo(
+                display_title=header.title,
+                credits=header.credits,
+                model=header.model,
+            )
+        else:
+            score_slides.append(slide)
+            if header.credits and score_info and not score_info.credits:
+                score_info.credits = header.credits
+
+    flush_score()
+    flush_ordinary()
+    return result
 
 
 def _slides_reference_song(slides: list[Slide], canonical: str) -> bool:
@@ -644,6 +838,8 @@ def _create_song_occurrence(
     canonical_title: str,
     slides: list[Slide],
     resolver: CreditResolver | None = None,
+    display_title_override: str | None = None,
+    credits_text_override: str | None = None,
 ) -> SongOccurrence:
     """
     Create a song occurrence from grouped slides.
@@ -652,7 +848,7 @@ def _create_song_occurrence(
     Uses the provided *resolver* for library + OCR fallback (#291).
     """
     # Extract display title from first slide with text
-    display_title = ""
+    display_title = display_title_override or ""
     for slide in slides:
         candidates = _extract_title_candidates(slide)
         if candidates:
@@ -662,9 +858,23 @@ def _create_song_occurrence(
                 break
 
     # Combine all text from group to extract credits
-    all_text = "\n".join(
-        "\n".join(slide.text.text_lines) for slide in slides
-    )
+    all_text_parts = ["\n".join(slide.text.text_lines) for slide in slides]
+    if credits_text_override:
+        # Printed score headers commonly omit the colon expected by the
+        # text-slide parser ("Words and Music by JENN ..."). Normalize only
+        # this structured OCR field, leaving ordinary slide text untouched.
+        normalized_credits = re.sub(
+            r"(?i)\bWords\s+(and|&)\s+Music\s+by\s*:?[ \t]*",
+            lambda match: f"Words {match.group(1)} Music by: ",
+            credits_text_override,
+        )
+        normalized_credits = re.sub(
+            r"(?i)\bArranged\s+by\s*:?[ \t]*",
+            "Arrangement by: ",
+            normalized_credits,
+        )
+        all_text_parts.append(normalized_credits)
+    all_text = "\n".join(all_text_parts)
 
     # Extract credits from text
     parsed = parse_credits(all_text)
@@ -710,7 +920,7 @@ def _create_song_occurrence(
 def _try_ocr_credits(slides: list[Slide]) -> str | None:
     """
     Attempt to extract credits text from the first image on the first slide
-    using Claude Vision API.
+    using the configured Vision provider.
 
     Returns raw credits text string, or None if OCR fails or yields nothing.
     """

--- a/src/worship_catalog/import_service.py
+++ b/src/worship_catalog/import_service.py
@@ -37,6 +37,8 @@ class ImportResult:
     preacher: str | None = None
     sermon_title: str | None = None
     songs: list[ImportedSong] = field(default_factory=list)
+    ocr_model: str | None = None
+    ocr_calls: int = 0
 
 
 def run_import(
@@ -173,4 +175,6 @@ def run_import(
         preacher=result.preacher,
         sermon_title=result.sermon_title,
         songs=[ImportedSong(s.ordinal, s.display_title) for s in result.songs],
+        ocr_model=result.ocr_model,
+        ocr_calls=result.ocr_calls,
     )

--- a/src/worship_catalog/ocr.py
+++ b/src/worship_catalog/ocr.py
@@ -1,21 +1,53 @@
 """Vision-based OCR for extracting song credits from slide images."""
 
 import base64
+import json
 import logging
 import os
 import re
 import time
+from dataclasses import dataclass
 
-# Default model; override by setting WORSHIP_OCR_MODEL env var.
-_OCR_MODEL_DEFAULT: str = "claude-haiku-4-5-20251001"
+import httpx
+
+from worship_catalog.normalize import _SCRIPTURE_RE, _TITLE_MAX_LENGTH, is_non_song_title
+
+# Provider/model defaults; both are overridable for benchmarking and fallback.
+_OCR_PROVIDER_DEFAULT: str = "openrouter"
+_OCR_MODEL_DEFAULT: str = "google/gemini-2.5-flash-lite"
+_ANTHROPIC_MODEL_DEFAULT: str = "claude-haiku-4-5-20251001"
+_OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+_OPENROUTER_REFERER = "https://github.com/mshirel/song-history"
 _MAX_OCR_TOKENS: int = 200  # Sufficient for a single credits line
 _MAX_RETRIES: int = 3
 _RETRY_BASE_DELAY: float = 1.0  # seconds; doubles on each retry
 
 
-def _get_ocr_model() -> str:
+def _get_ocr_provider() -> str:
+    """Return the configured provider, with legacy-key compatibility."""
+    configured = os.environ.get("WORSHIP_OCR_PROVIDER")
+    if configured:
+        provider = configured.strip().lower()
+        if provider not in {"openrouter", "anthropic"}:
+            raise ValueError(
+                "WORSHIP_OCR_PROVIDER must be 'openrouter' or 'anthropic'"
+            )
+        return provider
+    # Existing CLI installations that only have the legacy key keep working;
+    # new installs (and keyless error messages) use the OpenRouter default.
+    if os.environ.get("ANTHROPIC_API_KEY") and not os.environ.get("OPENROUTER_API_KEY"):
+        return "anthropic"
+    return _OCR_PROVIDER_DEFAULT
+
+
+def _get_ocr_model(provider: str | None = None) -> str:
     """Return the OCR model name, honouring the WORSHIP_OCR_MODEL env var."""
-    return os.environ.get("WORSHIP_OCR_MODEL", _OCR_MODEL_DEFAULT)
+    configured = os.environ.get("WORSHIP_OCR_MODEL")
+    if configured:
+        return configured
+    if provider == "anthropic":
+        return _ANTHROPIC_MODEL_DEFAULT
+    return _OCR_MODEL_DEFAULT
 
 _log = logging.getLogger(__name__)
 
@@ -28,6 +60,16 @@ _CREDITS_RE = re.compile(
 # phrases like "Words by the congregation" are rejected.
 _NAME_RE = re.compile(r"\b[A-Z][a-z]+\s+[A-Z][a-z]+")
 _MAX_OCR_OUTPUT_LENGTH = 300
+
+
+@dataclass(frozen=True)
+class ScoreHeader:
+    """Structured classification and header text for one image-only slide."""
+
+    is_score: bool
+    title: str | None
+    credits: str | None
+    model: str
 
 
 def _validate_ocr_output(text: str) -> str | None:
@@ -72,44 +114,25 @@ def _retryable_ocr_errors(anthropic: object) -> tuple[type[BaseException], ...]:
     return tuple(retryable)
 
 
-def extract_credits_via_vision(image_bytes: bytes) -> str | None:
-    """
-    Use Claude Vision API to extract the credits line from a slide image.
-
-    Targets the "Words: X / Music: Y" or "Words and Music by: X" line
-    commonly found at the bottom of Taylor Publications / hymnal slides.
-
-    Args:
-        image_bytes: Raw image bytes (JPEG, PNG, etc.)
-
-    Returns:
-        The raw credits text if found, or None if no credits detected or
-        if the API key is not configured.
-    """
+def _call_anthropic(image_bytes: bytes, prompt: str) -> str | None:
+    """Send one vision request through the legacy Anthropic backend."""
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     if not api_key:
         raise OSError(
-            "ANTHROPIC_API_KEY is not set. "
-            "Export it before using --ocr: export ANTHROPIC_API_KEY=sk-ant-..."
+            "ANTHROPIC_API_KEY is not set. Export it before using the "
+            "anthropic OCR provider."
         )
 
     try:
         import anthropic
     except ImportError as err:
         raise ImportError(
-            "The 'anthropic' package is required for OCR. "
-            "Install it with: pip install anthropic"
+            "The 'anthropic' package is required for the anthropic OCR provider."
         ) from err
 
-    image_b64 = base64.standard_b64encode(image_bytes).decode("utf-8")
-
-    # Detect media type from magic bytes
-    media_type = _detect_media_type(image_bytes)
-
     client = anthropic.Anthropic(api_key=api_key)
-
     request_kwargs = {
-        "model": _get_ocr_model(),
+        "model": _get_ocr_model("anthropic"),
         "max_tokens": _MAX_OCR_TOKENS,
         "messages": [
             {
@@ -119,54 +142,207 @@ def extract_credits_via_vision(image_bytes: bytes) -> str | None:
                         "type": "image",
                         "source": {
                             "type": "base64",
-                            "media_type": media_type,
-                            "data": image_b64,
+                            "media_type": _detect_media_type(image_bytes),
+                            "data": base64.standard_b64encode(image_bytes).decode("utf-8"),
                         },
                     },
-                    {
-                        "type": "text",
-                        "text": (
-                            "This is a worship song slide image. "
-                            "Find and return ONLY the song credits line — "
-                            "the line that starts with 'Words:', 'Music:', "
-                            "'Words and Music:', 'Words & Music:', or similar. "
-                            "Return the exact text of that line only. "
-                            "If no credits line is visible, return the word 'none'."
-                        ),
-                    },
+                    {"type": "text", "text": prompt},
                 ],
             }
         ],
     }
 
-    # Retry on transient API errors with exponential backoff
-    _retryable = _retryable_ocr_errors(anthropic)
+    retryable = _retryable_ocr_errors(anthropic)
     last_exc: BaseException | None = None
     for attempt in range(_MAX_RETRIES):
         try:
             message = client.messages.create(**request_kwargs)
-            break
-        except _retryable as exc:
+            texts = _iter_text_blocks(message.content)
+            return texts[0].strip() if texts else None
+        except retryable as exc:
             last_exc = exc
-            if attempt < _MAX_RETRIES - 1:
-                delay = _RETRY_BASE_DELAY * (2**attempt)
-                _log.warning(
-                    "OCR API transient error (attempt %d/%d), retrying in %.1fs: %s",
-                    attempt + 1,
-                    _MAX_RETRIES,
-                    delay,
-                    exc,
-                )
-                time.sleep(delay)
-            else:
+            if attempt >= _MAX_RETRIES - 1:
                 raise
-    else:
-        raise last_exc  # type: ignore[misc]
+            delay = _RETRY_BASE_DELAY * (2**attempt)
+            _log.warning(
+                "OCR API transient error (attempt %d/%d), retrying in %.1fs: %s",
+                attempt + 1,
+                _MAX_RETRIES,
+                delay,
+                exc,
+            )
+            time.sleep(delay)
+    raise last_exc  # type: ignore[misc]
 
-    text_blocks = _iter_text_blocks(message.content)
-    if not text_blocks:
+
+def _call_openrouter(
+    image_bytes: bytes,
+    prompt: str,
+    *,
+    json_response: bool = False,
+) -> str | None:
+    """Send one OpenAI-shaped vision request through OpenRouter."""
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        raise OSError(
+            "OPENROUTER_API_KEY is not set. Export it before using --ocr."
+        )
+
+    media_type = _detect_media_type(image_bytes)
+    image_b64 = base64.standard_b64encode(image_bytes).decode("utf-8")
+    payload: dict[str, object] = {
+        "model": _get_ocr_model("openrouter"),
+        "max_tokens": _MAX_OCR_TOKENS,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:{media_type};base64,{image_b64}",
+                        },
+                    },
+                    {"type": "text", "text": prompt},
+                ],
+            }
+        ],
+    }
+    if json_response:
+        payload["response_format"] = {"type": "json_object"}
+
+    response = httpx.post(
+        _OPENROUTER_URL,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "HTTP-Referer": _OPENROUTER_REFERER,
+            "X-Title": "song-history",
+        },
+        json=payload,
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    response_payload = response.json()
+    try:
+        content = response_payload["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError):
         return None
-    raw = text_blocks[0].strip()
+    return content.strip() if isinstance(content, str) else None
+
+
+def _call_vision(
+    image_bytes: bytes,
+    prompt: str,
+    *,
+    json_response: bool = False,
+) -> str | None:
+    """Dispatch a vision request to the configured provider."""
+    provider = _get_ocr_provider()
+    if provider == "anthropic":
+        return _call_anthropic(image_bytes, prompt)
+    return _call_openrouter(image_bytes, prompt, json_response=json_response)
+
+
+def _validate_ocr_title(title: str) -> str | None:
+    """Return a safe song title or ``None`` for footer/prose/scripture text."""
+    stripped = " ".join(title.split())
+    if not stripped or len(stripped) > _TITLE_MAX_LENGTH:
+        return None
+    if _SCRIPTURE_RE.match(stripped) or is_non_song_title(stripped):
+        return None
+    lowered = stripped.lower()
+    if lowered in {
+        "announcements",
+        "closing prayer",
+        "giving",
+        "offering",
+        "opening prayer",
+        "scripture reading",
+        "the lord's supper",
+        "welcome",
+    }:
+        return None
+    if any(
+        marker in lowered
+        for marker in ("copyright", "all rights reserved", "used by permission")
+    ):
+        return None
+    return stripped
+
+
+def _validate_score_credits(credits: object) -> str | None:
+    """Validate structured score credits without rejecting all-uppercase names."""
+    if not isinstance(credits, str):
+        return None
+    stripped = " ".join(credits.split())
+    if not stripped or len(stripped) > _MAX_OCR_OUTPUT_LENGTH:
+        return None
+    if not _CREDITS_RE.search(stripped):
+        return None
+    return stripped
+
+
+def _parse_score_header(raw: str, model: str) -> ScoreHeader | None:
+    """Parse defensive JSON, tolerating markdown fences around the object."""
+    start = raw.find("{")
+    end = raw.rfind("}")
+    if start < 0 or end < start:
+        return None
+    try:
+        payload = json.loads(raw[start : end + 1])
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict) or not isinstance(payload.get("is_score"), bool):
+        return None
+    is_score = payload["is_score"]
+    if not is_score:
+        return ScoreHeader(False, None, None, model)
+    raw_title = payload.get("title")
+    title = _validate_ocr_title(raw_title) if isinstance(raw_title, str) else None
+    credits = _validate_score_credits(payload.get("credits"))
+    return ScoreHeader(True, title, credits, model)
+
+
+def extract_score_header_via_vision(image_bytes: bytes) -> ScoreHeader | None:
+    """Classify a slide and recover its printed score header as structured JSON."""
+    prompt = (
+        "Classify this worship slide image. A music-score page contains visible "
+        "musical staff lines and notation; sermon art, logos, scripture, photos, "
+        "and title cards are not score pages. Return ONLY JSON with exactly these "
+        "fields: {\"is_score\": boolean, \"title\": string|null, "
+        "\"credits\": string|null}. For a score, title is the printed song header "
+        "when legible and credits is any Words/Music/Arranged-by line. For a "
+        "non-score, both text fields must be null. Do not infer missing text."
+    )
+    raw = _call_vision(image_bytes, prompt, json_response=True)
+    if not raw:
+        return None
+    return _parse_score_header(raw, _get_ocr_model(_get_ocr_provider()))
+
+
+def extract_credits_via_vision(image_bytes: bytes) -> str | None:
+    """
+    Use the configured vision provider to extract a credits line.
+
+    Targets the "Words: X / Music: Y" or "Words and Music by: X" line
+    commonly found at the bottom of Taylor Publications / hymnal slides.
+
+    Args:
+        image_bytes: Raw image bytes (JPEG, PNG, etc.)
+
+    Returns:
+        The raw credits text if found, or None if no credits detected or
+        if the selected provider's API key is not configured.
+    """
+    prompt = (
+        "This is a worship song slide image. Find and return ONLY the song "
+        "credits line — the line that starts with 'Words:', 'Music:', 'Words "
+        "and Music:', 'Words & Music:', or similar. Return the exact text of "
+        "that line only. If no credits line is visible, return the word 'none'."
+    )
+    raw = _call_vision(image_bytes, prompt)
+    if raw is None:
+        return None
     if raw.lower() == "none" or not raw:
         return None
     return _validate_ocr_output(raw)

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -41,6 +41,7 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 
 from worship_catalog.db import Database
+from worship_catalog.extractor import OcrBudget
 from worship_catalog.import_service import run_import
 from worship_catalog.log_config import RequestLoggingMiddleware
 from worship_catalog.log_config import setup as _setup_logging
@@ -1146,6 +1147,35 @@ def _get_inbox_dir() -> Path:
     return p
 
 
+_WEB_OCR_MAX_CALLS_DEFAULT = 25
+
+
+def _get_web_ocr_budget() -> OcrBudget | None:
+    """Return a per-upload OCR budget when the selected provider is configured."""
+    provider = os.environ.get("WORSHIP_OCR_PROVIDER", "openrouter").strip().lower()
+    key_name = (
+        "ANTHROPIC_API_KEY" if provider == "anthropic" else "OPENROUTER_API_KEY"
+    )
+    if not os.environ.get(key_name):
+        return None
+
+    configured = os.environ.get(
+        "WORSHIP_MAX_OCR_CALLS", str(_WEB_OCR_MAX_CALLS_DEFAULT)
+    )
+    try:
+        max_calls = int(configured)
+        if max_calls < 0:
+            raise ValueError
+    except ValueError:
+        _log.warning(
+            "Invalid WORSHIP_MAX_OCR_CALLS=%r; using default %d",
+            configured,
+            _WEB_OCR_MAX_CALLS_DEFAULT,
+        )
+        max_calls = _WEB_OCR_MAX_CALLS_DEFAULT
+    return OcrBudget(max_calls=max_calls)
+
+
 def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
     """Import a PPTX file and update the job record when done.  Runs in a thread.
 
@@ -1162,7 +1192,15 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
     _notify_message = f"{pptx_path.name} — unknown error"
     _notify_priority = -1
     try:
-        result = run_import(db, pptx_path)
+        ocr_budget = _get_web_ocr_budget()
+        result = run_import(
+            db,
+            pptx_path,
+            use_ocr=ocr_budget is not None,
+            ocr_budget=ocr_budget,
+        )
+
+        anomalies_json = json.dumps(result.anomalies) if result.anomalies else None
 
         if result.songs_imported == 0:
             db.update_import_job(
@@ -1170,6 +1208,9 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
                 status="complete",
                 songs_imported=0,
                 error_message="No songs found — file may not be a worship slide deck",
+                anomalies_json=anomalies_json,
+                ocr_model=result.ocr_model,
+                ocr_calls=result.ocr_calls,
             )
             _notify_title = "Import complete (0 songs)"
             _notify_message = f"{pptx_path.name} — no songs found"
@@ -1187,6 +1228,9 @@ def _run_import_in_background(job_id: str, pptx_path: Path) -> None:
                 songs_json=json.dumps(
                     [s.display_title for s in result.songs]
                 ) if result.songs else None,
+                anomalies_json=anomalies_json,
+                ocr_model=result.ocr_model,
+                ocr_calls=result.ocr_calls,
             )
             _notify_title = "Import complete"
             _notify_message = (

--- a/src/worship_catalog/web/static/upload.js
+++ b/src/worship_catalog/web/static/upload.js
@@ -51,6 +51,8 @@
       ["Song Leader", job.song_leader],
       ["Preacher", job.preacher],
       ["Sermon", job.sermon_title],
+      ["OCR Model", job.ocr_model],
+      ["OCR Calls", job.ocr_calls > 0 ? String(job.ocr_calls) : null],
     ];
     var hasAnyMeta = metaRows.some(function (r) { return r[1]; });
     if (hasAnyMeta) {
@@ -93,6 +95,34 @@
           ol.appendChild(li);
         });
         frag.appendChild(ol);
+      }
+    }
+
+    // OCR recovery flags are intentionally prominent: operators should verify
+    // model-recovered titles before relying on them for reporting.
+    if (job.anomalies_json) {
+      var anomalies;
+      try { anomalies = JSON.parse(job.anomalies_json); } catch (e) { anomalies = []; }
+      if (Array.isArray(anomalies) && anomalies.length > 0) {
+        var anomalyLabel = document.createElement("p");
+        anomalyLabel.style.cssText =
+          "font-size:0.85rem;font-weight:600;color:#856404;margin:0.75rem 0 0.25rem;";
+        anomalyLabel.textContent = "Review flags:";
+        frag.appendChild(anomalyLabel);
+        var anomalyList = document.createElement("ul");
+        anomalyList.style.cssText =
+          "margin:0;padding-left:1.5rem;font-size:0.85rem;color:#856404;";
+        anomalies.forEach(function (anomaly) {
+          var item = document.createElement("li");
+          var message = anomaly && anomaly.message
+            ? anomaly.message
+            : "OCR result requires review";
+          item.textContent = anomaly && anomaly.title
+            ? anomaly.title + " — " + message
+            : message;
+          anomalyList.appendChild(item);
+        });
+        frag.appendChild(anomalyList);
       }
     }
 

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -1370,6 +1370,36 @@ class TestUpdateImportJobSQLSafety:
         songs = json.loads(row["songs_json"])
         assert songs == ["Amazing Grace", "How Great Thou Art", "Holy Holy Holy"]
 
+    def test_update_with_ocr_audit_metadata_persists(self, temp_db: Database) -> None:
+        import json
+
+        job_id = "ocr-audit-job-001"
+        anomalies = [
+            {
+                "type": "score_image_ocr",
+                "message": "title recovered from score image via OCR",
+                "title": "Goodness of God",
+                "first_slide_index": 38,
+                "model": "google/gemini-2.5-flash-lite",
+            }
+        ]
+        temp_db.create_import_job(job_id, filename="score.pptx")
+        temp_db.update_import_job(
+            job_id,
+            status="complete",
+            anomalies_json=json.dumps(anomalies),
+            ocr_model="google/gemini-2.5-flash-lite",
+            ocr_calls=25,
+        )
+
+        row = temp_db.get_import_job(job_id)
+        temp_db.close()
+
+        assert row is not None
+        assert json.loads(row["anomalies_json"]) == anomalies
+        assert row["ocr_model"] == "google/gemini-2.5-flash-lite"
+        assert row["ocr_calls"] == 25
+
     def test_new_metadata_fields_present_as_none_when_not_set(self, temp_db: Database) -> None:
         job_id = "meta-job-002"
         temp_db.create_import_job(job_id, filename="test.pptx")
@@ -2358,7 +2388,7 @@ class TestDatabaseIndexes:
         cursor = temp_db.cursor()
         cursor.execute("PRAGMA user_version")
         assert cursor.fetchone()[0] == _SCHEMA_VERSION
-        assert _SCHEMA_VERSION == 6  # bumped for service_exclusions table (#480)
+        assert _SCHEMA_VERSION == 7  # bumped for import-job OCR audit fields (#537)
 
 
 @pytest.mark.integration

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -208,6 +208,9 @@ class TestImportNotificationIntegration:
         mock_result.preacher = None
         mock_result.sermon_title = None
         mock_result.songs = []
+        mock_result.anomalies = []
+        mock_result.ocr_model = None
+        mock_result.ocr_calls = 0
 
         with (
             patch("worship_catalog.web.app._get_db") as mock_get_db,

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -9,6 +9,12 @@ from worship_catalog.extractor import OcrBudget
 from worship_catalog.ocr import _MAX_RETRIES, _detect_media_type, extract_credits_via_vision
 
 
+@pytest.fixture(autouse=True)
+def _legacy_anthropic_provider(monkeypatch):
+    """Keep legacy credit-extraction tests on their original backend."""
+    monkeypatch.setenv("WORSHIP_OCR_PROVIDER", "anthropic")
+
+
 class TestOcrBudget:
     """Tests for the OcrBudget call-cap class."""
 

--- a/tests/test_ocr_provider.py
+++ b/tests/test_ocr_provider.py
@@ -1,0 +1,154 @@
+"""Provider and structured score-header OCR tests for issue #537."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import worship_catalog.ocr as ocr
+
+
+@pytest.fixture(autouse=True)
+def _openrouter_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WORSHIP_OCR_PROVIDER", "openrouter")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "or-test-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+
+def _response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = {
+        "choices": [{"message": {"content": content}}],
+    }
+    response.raise_for_status.return_value = None
+    return response
+
+
+class TestOpenRouterVisionProvider:
+    def test_uses_openai_image_shape_and_attribution_headers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        post = MagicMock(
+            return_value=_response(
+                '{"is_score":true,"title":"Goodness Of God","credits":null}'
+            )
+        )
+        monkeypatch.setattr(ocr.httpx, "post", post)
+
+        result = ocr.extract_score_header_via_vision(b"\xff\xd8image")
+
+        assert result is not None
+        assert result.is_score is True
+        assert result.title == "Goodness Of God"
+        _, kwargs = post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer or-test-key"
+        assert kwargs["headers"]["HTTP-Referer"]
+        assert kwargs["headers"]["X-Title"] == "song-history"
+        payload = kwargs["json"]
+        assert payload["model"] == "google/gemini-2.5-flash-lite"
+        assert payload["response_format"] == {"type": "json_object"}
+        image_part = payload["messages"][0]["content"][0]
+        assert image_part["type"] == "image_url"
+        assert image_part["image_url"]["url"].startswith("data:image/jpeg;base64,")
+
+    def test_model_slug_passes_through(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("WORSHIP_OCR_MODEL", "openai/gpt-5-nano")
+        post = MagicMock(
+            return_value=_response(
+                '{"is_score":false,"title":null,"credits":null}'
+            )
+        )
+        monkeypatch.setattr(ocr.httpx, "post", post)
+
+        ocr.extract_score_header_via_vision(b"\xff\xd8image")
+
+        assert post.call_args.kwargs["json"]["model"] == "openai/gpt-5-nano"
+
+    def test_plain_credit_extraction_does_not_force_json_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        post = MagicMock(
+            return_value=_response("Words and Music by: Jenn Johnson and Ed Cash")
+        )
+        monkeypatch.setattr(ocr.httpx, "post", post)
+
+        result = ocr.extract_credits_via_vision(b"\xff\xd8image")
+
+        assert result == "Words and Music by: Jenn Johnson and Ed Cash"
+        assert "response_format" not in post.call_args.kwargs["json"]
+
+    def test_missing_key_is_actionable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENROUTER_API_KEY")
+
+        with pytest.raises(OSError, match="OPENROUTER_API_KEY"):
+            ocr.extract_score_header_via_vision(b"\xff\xd8image")
+
+    def test_explicit_anthropic_provider_uses_legacy_backend(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("WORSHIP_OCR_PROVIDER", "anthropic")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        anthropic_call = MagicMock(
+            return_value='{"is_score":true,"title":"Amazing Grace","credits":null}'
+        )
+        openrouter_call = MagicMock()
+        monkeypatch.setattr(ocr, "_call_anthropic", anthropic_call)
+        monkeypatch.setattr(ocr, "_call_openrouter", openrouter_call)
+
+        result = ocr.extract_score_header_via_vision(b"\xff\xd8image")
+
+        assert result is not None and result.title == "Amazing Grace"
+        anthropic_call.assert_called_once()
+        openrouter_call.assert_not_called()
+
+
+class TestStructuredScoreHeader:
+    @pytest.mark.parametrize(
+        ("content", "expected"),
+        [
+            ('{"is_score":false,"title":null,"credits":null}', (False, None)),
+            ('{"is_score":true,"title":null,"credits":null}', (True, None)),
+        ],
+    )
+    def test_preserves_score_tri_state(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        content: str,
+        expected: tuple[bool, str | None],
+    ) -> None:
+        monkeypatch.setattr(ocr.httpx, "post", MagicMock(return_value=_response(content)))
+
+        result = ocr.extract_score_header_via_vision(b"\xff\xd8image")
+
+        assert result is not None
+        assert (result.is_score, result.title) == expected
+
+    def test_returns_validated_title_and_credits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        content = (
+            '```json\n{"is_score":true,"title":"Goodness Of God",'
+            '"credits":"Words and Music by JENN JOHNSON and ED CASH"}\n```'
+        )
+        monkeypatch.setattr(ocr.httpx, "post", MagicMock(return_value=_response(content)))
+
+        result = ocr.extract_score_header_via_vision(b"\xff\xd8image")
+
+        assert result is not None
+        assert result.title == "Goodness Of God"
+        assert result.credits == "Words and Music by JENN JOHNSON and ED CASH"
+
+    def test_malformed_json_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            ocr.httpx,
+            "post",
+            MagicMock(return_value=_response("this is not JSON")),
+        )
+
+        assert ocr.extract_score_header_via_vision(b"\xff\xd8image") is None
+
+    @pytest.mark.parametrize(
+        "title",
+        ["A" * 121, "John 3:16", "Closing Prayer", "Copyright 2018 Alletrop"],
+    )
+    def test_title_validation_rejects_non_song_text(self, title: str) -> None:
+        assert ocr._validate_ocr_title(title) is None

--- a/tests/test_score_image_extraction.py
+++ b/tests/test_score_image_extraction.py
@@ -1,0 +1,234 @@
+"""Per-slide scanned score grouping tests for issue #537."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import worship_catalog.extractor as extractor
+from worship_catalog.extractor import OcrBudget
+from worship_catalog.ocr import ScoreHeader
+from worship_catalog.pptx_reader import Slide, SlideImage, SlideText
+
+
+def _slide(index: int, lines: list[str] | None = None, blob: bytes | None = None) -> Slide:
+    images = [SlideImage(shape_id=1, blob=blob)] if blob is not None else []
+    return Slide(
+        index=index,
+        hidden=False,
+        text=SlideText(text_lines=lines or []),
+        images=images,
+    )
+
+
+def _header(
+    title: str | None = "Goodness Of God",
+    *,
+    is_score: bool = True,
+    credits: str | None = None,
+) -> ScoreHeader:
+    return ScoreHeader(
+        is_score=is_score,
+        title=title,
+        credits=credits,
+        model="google/gemini-2.5-flash-lite",
+    )
+
+
+class TestScoreImageSlidePattern:
+    def test_image_only_score_run_groups_as_one_song(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slides = [_slide(i, blob=f"score-{i}".encode()) for i in range(4)]
+        vision = MagicMock(side_effect=[_header(), _header(None), _header(None), _header()])
+        monkeypatch.setattr(extractor, "extract_score_header_via_vision", vision)
+
+        result = extractor._group_song_slides_with_score_ocr(
+            slides, OcrBudget(max_calls=10)
+        )
+
+        assert [(title, len(group)) for title, group in result.groups] == [
+            ("goodness of god", 4)
+        ]
+        assert vision.call_count == 4
+        info = result.score_groups[slides[0].index]
+        assert info.display_title == "Goodness Of God"
+        assert info.model == "google/gemini-2.5-flash-lite"
+
+    def test_photo_background_slide_is_not_a_song(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vision = MagicMock(return_value=_header(None, is_score=False))
+        monkeypatch.setattr(extractor, "extract_score_header_via_vision", vision)
+
+        result = extractor._group_song_slides_with_score_ocr(
+            [_slide(37, blob=b"giving-photo")], OcrBudget(max_calls=5)
+        )
+
+        assert result.groups == []
+        vision.assert_called_once_with(b"giving-photo")
+
+    def test_score_run_between_text_songs_is_not_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slides = [
+            _slide(0, ["Amazing Grace", "PaperlessHymnal.com"]),
+            *[_slide(i, blob=f"score-{i}".encode()) for i in range(1, 5)],
+            _slide(5, ["How Great Thou Art", "PaperlessHymnal.com"]),
+        ]
+        monkeypatch.setattr(
+            extractor,
+            "extract_score_header_via_vision",
+            MagicMock(side_effect=[_header(), _header(None), _header(None), _header(None)]),
+        )
+
+        result = extractor._group_song_slides_with_score_ocr(
+            slides, OcrBudget(max_calls=10)
+        )
+
+        assert [title for title, _ in result.groups] == [
+            "amazing grace",
+            "goodness of god",
+            "how great thou art",
+        ]
+        assert len(result.groups[0][1]) == 1
+        assert len(result.groups[1][1]) == 4
+
+    def test_title_change_splits_contiguous_image_run(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slides = [_slide(i, blob=str(i).encode()) for i in range(4)]
+        monkeypatch.setattr(
+            extractor,
+            "extract_score_header_via_vision",
+            MagicMock(
+                side_effect=[
+                    _header("Song A"),
+                    _header(None),
+                    _header("Song B"),
+                    _header(None),
+                ]
+            ),
+        )
+
+        result = extractor._group_song_slides_with_score_ocr(
+            slides, OcrBudget(max_calls=10)
+        )
+
+        assert [(title, len(group)) for title, group in result.groups] == [
+            ("song a", 2),
+            ("song b", 2),
+        ]
+
+    def test_nonscore_boundaries_are_excluded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slides = [_slide(i, blob=str(i).encode()) for i in range(4)]
+        monkeypatch.setattr(
+            extractor,
+            "extract_score_header_via_vision",
+            MagicMock(
+                side_effect=[
+                    _header(None, is_score=False),
+                    _header("Goodness Of God"),
+                    _header(None),
+                    _header(None, is_score=False),
+                ]
+            ),
+        )
+
+        result = extractor._group_song_slides_with_score_ocr(
+            slides, OcrBudget(max_calls=10)
+        )
+
+        assert len(result.groups) == 1
+        assert [slide.index for slide in result.groups[0][1]] == [1, 2]
+
+    def test_no_score_pages_yields_no_song(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            extractor,
+            "extract_score_header_via_vision",
+            MagicMock(return_value=_header(None, is_score=False)),
+        )
+        budget = OcrBudget(max_calls=3)
+
+        result = extractor._group_song_slides_with_score_ocr(
+            [_slide(i, blob=str(i).encode()) for i in range(8)], budget
+        )
+
+        assert result.groups == []
+        assert budget.calls_made == 3
+
+    def test_budget_exhaustion_keeps_confirmed_score_tail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vision = MagicMock(side_effect=[_header(), _header(None)])
+        monkeypatch.setattr(extractor, "extract_score_header_via_vision", vision)
+        budget = OcrBudget(max_calls=2)
+
+        result = extractor._group_song_slides_with_score_ocr(
+            [_slide(i, blob=str(i).encode()) for i in range(5)], budget
+        )
+
+        assert [(title, len(group)) for title, group in result.groups] == [
+            ("goodness of god", 5)
+        ]
+        assert vision.call_count == 2
+
+    def test_ocr_failure_does_not_fabricate_song(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            extractor, "extract_score_header_via_vision", MagicMock(return_value=None)
+        )
+
+        result = extractor._group_song_slides_with_score_ocr(
+            [_slide(1, blob=b"unreadable")], OcrBudget(max_calls=5)
+        )
+
+        assert result.groups == []
+
+
+class TestScoreOccurrenceMetadata:
+    def test_recovered_title_credits_and_anomaly_flow_to_occurrence(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        slide = _slide(39, blob=b"score")
+        header = _header(
+            "Goodness Of God",
+            credits=(
+                "Words and Music by JENN JOHNSON, ED CASH, JASON INGRAM, "
+                "BEN FIELDING, and BRIAN JOHNSON / Arranged by Shane Coffman "
+                "and Mark Simmons"
+            ),
+        )
+        monkeypatch.setattr(
+            extractor, "extract_score_header_via_vision", MagicMock(return_value=header)
+        )
+        grouped = extractor._group_song_slides_with_score_ocr(
+            [slide], OcrBudget(max_calls=5)
+        )
+        info = grouped.score_groups[39]
+
+        occurrence = extractor._create_song_occurrence(
+            1,
+            "goodness of god",
+            [slide],
+            display_title_override=info.display_title,
+            credits_text_override=info.credits,
+        )
+
+        assert occurrence.display_title == "Goodness Of God"
+        assert occurrence.words_by == (
+            "JENN JOHNSON, ED CASH, JASON INGRAM, BEN FIELDING, and BRIAN JOHNSON"
+        )
+        assert occurrence.music_by == occurrence.words_by
+        assert occurrence.arranger == "Shane Coffman and Mark Simmons"
+        assert grouped.anomalies == [
+            {
+                "type": "score_image_ocr",
+                "message": "title recovered from score image via OCR",
+                "title": "Goodness Of God",
+                "first_slide_index": 39,
+                "model": "google/gemini-2.5-flash-lite",
+            }
+        ]

--- a/tests/test_scripts.bats
+++ b/tests/test_scripts.bats
@@ -22,6 +22,17 @@
   grep -q "ANTHROPIC_API_KEY" deploy/pi/.env.example
 }
 
+@test ".env.example contains OpenRouter OCR defaults" {
+  grep -q "OPENROUTER_API_KEY" deploy/pi/.env.example
+  grep -q "WORSHIP_OCR_MODEL=google/gemini-2.5-flash-lite" deploy/pi/.env.example
+  grep -q "WORSHIP_MAX_OCR_CALLS=25" deploy/pi/.env.example
+}
+
+@test "docker-compose passes OpenRouter OCR configuration to web imports" {
+  grep -q "OPENROUTER_API_KEY" deploy/pi/docker-compose.yml
+  grep -q "WORSHIP_MAX_OCR_CALLS" deploy/pi/docker-compose.yml
+}
+
 @test "docker-compose.yml references traefik service" {
   grep -q "traefik" deploy/pi/docker-compose.yml
 }

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1413,7 +1413,8 @@ class TestJobStatusEndpoint:
             "job_id", "filename", "status", "started_at",
             "completed_at", "songs_imported", "error_message",
             "service_date", "service_name", "song_leader",
-            "preacher", "sermon_title", "songs_json",
+            "preacher", "sermon_title", "songs_json", "anomalies_json",
+            "ocr_model", "ocr_calls",
         ):
             assert field in body
 
@@ -3091,6 +3092,117 @@ class TestBackgroundImportDelegatesToService:
         # Second positional arg should be the pptx_path
         assert call_args[0][1] == pptx_path
 
+    def test_background_import_enables_openrouter_ocr_and_persists_audit(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from importlib import reload
+        from unittest.mock import MagicMock
+
+        from worship_catalog.import_service import ImportResult, ImportedSong
+
+        db_path = tmp_path / "openrouter.db"
+        db = Database(db_path)
+        db.connect()
+        db.init_schema()
+        job_id = "openrouter-score-job"
+        db.create_import_job(job_id, filename="score.pptx")
+        db.close()
+
+        monkeypatch.setenv("DB_PATH", str(db_path))
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("WORSHIP_OCR_PROVIDER", raising=False)
+        monkeypatch.delenv("WORSHIP_MAX_OCR_CALLS", raising=False)
+
+        import worship_catalog.web.app as app_module
+
+        reload(app_module)
+        anomaly = {
+            "type": "score_image_ocr",
+            "message": "title recovered from score image via OCR",
+            "title": "Goodness of God",
+        }
+        mock_run = MagicMock(return_value=ImportResult(
+            service_date="2026-06-07",
+            service_name="AM Worship",
+            songs_imported=1,
+            anomalies=[anomaly],
+            songs=[ImportedSong(1, "Goodness of God")],
+            ocr_model="google/gemini-2.5-flash-lite",
+            ocr_calls=25,
+        ))
+        monkeypatch.setattr(app_module, "run_import", mock_run)
+        monkeypatch.setattr(app_module, "send_pushover", MagicMock())
+
+        pptx_path = tmp_path / "score.pptx"
+        pptx_path.write_bytes(b"fake")
+        app_module._run_import_in_background(job_id, pptx_path)
+
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["use_ocr"] is True
+        assert kwargs["ocr_budget"].max_calls == 25
+
+        result_db = Database(db_path)
+        result_db.connect()
+        row = result_db.get_import_job(job_id)
+        result_db.close()
+        assert row is not None
+        assert json.loads(row["anomalies_json"]) == [anomaly]
+        assert row["ocr_model"] == "google/gemini-2.5-flash-lite"
+        assert row["ocr_calls"] == 25
+
+    def test_background_import_stays_text_only_without_provider_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from importlib import reload
+        from unittest.mock import MagicMock
+
+        from worship_catalog.import_service import ImportResult
+
+        db_path = tmp_path / "text-only.db"
+        db = Database(db_path)
+        db.connect()
+        db.init_schema()
+        job_id = "text-only-job"
+        db.create_import_job(job_id, filename="ordinary.pptx")
+        db.close()
+
+        monkeypatch.setenv("DB_PATH", str(db_path))
+        monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("WORSHIP_OCR_PROVIDER", raising=False)
+
+        import worship_catalog.web.app as app_module
+
+        reload(app_module)
+        mock_run = MagicMock(return_value=ImportResult(
+            service_date="2026-06-07",
+            service_name="AM Worship",
+            songs_imported=1,
+        ))
+        monkeypatch.setattr(app_module, "run_import", mock_run)
+        monkeypatch.setattr(app_module, "send_pushover", MagicMock())
+
+        pptx_path = tmp_path / "ordinary.pptx"
+        pptx_path.write_bytes(b"fake")
+        app_module._run_import_in_background(job_id, pptx_path)
+
+        assert mock_run.call_args.kwargs == {"use_ocr": False, "ocr_budget": None}
+
+    def test_web_ocr_budget_honors_configured_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import worship_catalog.web.app as app_module
+
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter-key")
+        monkeypatch.delenv("WORSHIP_OCR_PROVIDER", raising=False)
+        monkeypatch.setenv("WORSHIP_MAX_OCR_CALLS", "7")
+
+        budget = app_module._get_web_ocr_budget()
+
+        assert budget is not None
+        assert budget.max_calls == 7
+
 
 class TestGetDbSchemaInit:
     """Verify that init_schema() is only called once, not on every request."""
@@ -3361,6 +3473,9 @@ class TestUploadFormCSPCompatible:
         assert resp.status_code == 200
         assert "fetch" in resp.text, "upload.js must use fetch to POST the form"
         assert "csrftoken" in resp.text.lower(), "upload.js must read the CSRF cookie"
+        assert "ocr_model" in resp.text
+        assert "ocr_calls" in resp.text
+        assert "anomalies_json" in resp.text
 
     def test_upload_form_references_external_js(self, client):
         """upload.html must load upload.js from /static/."""

--- a/uv.lock
+++ b/uv.lock
@@ -421,7 +421,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2218,6 +2218,7 @@ name = "worship-catalog"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "httpx" },
     { name = "pydantic" },
     { name = "python-pptx" },
     { name = "pyyaml" },
@@ -2227,7 +2228,6 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "fastapi" },
-    { name = "httpx" },
     { name = "mutmut" },
     { name = "mypy" },
     { name = "olefile" },
@@ -2269,7 +2269,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.0,<9" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.110,!=0.136.3,<1" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110,!=0.136.3,<1" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<1" },
+    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "itsdangerous", marker = "extra == 'web'", specifier = ">=2.2.0,<3" },
     { name = "jinja2", marker = "extra == 'web'", specifier = ">=3.1,<4" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.5.0,<4" },


### PR DESCRIPTION
## Summary
- add OpenRouter-backed structured per-slide score classification with `google/gemini-2.5-flash-lite` as the default and Anthropic as the legacy fallback
- segment contiguous image-only slides on validated title transitions while excluding non-score boundaries and respecting the shared OCR budget
- enable bounded OCR for browser imports when a provider key is configured, persist its audit metadata, and display model/call-count/review flags safely
- document and deploy the provider configuration, migrate import-job storage, and mark Sprint 3 complete

## Verification
- `uv run --frozen pytest -m 'not e2e' -q` — 1,363 passed, 9 skipped, 2 xfailed
- `uv run --frozen pytest -m e2e -q` — 1 passed, 58 environment-skipped
- `uv run --frozen ruff check src`
- `uv run --frozen mypy src/worship_catalog`
- `uv run --frozen pip-audit`
- focused Bats OpenRouter deployment checks
- real `AM Worship 2026.06.07.pptx` structure test recovered one Goodness of God occurrence spanning slides 39–68 with a 25-call budget
- Playwright upload-result audit rendering test
- wheel build/metadata dependency check

Closes #537
