### PR TITLE
fix(data): make song upserts snapshot-safe

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -536,36 +536,19 @@ class Database:
     ) -> int:
         """Insert or get song by canonical title. Returns song_id."""
         cursor = self._conn.cursor()
-
-        # Try to get existing
         cursor.execute(
-            "SELECT id FROM songs WHERE canonical_title = ?", (canonical_title,)
+            """
+            INSERT INTO songs (canonical_title, display_title)
+            VALUES (?, ?)
+            ON CONFLICT(canonical_title) DO UPDATE SET id = songs.id
+            RETURNING id
+            """,
+            (canonical_title, display_title),
         )
         row = cursor.fetchone()
-        if row:
-            return row[0]
-
-        # Insert new — retry-safe under concurrent writers (#400).  A second
-        # importer can insert the same canonical_title between our SELECT and
-        # INSERT; the UNIQUE(canonical_title) constraint then raises
-        # IntegrityError.  Re-read and return the row the other writer created.
-        try:
-            cursor.execute(
-                "INSERT INTO songs (canonical_title, display_title) VALUES (?, ?)",
-                (canonical_title, display_title),
-            )
-            self._maybe_commit()
-            return cursor.lastrowid
-        except sqlite3.IntegrityError:
-            if not self._in_transaction:
-                self._conn.rollback()
-            cursor.execute(
-                "SELECT id FROM songs WHERE canonical_title = ?", (canonical_title,)
-            )
-            row = cursor.fetchone()
-            if row:
-                return row[0]
-            raise
+        assert row is not None
+        self._maybe_commit()
+        return int(row[0])
 
     def insert_or_get_song_edition(
         self,
@@ -578,56 +561,22 @@ class Database:
     ) -> int:
         """Insert or get song edition. Returns edition_id."""
         cursor = self._conn.cursor()
-
-        # Try to get existing - handle NULL comparisons explicitly.
-        select_sql = """
-            SELECT id FROM song_editions
-            WHERE song_id = ?
-            AND (publisher = ? OR (publisher IS NULL AND ? IS NULL))
-            AND (words_by = ? OR (words_by IS NULL AND ? IS NULL))
-            AND (music_by = ? OR (music_by IS NULL AND ? IS NULL))
-            AND (arranger = ? OR (arranger IS NULL AND ? IS NULL))
+        # The identity constraint is an expression index over COALESCE values,
+        # so omit a column conflict target and let SQLite match that index.
+        cursor.execute(
             """
-        select_params = (
-            song_id,
-            publisher,
-            publisher,
-            words_by,
-            words_by,
-            music_by,
-            music_by,
-            arranger,
-            arranger,
+            INSERT INTO song_editions
+            (song_id, publisher, words_by, music_by, arranger, copyright_notice)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT DO UPDATE SET id = song_editions.id
+            RETURNING id
+            """,
+            (song_id, publisher, words_by, music_by, arranger, copyright_notice),
         )
-        cursor.execute(select_sql, select_params)
         row = cursor.fetchone()
-        if row:
-            return row[0]
-
-        # Insert new — retry-safe under concurrent writers when the identity
-        # columns are non-NULL (#400).  NOTE: when publisher/words_by/music_by/
-        # arranger are NULL, SQLite treats each NULL as distinct in the UNIQUE
-        # index, so no IntegrityError fires and concurrent duplicates are still
-        # possible — that NULL-distinct weakness is tracked in #420.
-        try:
-            cursor.execute(
-                """
-                INSERT INTO song_editions
-                (song_id, publisher, words_by, music_by, arranger, copyright_notice)
-                VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (song_id, publisher, words_by, music_by, arranger, copyright_notice),
-            )
-            self._maybe_commit()
-            return cursor.lastrowid
-        except sqlite3.IntegrityError:
-            if not self._in_transaction:
-                self._conn.rollback()
-            cursor.execute(select_sql, select_params)
-            row = cursor.fetchone()
-            if row:
-                return row[0]
-            raise
+        assert row is not None
+        self._maybe_commit()
+        return int(row[0])
 
     # --- Services ---
 

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2936,6 +2936,135 @@ class TestConcurrentInsertOrGet:
         db.conn.execute("PRAGMA busy_timeout=5000")
         return db
 
