### PR TITLE
fix(data): select song credits deterministically

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1309,8 +1309,16 @@ class Database:
                 like = f"%{_escape_like(search)}%"
                 where = """
                     WHERE (LOWER(s.display_title) LIKE LOWER(?) ESCAPE '\\'
-                       OR LOWER(COALESCE(se.words_by, '')) LIKE LOWER(?) ESCAPE '\\'
-                       OR LOWER(COALESCE(se.music_by, '')) LIKE LOWER(?) ESCAPE '\\')
+                       OR EXISTS (
+                           SELECT 1 FROM song_editions search_se
+                           WHERE search_se.song_id = s.id
+                             AND (
+                               LOWER(COALESCE(search_se.words_by, ''))
+                                   LIKE LOWER(?) ESCAPE '\\'
+                               OR LOWER(COALESCE(search_se.music_by, ''))
+                                   LIKE LOWER(?) ESCAPE '\\'
+                             )
+                       ))
                 """
                 cursor.execute(count_base + where, (like, like, like))
                 total: int = cursor.fetchone()[0]

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1260,20 +1260,45 @@ class Database:
     ) -> tuple[list[dict[str, Any]], int]:
         """Return songs with performance count, optionally filtered and sorted."""
         sort = _safe_order_by(sort, self._SONGS_SORT_COLS)
-        order = f"{sort} {_safe_sort_dir(sort_dir)}, s.display_title"
+        order = f"{sort} {_safe_sort_dir(sort_dir)}, s.display_title, s.id"
         cursor = self._conn.cursor()
+        # Choose one display edition per song. Prefer the edition from the most
+        # recent service that explicitly referenced one; for songs never linked
+        # to an edition, fall back to the newest edition row.
+        edition_join = """
+            LEFT JOIN song_editions se ON se.id = COALESCE(
+                (
+                    SELECT recent_ss.song_edition_id
+                    FROM service_songs recent_ss
+                    JOIN services recent_sv ON recent_sv.id = recent_ss.service_id
+                    WHERE recent_ss.song_id = s.id
+                      AND recent_ss.song_edition_id IS NOT NULL
+                    ORDER BY recent_sv.service_date DESC,
+                             recent_sv.id DESC,
+                             recent_ss.id DESC
+                    LIMIT 1
+                ),
+                (
+                    SELECT fallback_se.id
+                    FROM song_editions fallback_se
+                    WHERE fallback_se.song_id = s.id
+                    ORDER BY fallback_se.id DESC
+                    LIMIT 1
+                )
+            )
+        """
         base = """
             SELECT s.id, s.display_title, s.canonical_title,
                    se.words_by, se.music_by, se.arranger,
                    COUNT(DISTINCT ss.service_id) AS performance_count
             FROM songs s
-            LEFT JOIN song_editions se ON se.song_id = s.id
+        """ + edition_join + """
             LEFT JOIN service_songs ss ON ss.song_id = s.id
         """
         count_base = """
             SELECT COUNT(DISTINCT s.id)
             FROM songs s
-            LEFT JOIN song_editions se ON se.song_id = s.id
+        """ + edition_join + """
             LEFT JOIN service_songs ss ON ss.song_id = s.id
         """
         offset = (page - 1) * per_page
@@ -1290,14 +1315,25 @@ class Database:
                 cursor.execute(count_base + where, (like, like, like))
                 total: int = cursor.fetchone()[0]
                 cursor.execute(
-                    base + where + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
+                    base
+                    + where
+                    + "GROUP BY s.id, s.display_title, s.canonical_title, "
+                    + "se.words_by, se.music_by, se.arranger "
+                    + "ORDER BY "
+                    + order
+                    + " LIMIT ? OFFSET ?",
                     (like, like, like, per_page, offset),
                 )
             else:
                 cursor.execute(count_base)
                 total = cursor.fetchone()[0]
                 cursor.execute(
-                    base + "GROUP BY s.id ORDER BY " + order + " LIMIT ? OFFSET ?",
+                    base
+                    + "GROUP BY s.id, s.display_title, s.canonical_title, "
+                    + "se.words_by, se.music_by, se.arranger "
+                    + "ORDER BY "
+                    + order
+                    + " LIMIT ? OFFSET ?",
                     (per_page, offset),
                 )
             rows = [dict(row) for row in cursor.fetchall()]

