### PR TITLE
chore(deploy): pin corrected OCR credits image

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -46,8 +46,8 @@ services:
     # :latest silently swaps running app code with no digest record and no
     # rollback target. Pin to the sha- tag + digest CI publishes; Dependabot's
     # `docker` ecosystem entry (#502) bumps this on a reviewed PR.
-    # Tag sha-<commit> = main@f37d817; digest resolved from GHCR 2026-07-18.
-    image: ghcr.io/mshirel/song-history:sha-f37d817e20c00fac31e3f7523c12c8aed9c7ccaf@sha256:b03a8e4e66b2a57c99fbdf4d761c1f28b68a59dc9bab8d8b8829562a4decd7aa
+    # Tag sha-<commit> = main@68eaf57; digest resolved from GHCR 2026-07-18.
+    image: ghcr.io/mshirel/song-history:sha-68eaf57d3740a2180d3201786d423b2d924f1f69@sha256:4e6e472601d6957ecbc6ec2d7e8f4a9f22117e3503d2a7c40161651856dd1b26
     restart: unless-stopped
     init: true
     # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
@@ -88,8 +88,8 @@ services:
   song-history:
     # Immutably pinned (#512) — was the mutable :latest. Keep this in lockstep
     # with the `watcher` service above; Dependabot (#502) bumps both.
-    # Tag sha-<commit> = main@f37d817; digest resolved from GHCR 2026-07-18.
-    image: ghcr.io/mshirel/song-history:sha-f37d817e20c00fac31e3f7523c12c8aed9c7ccaf@sha256:b03a8e4e66b2a57c99fbdf4d761c1f28b68a59dc9bab8d8b8829562a4decd7aa
+    # Tag sha-<commit> = main@68eaf57; digest resolved from GHCR 2026-07-18.
+    image: ghcr.io/mshirel/song-history:sha-68eaf57d3740a2180d3201786d423b2d924f1f69@sha256:4e6e472601d6957ecbc6ec2d7e8f4a9f22117e3503d2a7c40161651856dd1b26
     restart: unless-stopped
     stop_grace_period: 35s
     ports:


### PR DESCRIPTION
## Summary
- advance both Pi services to the immutable image containing the merged OCR credit-boundary fix
- keep watcher and web service on the same full-SHA tag and GHCR index digest
- unblock final production verification for #538 and #558

## Validation
- main image publish pipeline passed test, security, browser E2E, CVE scan, smoke test, and multi-platform push
- `docker compose --env-file deploy/pi/.env.example -f deploy/pi/docker-compose.yml config --quiet`
- `uv run --frozen pytest tests/test_pi_compose.py -q` (10 passed)
- `graphify update .`
- `git diff --check`

Supports #538 and #558