### PR TITLE
fix(credits): split same-line arranger

### DIFF
--- a/src/worship_catalog/normalize.py
+++ b/src/worship_catalog/normalize.py
@@ -378,8 +378,9 @@ def parse_credits(text: str) -> dict[str, str | None]:
        both ``words_by`` and ``music_by`` in one pass.  If this pattern were
        checked after the standalone "Words by" / "Music by" patterns it would
        sometimes be skipped because one of those fields would already be populated.
-       The pattern deliberately stops at ``/`` or ``, Arr`` so the arranger is
-       not swallowed into the combined value.
+       The pattern deliberately stops at ``/``, ``, Arr``, or a full
+       ``Arrangement/Arranged by`` clause so the arranger is not swallowed
+       into the combined value.
 
     2. **Standalone "Words by:" / "Words:"** — only attempted when ``words_by``
        is still None after step 1.  Stopping at ``/`` and ``,`` prevents
@@ -389,7 +390,8 @@ def parse_credits(text: str) -> dict[str, str | None]:
        ``music_by`` is still None.
 
     4. **Arranger patterns** — tried in priority order:
-       ``Arrangement by:`` → ``Arr. by`` → ``Arr.:`` / ``Arr:`` → ``Arr. Name``
+       ``Arrangement/Arranged by:`` → ``Arr. by`` → ``Arr.:`` / ``Arr:`` →
+       ``Arr. Name``
        The final pattern excludes ``Arr. Copyright`` lines (copyright notices
        that start with "Arr." but are not arranger credits).
 
@@ -419,9 +421,11 @@ def parse_credits(text: str) -> dict[str, str | None]:
         return result
 
     # Handle "Words and Music by:" / "Words & Music:" / "Music and Words by:"
-    # Stop at "/" or ", Arr" so the arranger isn't swallowed into the combined value.
+    # Stop at "/", ", Arr", or a same-line "Arrangement/Arranged by" so the
+    # arranger isn't swallowed into the combined value.
     match = re.search(
-        r'(?:Words\s+(?:and|&)\s+Music|Music\s+and\s+Words)\s*(?:by)?:\s*([^/\n]+?)(?:,\s*Arr|/|\n|$)',
+        r'(?:Words\s+(?:and|&)\s+Music|Music\s+and\s+Words)\s*(?:by)?:\s*'
+        r'([^/\n]+?)(?:,\s*Arr|\s+Arrang(?:ement|ed)\s+by|/|\n|$)',
         text, re.IGNORECASE
     )
     if match:
@@ -445,10 +449,10 @@ def parse_credits(text: str) -> dict[str, str | None]:
         if match:
             result['music_by'] = match.group(1).strip()
 
-    # Handle arranger: "Arrangement by:", "Arr. by", "Arr.:", "Arr:", "Arr. Name"
+    # Handle arranger: "Arrangement/Arranged by:", "Arr. by", "Arr.:", "Arr:", "Arr. Name"
     # Skip "Arr. Copyright" lines (copyright notices, not arranger credits).
     for pattern in [
-        r'Arrangement\s+by[:\s]\s*([^/\n,]+)',
+        r'Arrang(?:ement|ed)\s+by[:\s]\s*([^/\n,]+)',
         r'Arr\.\s+by\s+([^/\n,]+)',
         r'Arr\.?:\s*([^/\n,]+)',
         r'Arr\.\s+(?!Copyright)([^/\n,]+)',
@@ -469,7 +473,7 @@ def parse_credits(text: str) -> dict[str, str | None]:
             value = re.escape(val)
             pattern = (
                 r'(?i)(words\s+(?:and|&)\s+music|words\s+by|music\s+by|'
-                r'arr(?:angement)?\s+by).*?' + value
+                r'arr(?:angement|anged)?\s+by).*?' + value
             )
             remaining = re.sub(pattern, '', remaining)
 

--- a/tests/test_credits_parsing.py
+++ b/tests/test_credits_parsing.py
@@ -31,6 +31,22 @@ class TestCreditsParsing:
         assert result['words_by'] == "James Montgomery"
         assert result['music_by'] == "James Montgomery"
 
+    @pytest.mark.parametrize("arranger_label", ["Arrangement", "Arranged"])
+    def test_parse_words_and_music_stops_at_same_line_arrangement(self, arranger_label):
+        """Keep a same-line arrangement credit out of the composer fields."""
+        composers = "JENN JOHNSON, ED CASH, JASON INGRAM, BEN FIELDING, and BRIAN JOHNSON"
+        text = (
+            f"Words and Music by: {composers} "
+            f"{arranger_label} by: Shane Coffman and Mark Simmons"
+        )
+
+        result = parse_credits(text)
+
+        assert result['words_by'] == composers
+        assert result['music_by'] == composers
+        assert result['arranger'] == "Shane Coffman and Mark Simmons"
+        assert result['other_credits'] is None
+
     def test_parse_words_by_only(self):
         """Parse 'Words by: Name' separately from music."""
         text = "Words by: Samuel Stone\nMusic by: John B. Dykes"


### PR DESCRIPTION
## Summary
- stop combined Words/Music parsing before same-line `Arrangement by` or `Arranged by` clauses
- parse both full arranger-label variants into the arranger field
- cover the exact Goodness of God OCR credit string observed during #538 rollout

## Validation
- `uv run --frozen pytest -m "not e2e" -q` (1366 passed, 9 skipped, 2 xfailed)
- `uv run --frozen pytest tests/test_credits_parsing.py -q` (56 passed, 2 xfailed)
- `uv run --frozen mypy src`
- `uv run --frozen ruff check src`
- `uv run --frozen pip-audit`
- `graphify update .` and `git diff --check`

Closes #558
Supports #538