--- a/src/worship_catalog/services/report_service.py
+++ b/src/worship_catalog/services/report_service.py
@@ -40,19 +40,21 @@ def compute_stats_data(
     # must contribute exactly 1 to its count, not N (#97).
     song_service_ids: dict[str, set[int]] = {}
     song_credits: dict[str, str] = {}
+    song_credit_recency: dict[str, tuple[str, int, int]] = {}
     for e in events:
         title = e["display_title"]
         song_service_ids.setdefault(title, set()).add(e["service_id"])
-        if title not in song_credits:
-            parts: list[str] = []
-            if e.get("words_by"):
-                parts.append(f"Words: {e['words_by']}")
-            if e.get("music_by") and e.get("music_by") != e.get("words_by"):
-                parts.append(f"Music: {e['music_by']}")
-            if e.get("arranger"):
-                parts.append(f"Arr: {e['arranger']}")
-            if parts:
-                song_credits[title] = ", ".join(parts)
+        parts: list[str] = []
+        if e.get("words_by"):
+            parts.append(f"Words: {e['words_by']}")
+        if e.get("music_by") and e.get("music_by") != e.get("words_by"):
+            parts.append(f"Music: {e['music_by']}")
+        if e.get("arranger"):
+            parts.append(f"Arr: {e['arranger']}")
+        recency = (e["service_date"], e["service_id"], e["id"])
+        if parts and recency > song_credit_recency.get(title, ("", 0, 0)):
+            song_credit_recency[title] = recency
+            song_credits[title] = ", ".join(parts)
     song_counts: dict[str, int] = {t: len(sids) for t, sids in song_service_ids.items()}
 
     sorted_songs = sorted(song_counts.items(), key=lambda x: (-x[1], x[0].lower()))

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2070,6 +2070,24 @@ class TestQuerySongsPaginated:
         assert rows[0]["words_by"] == "Newest Credits"
         assert temp_db.query_song_editions(song_id)[-1]["id"] == newest_edition
 
+    def test_search_finds_alternate_edition_but_displays_recent_use(self, temp_db):
+        song_id = temp_db.insert_or_get_song("song a", "Song A")
+        selected_edition = temp_db.insert_or_get_song_edition(
+            song_id, words_by="Recent Writer"
+        )
+        temp_db.insert_or_get_song_edition(song_id, words_by="Historical Writer")
+        service_id = temp_db.insert_or_update_service(
+            "2026-02-01", "AM Worship", "service.pptx", "hash"
+        )
+        temp_db.insert_service_song(
+            service_id, song_id, ordinal=1, song_edition_id=selected_edition
+        )
+
+        rows, total = temp_db.query_songs_paginated(search="Historical Writer")
+
+        assert total == 1
+        assert rows[0]["words_by"] == "Recent Writer"
+
     def test_pagination(self, temp_db):
         for i in range(5):
             temp_db.insert_or_get_song(f"song {i}", f"Song {i}")

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -2004,6 +2004,72 @@ class TestQuerySongsPaginated:
         rows, total = temp_db.query_songs_paginated(search="Newton")
         assert total == 1
 
+    def test_credits_use_most_recently_used_edition(self, temp_db):
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        bob_edition = temp_db.insert_or_get_song_edition(
+            song_id, publisher="Z Publisher", words_by="Bob"
+        )
+        alice_edition = temp_db.insert_or_get_song_edition(
+            song_id, publisher="A Publisher", words_by="Alice"
+        )
+        old_service = temp_db.insert_or_update_service(
+            "2026-01-01", "AM Worship", "old.pptx", "old"
+        )
+        new_service = temp_db.insert_or_update_service(
+            "2026-02-01", "AM Worship", "new.pptx", "new"
+        )
+        temp_db.insert_service_song(
+            old_service, song_id, ordinal=1, song_edition_id=alice_edition
+        )
+        temp_db.insert_service_song(
+            new_service, song_id, ordinal=1, song_edition_id=bob_edition
+        )
+
+        rows, total = temp_db.query_songs_paginated()
+
+        assert total == 1
+        assert len(rows) == 1
+        assert rows[0]["words_by"] == "Bob"
+
+    def test_credit_sort_uses_displayed_edition(self, temp_db):
+        song_a = temp_db.insert_or_get_song("song a", "Song A")
+        selected_a = temp_db.insert_or_get_song_edition(
+            song_a, publisher="Z Publisher", words_by="Zulu"
+        )
+        temp_db.insert_or_get_song_edition(
+            song_a, publisher="A Publisher", words_by="Aaron"
+        )
+        song_b = temp_db.insert_or_get_song("song b", "Song B")
+        selected_b = temp_db.insert_or_get_song_edition(song_b, words_by="Mike")
+        service_id = temp_db.insert_or_update_service(
+            "2026-02-01", "AM Worship", "service.pptx", "hash"
+        )
+        temp_db.insert_service_song(
+            service_id, song_a, ordinal=1, song_edition_id=selected_a
+        )
+        temp_db.insert_service_song(
+            service_id, song_b, ordinal=2, song_edition_id=selected_b
+        )
+
+        rows, _ = temp_db.query_songs_paginated(sort="words_by", sort_dir="asc")
+
+        assert [(row["display_title"], row["words_by"]) for row in rows] == [
+            ("Song B", "Mike"),
+            ("Song A", "Zulu"),
+        ]
+
+    def test_unperformed_song_uses_newest_edition_as_fallback(self, temp_db):
+        song_id = temp_db.insert_or_get_song("song a", "Song A")
+        temp_db.insert_or_get_song_edition(song_id, words_by="Older Credits")
+        newest_edition = temp_db.insert_or_get_song_edition(
+            song_id, words_by="Newest Credits"
+        )
+
+        rows, _ = temp_db.query_songs_paginated()
+
+        assert rows[0]["words_by"] == "Newest Credits"
+        assert temp_db.query_song_editions(song_id)[-1]["id"] == newest_edition
+
     def test_pagination(self, temp_db):
         for i in range(5):
             temp_db.insert_or_get_song(f"song {i}", f"Song {i}")

--- a/tests/test_report_service.py
+++ b/tests/test_report_service.py
@@ -108,6 +108,34 @@ class TestReportService:
             f"Arranger should appear in credits string, got: {credits!r}"
         )
 
