### PR TITLE
fix(deploy): restore non-root container DNS

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -163,9 +163,9 @@ services:
     # gid 0 (root group) so it can READ the group-readable Docker json logs under
     # /var/lib/docker/containers WITHOUT root. Requires two host-side prep steps
     # (see docs/pi-deploy.md):
-    #   1. Container logs must be group-readable. Docker's default is 0640
-    #      root:root (group can read); if a hardened daemon.json sets 0600, apply
-    #      an ACL:  setfacl -R -m g:0:rX -d -m g:0:rX /var/lib/docker/containers
+    #   1. Container logs must be group-readable. Docker's default 0640
+    #      root:root is sufficient; the host helper grants directory discovery
+    #      without a default ACL (which would break DNS for non-root containers).
     #   2. promtail writes positions.yaml into the mounted /opt/song-history/promtail
     #      dir, so that dir must be writable by uid 10001 (or gid 0):
     #      chown -R 10001:0 /opt/song-history/promtail && chmod -R g+rwX ...

--- a/deploy/pi/scripts/prepare-promtail-log-access.sh
+++ b/deploy/pi/scripts/prepare-promtail-log-access.sh
@@ -15,3 +15,31 @@ fi
 # also needs the read bit to enumerate both this directory and its children.
 chmod g+rx "$CONTAINERS_DIR"
 find "$CONTAINERS_DIR" -mindepth 1 -maxdepth 1 -type d -exec chmod g+rx {} +
+
+# Older setup guidance applied a default ACL to this tree.  Docker's generated
+# hosts/hostname/resolv.conf files inherited other=--- from that ACL, leaving
+# non-root containers unable to resolve DNS.  Remove only the default ACL from
+# the container root and immediate container directories; their access ACLs
+# and the group permissions Promtail needs remain intact.
+python3 - "$CONTAINERS_DIR" <<'PY'
+import errno
+import os
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+directories = [root, *(path for path in root.iterdir() if path.is_dir())]
+for directory in directories:
+    try:
+        os.removexattr(directory, "system.posix_acl_default")
+    except OSError as exc:
+        if exc.errno not in {errno.ENODATA, errno.ENOTSUP}:
+            raise
+PY
+
+# Repair containers already created under the stale ACL.  These three files
+# are Docker-managed network metadata, not application secrets, and must be
+# readable by the configured non-root container user.
+find "$CONTAINERS_DIR" -mindepth 2 -maxdepth 2 -type f \
+    \( -name hosts -o -name hostname -o -name resolv.conf \) \
+    -exec chmod o+r {} +

--- a/docs/pi-deploy.md
+++ b/docs/pi-deploy.md
@@ -68,7 +68,9 @@ Because the host serves a public tunnel, lock it down. Codified in the repo:
      `0710`: gid 0 can open a known file but cannot enumerate Promtail's wildcard.
      Install and enable `promtail-log-access.path`; it runs the least-privilege
      `prepare-promtail-log-access.sh` helper whenever Docker creates a container
-     directory, adding only group read/traverse to the directory tree.
+     directory, adding only group read/traverse to the directory tree. The helper
+     also removes legacy default ACLs from this tree: those ACLs make Docker's
+     resolver files unreadable to non-root containers and break outbound DNS.
   2. Promtail writes `positions.yaml` into the mounted positions dir, so make it
      writable by the uid/gid: `sudo chown -R 10001:0 /opt/song-history/promtail
      && sudo chmod -R g+rwX /opt/song-history/promtail`.

--- a/tests/test_promtail_log_access_sh.py
+++ b/tests/test_promtail_log_access_sh.py
@@ -1,5 +1,6 @@
 """Tests for the non-root Promtail Docker-log access helper."""
 
+import os
 import stat
 import subprocess
 from pathlib import Path
@@ -7,6 +8,13 @@ from pathlib import Path
 SCRIPT = Path("deploy/pi/scripts/prepare-promtail-log-access.sh")
 PATH_UNIT = Path("deploy/pi/systemd/promtail-log-access.path")
 SERVICE_UNIT = Path("deploy/pi/systemd/promtail-log-access.service")
+
+# Equivalent to the stale default ACL observed on pi-songs: owner rwx, group
+# r-x, mask r-x, other ---. Files Docker creates beneath it inherit other=---.
+STALE_DEFAULT_ACL = bytes.fromhex(
+    "0200000001000700ffffffff04000500ffffffff"
+    "10000500ffffffff20000000ffffffff"
+)
 
 
 def test_grants_group_enumeration_without_changing_log_mode(tmp_path: Path) -> None:
@@ -24,6 +32,23 @@ def test_grants_group_enumeration_without_changing_log_mode(tmp_path: Path) -> N
     assert stat.S_IMODE(containers.stat().st_mode) == 0o750
     assert stat.S_IMODE(container.stat().st_mode) == 0o750
     assert stat.S_IMODE(log.stat().st_mode) == 0o640
+
+
+def test_removes_stale_default_acl_and_repairs_docker_resolver_mode(tmp_path: Path) -> None:
+    containers = tmp_path / "containers"
+    container = containers / ("a" * 64)
+    container.mkdir(parents=True)
+    resolver = container / "resolv.conf"
+    resolver.write_text("nameserver 127.0.0.11\n")
+    resolver.chmod(0o640)
+    os.setxattr(containers, "system.posix_acl_default", STALE_DEFAULT_ACL)
+    os.setxattr(container, "system.posix_acl_default", STALE_DEFAULT_ACL)
+
+    subprocess.run([str(SCRIPT), str(containers)], check=True)
+
+    assert "system.posix_acl_default" not in os.listxattr(containers)
+    assert "system.posix_acl_default" not in os.listxattr(container)
+    assert stat.S_IMODE(resolver.stat().st_mode) == 0o644
 
 
 def test_rejects_missing_container_directory(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove the stale default ACL that makes Docker resolver files unreadable by non-root containers
- repair existing Docker `hosts`, `hostname`, and `resolv.conf` modes while preserving Promtail log permissions
- remove the dangerous default-ACL guidance and document the DNS failure mode
- add a regression that recreates the production ACL and verifies cleanup

## Validation
- `uv run --frozen pytest -m "not e2e" -q` (1364 passed, 9 skipped, 2 xfailed)
- `uv run --frozen pytest tests/test_promtail_log_access_sh.py tests/test_pi_compose.py -q` (14 passed)
- `uv run --frozen mypy src`
- `uv run --frozen ruff check src tests/test_promtail_log_access_sh.py`
- `uv run --frozen pip-audit`
- `shellcheck deploy/pi/scripts/prepare-promtail-log-access.sh`
- compose config, graphify update, and diff checks

Closes #556
Supports #538