+    @staticmethod
+    def _connect_cross_thread(db_path):
+        """Create a test connection before its worker thread starts."""
+        db = Database(db_path)
+        db.conn = sqlite3.connect(db_path, check_same_thread=False)
+        db.conn.row_factory = sqlite3.Row
+        db.conn.execute("PRAGMA journal_mode=WAL")
+        db.conn.execute("PRAGMA foreign_keys=ON")
+        db.conn.execute("PRAGMA busy_timeout=5000")
+        return db
+
+    class _BarrierCursor:
+        """Freeze and align two deferred snapshots at their identity read."""
+
+        def __init__(self, cursor, select_prefix, barrier):
+            self._cursor = cursor
+            self._select_prefix = select_prefix
+            self._barrier = barrier
+
+        def execute(self, sql, parameters=()):
+            normalized_sql = " ".join(sql.split())
+            if normalized_sql.startswith(self._select_prefix):
+                if not self._cursor.connection.in_transaction:
+                    self._cursor.execute("BEGIN")
+            result = self._cursor.execute(sql, parameters)
+            if normalized_sql.startswith(self._select_prefix):
+                self._barrier.wait(timeout=5)
+            return result
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class _BarrierConnection:
+        def __init__(self, connection, select_prefix, barrier):
+            self._connection = connection
+            self._select_prefix = select_prefix
+            self._barrier = barrier
+
+        def cursor(self):
+            return TestConcurrentInsertOrGet._BarrierCursor(
+                self._connection.cursor(), self._select_prefix, self._barrier
+            )
+
+        def __getattr__(self, name):
+            return getattr(self._connection, name)
+
+    def test_transactional_song_insert_does_not_upgrade_stale_snapshot(self, tmp_path):
+        db_path = tmp_path / "transaction_race_song.db"
+        init = self._connect(db_path)
+        init.init_schema()
+        init.close()
+
+        start_barrier = threading.Barrier(2)
+        select_barrier = threading.Barrier(2)
+        ids: list[int] = []
+        errors: list[Exception] = []
+        databases = [self._connect_cross_thread(db_path) for _ in range(2)]
+        for db in databases:
+            db.conn = self._BarrierConnection(
+                db.conn, "SELECT id FROM songs WHERE canonical_title", select_barrier
+            )
+
+        def worker(db) -> None:
+            try:
+                start_barrier.wait(timeout=5)
+                with db.transaction():
+                    ids.append(
+                        db.insert_or_get_song("amazing grace", "Amazing Grace")
+                    )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                db.close()
+
+        threads = [threading.Thread(target=worker, args=(db,)) for db in databases]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not any(thread.is_alive() for thread in threads)
+        assert not errors, f"Transactional insert_or_get_song raised: {errors!r}"
+        assert len(ids) == 2
+        assert len(set(ids)) == 1
+
+    def test_transactional_edition_insert_does_not_upgrade_stale_snapshot(
+        self, tmp_path
+    ):
+        db_path = tmp_path / "transaction_race_edition.db"
+        init = self._connect(db_path)
+        init.init_schema()
+        song_id = init.insert_or_get_song("amazing grace", "Amazing Grace")
+        init.close()
+
+        start_barrier = threading.Barrier(2)
+        select_barrier = threading.Barrier(2)
+        ids: list[int] = []
+        errors: list[Exception] = []
+        databases = [self._connect_cross_thread(db_path) for _ in range(2)]
+        for db in databases:
+            db.conn = self._BarrierConnection(
+                db.conn, "SELECT id FROM song_editions WHERE", select_barrier
+            )
+
+        def worker(db) -> None:
+            try:
+                start_barrier.wait(timeout=5)
+                with db.transaction():
+                    ids.append(
+                        db.insert_or_get_song_edition(
+                            song_id, words_by="John Newton"
+                        )
+                    )
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+            finally:
+                db.close()
+
+        threads = [threading.Thread(target=worker, args=(db,)) for db in databases]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert not any(thread.is_alive() for thread in threads)
+        assert not errors, f"Transactional insert_or_get_song_edition raised: {errors!r}"
+        assert len(ids) == 2
+        assert len(set(ids)) == 1
+
     def test_concurrent_insert_or_get_song_no_error(self, tmp_path):
         db_path = tmp_path / "race_song.db"
         init = self._connect(db_path)


### PR DESCRIPTION
Closes #540

## Summary
- replace song read/insert/re-read races with atomic SQLite upserts
- return the winning song or edition ID from the same statement
- add deterministic deferred-snapshot transaction race coverage

## Validation
- 1368 passed, 9 skipped, 59 deselected, 2 xfailed (`pytest -m "not e2e"`)
- Ruff passed for `src/`
- mypy passed for `src/`
- pip-audit found no known vulnerabilities