### PR TITLE
fix(arch): align fresh services schema

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -373,6 +373,11 @@ class Database:
 
         cursor = self._conn.cursor()
 
+        cursor.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'services'"
+        )
+        services_table_existed = cursor.fetchone() is not None
+
         # Services table
         cursor.execute(
             """
@@ -380,13 +385,13 @@ class Database:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 service_date TEXT NOT NULL,
                 service_name TEXT NOT NULL,
+                source_file TEXT NOT NULL,
+                source_hash TEXT NOT NULL,
                 song_leader TEXT,
                 preacher TEXT,
                 sermon_title TEXT,
-                source_file TEXT NOT NULL,
-                source_hash TEXT NOT NULL,
                 imported_at TEXT NOT NULL,
-                UNIQUE(service_date, service_name, source_hash)
+                UNIQUE(service_date, service_name)
             )
             """
         )
@@ -494,12 +499,18 @@ class Database:
         )
 
         # --- Migration tracking & execution ---
-        self._apply_migrations()
+        # A newly created services table already has migration 3's date/name
+        # identity. Record that migration without running its legacy table-copy
+        # upgrade; databases that arrived with services still run it normally.
+        baseline_versions = frozenset({3}) if not services_table_existed else frozenset()
+        self._apply_migrations(baseline_versions=baseline_versions)
 
         self._conn.execute(f"PRAGMA user_version = {_SCHEMA_VERSION}")
         self._maybe_commit()
 
-    def _apply_migrations(self) -> None:
+    def _apply_migrations(
+        self, *, baseline_versions: frozenset[int] = frozenset()
+    ) -> None:
         """Create schema_migrations table and run any pending migrations."""
         cursor = self._conn.cursor()
 
@@ -522,18 +533,22 @@ class Database:
         for version in sorted(_MIGRATIONS):
             if version in applied:
                 continue
-            for stmt in _MIGRATIONS[version]:
-                # PRAGMA foreign_keys is a no-op inside a transaction (SQLite
-                # rule).  Commit any pending implicit DML transaction first so
-                # the PRAGMA takes effect immediately.
-                if stmt.strip().upper().startswith("PRAGMA"):
-                    self._conn.commit()
-                cursor.execute(stmt)
+            if version not in baseline_versions:
+                for stmt in _MIGRATIONS[version]:
+                    # PRAGMA foreign_keys is a no-op inside a transaction (SQLite
+                    # rule). Commit any pending implicit DML transaction first so
+                    # the PRAGMA takes effect immediately.
+                    if stmt.strip().upper().startswith("PRAGMA"):
+                        self._conn.commit()
+                    cursor.execute(stmt)
             cursor.execute(
                 "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
                 (version, now),
             )
-            _log.info("Applied schema migration %d", version)
+            if version in baseline_versions:
+                _log.info("Recorded schema migration %d from fresh baseline", version)
+            else:
+                _log.info("Applied schema migration %d", version)
 
     # --- Songs ---
 

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -1831,6 +1831,42 @@ class TestSchemaMigration:
         assert 1 in versions
         db.close()
 
+    def test_fresh_services_schema_skips_legacy_table_rebuild(self, tmp_path: Path) -> None:
+        """Fresh databases start at the v3 service identity without rebuilding."""
+        db = Database(tmp_path / "fresh.db")
+        db.connect()
+        statements: list[str] = []
+        db.conn.set_trace_callback(statements.append)
+
+        db.init_schema()
+
+        schema_sql = db.conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='services'"
+        ).fetchone()[0]
+        normalized_schema = " ".join(schema_sql.split())
+        assert "UNIQUE(service_date, service_name)" in normalized_schema
+        assert "UNIQUE(service_date, service_name, source_hash)" not in normalized_schema
+        columns = [
+            row["name"]
+            for row in db.conn.execute("PRAGMA table_info(services)").fetchall()
+        ]
+        assert columns == [
+            "id",
+            "service_date",
+            "service_name",
+            "source_file",
+            "source_hash",
+            "song_leader",
+            "preacher",
+            "sermon_title",
+            "imported_at",
+        ]
+        assert not any("SERVICES_NEW" in statement.upper() for statement in statements)
+        assert db.conn.execute(
+            "SELECT COUNT(*) FROM schema_migrations WHERE version = 3"
+        ).fetchone()[0] == 1
+        db.close()
+
     def test_migrations_are_idempotent(self, tmp_path: Path) -> None:
         """Calling init_schema() twice does not duplicate migration records."""
         db_path = tmp_path / "fresh.db"


### PR DESCRIPTION
Closes #510

## Summary
- define the fresh services table with the authoritative date/name identity and migrated column order
- record migration 3 from the fresh baseline without running its legacy table rebuild
- preserve the full migration-3 dedupe/copy path for databases with an existing services table
- trace fresh initialization to prove no services_new copy/drop/rename occurs

## Validation
- 1376 passed, 9 skipped, 59 deselected, 2 xfailed (`pytest -m "not e2e"`)
- legacy migration-3 dedupe, winner, and child-cleanup tests pass
- Ruff and mypy passed for `src/`
- pip-audit found no known vulnerabilities