+    def test_compute_stats_data_uses_most_recent_edition_credits(self, temp_db):
+        """Stats credits come from the latest credited use in the report range."""
+        song_id = temp_db.insert_or_get_song("amazing grace", "Amazing Grace")
+        alice_edition = temp_db.insert_or_get_song_edition(song_id, words_by="Alice")
+        bob_edition = temp_db.insert_or_get_song_edition(song_id, words_by="Bob")
+        for date, edition_id in (
+            ("2026-01-01", alice_edition),
+            ("2026-02-01", bob_edition),
+        ):
+            service_id = temp_db.insert_or_update_service(
+                date, "Sunday AM", f"{date}.pptx", f"hash-{date}"
+            )
+            temp_db.insert_service_song(
+                service_id, song_id, ordinal=1, song_edition_id=edition_id
+            )
+            temp_db.insert_or_get_copy_event(
+                service_id,
+                song_id,
+                "projection",
+                song_edition_id=edition_id,
+            )
+
+        data = compute_stats_data(
+            temp_db, "2026-01-01", "2026-12-31", None, True
+        )
+
+        assert data["song_credits"]["Amazing Grace"] == "Words: Bob"
+
 
 class TestComputeStatsDataExtended:
     """Extended tests for compute_stats_data (#340)."""


### PR DESCRIPTION
Closes #500

## Summary
- choose credits from the most recently dated service use with stable ID tie-breakers
- fall back to the newest edition for songs without edition-linked service history
- sort song-library credit columns using the same displayed edition
- preserve author search across every known alternate edition
- make stats credits choose the latest credited event in the selected report range

## Validation
- 1375 passed, 9 skipped, 59 deselected, 2 xfailed (`pytest -m "not e2e"`)
- Ruff and mypy passed for `src/`
- pip-audit found no known vulnerabilities
- synthetic 1,000-song / 6,000-use query: 0.0082s