### PR TITLE
fix(devops): stream uploads to disk

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -91,6 +91,9 @@ services:
     # Tag sha-<commit> = main@68eaf57; digest resolved from GHCR 2026-07-18.
     image: ghcr.io/mshirel/song-history:sha-68eaf57d3740a2180d3201786d423b2d924f1f69@sha256:4e6e472601d6957ecbc6ec2d7e8f4a9f22117e3503d2a7c40161651856dd1b26
     restart: unless-stopped
+    # Bound the public upload process on the 512 MB Pi host (#503). Uploads are
+    # streamed to disk, so even the 200 MB maximum file fits this budget.
+    mem_limit: 512m
     stop_grace_period: 35s
     ports:
       - "8000:8000"  # Prometheus /metrics scraping (internal only — not routed via Traefik)

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -1411,45 +1411,58 @@ async def upload(
             content={"detail": "Filename is invalid after sanitization"},
             status_code=400,
         )
-    # Read body in chunks to bound memory usage (#297)
-    chunks: list[bytes] = []
-    total_read = 0
-    while True:
-        chunk = await file.read(_UPLOAD_CHUNK_SIZE)
-        if not chunk:
-            break
-        total_read += len(chunk)
-        if total_read > MAX_UPLOAD_BYTES:
-            break
-        chunks.append(chunk)
-    content = b"".join(chunks)
-    # Validate ZIP magic bytes — PPTX is a ZIP archive (PK\x03\x04) (#320)
-    if len(content) < 4 or content[:4] != b"PK\x03\x04":
-        send_pushover(
-            title="Upload rejected",
-            message=f"{filename} — not a valid PPTX (bad magic bytes)",
-            priority=-1,
-        )
-        return JSONResponse(
-            content={"detail": "File is not a valid PPTX archive"},
-            status_code=400,
-        )
-    if total_read > MAX_UPLOAD_BYTES:
-        limit_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
-        send_pushover(
-            title="Upload rejected",
-            message=f"{filename} — file exceeds {limit_mb} MB limit",
-            priority=-1,
-        )
-        return JSONResponse(
-            content={"detail": f"File exceeds maximum allowed size of {limit_mb} MB"},
-            status_code=413,
-        )
-    # Save to inbox
+    # Stream to a hidden sibling file so neither the watcher nor the import pool
+    # can observe a partial PPTX.  Rename into place only after validation (#503).
     inbox = _get_inbox_dir()
     job_id = secrets.token_urlsafe(32)
     dest = inbox / f"{job_id}_{filename}"
-    dest.write_bytes(content)
+    partial = inbox / f".{job_id}.uploading"
+    total_read = 0
+    magic = bytearray()
+    try:
+        with partial.open("xb") as output:
+            while True:
+                chunk = await file.read(_UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                total_read += len(chunk)
+                if total_read > MAX_UPLOAD_BYTES:
+                    break
+                if len(magic) < 4:
+                    magic.extend(chunk[: 4 - len(magic)])
+                output.write(chunk)
+
+        if total_read > MAX_UPLOAD_BYTES:
+            limit_mb = MAX_UPLOAD_BYTES // (1024 * 1024)
+            send_pushover(
+                title="Upload rejected",
+                message=f"{filename} — file exceeds {limit_mb} MB limit",
+                priority=-1,
+            )
+            return JSONResponse(
+                content={
+                    "detail": f"File exceeds maximum allowed size of {limit_mb} MB"
+                },
+                status_code=413,
+            )
+
+        # PPTX is a ZIP archive.  Accumulate only its four-byte signature so
+        # validation also works when a read boundary falls inside the magic.
+        if bytes(magic) != b"PK\x03\x04":
+            send_pushover(
+                title="Upload rejected",
+                message=f"{filename} — not a valid PPTX (bad magic bytes)",
+                priority=-1,
+            )
+            return JSONResponse(
+                content={"detail": "File is not a valid PPTX archive"},
+                status_code=400,
+            )
+
+        partial.replace(dest)
+    finally:
+        partial.unlink(missing_ok=True)
+
     # Create pending job record
     db.create_import_job(job_id, filename=filename)
     # Submit import to bounded thread pool (#52).

--- a/tests/test_pi_compose.py
+++ b/tests/test_pi_compose.py
@@ -95,6 +95,16 @@ class TestTrustedProxy:
         )
 
 
+class TestAppMemoryLimit:
+    """The public app must fit inside the Pi's explicit memory budget (#503)."""
+
+    def test_song_history_has_512_mb_memory_limit(self) -> None:
+        service = yaml.safe_load(COMPOSE_PATH.read_text())["services"]["song-history"]
+        assert str(service.get("mem_limit", "")).lower() == "512m", (
+            "song-history must have an explicit 512 MB Compose memory limit"
+        )
+
+
 @pytest.mark.skipif(not TRAEFIK_PATH.exists(), reason="Pi traefik config not present")
 class TestTraefikDashboard:
     """The Traefik API dashboard must not run in insecure mode (#513).

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4080,6 +4080,91 @@ class TestUploadMagicBytes:
         assert "not a valid PPTX" in resp.json()["detail"]
 
 
+class TestUploadStreamingIssue503:
+    """Uploads are streamed atomically without retaining the whole body (#503)."""
+
+    def test_upload_streams_to_inbox_without_path_write_bytes(
+        self, client, tmp_path, monkeypatch
+    ):
+        """The handler must not materialize the complete upload for write_bytes()."""
+        import worship_catalog.web.app as app_module
+
+        submitted: list[Path] = []
+        monkeypatch.setattr(
+            app_module._import_executor,
+            "submit",
+            lambda _fn, _job_id, path: submitted.append(path),
+        )
+
+        def reject_whole_file_write(_self: Path, _data: bytes) -> int:
+            raise AssertionError("upload used Path.write_bytes instead of streaming")
+
+        monkeypatch.setattr(Path, "write_bytes", reject_whole_file_write)
+        payload = b"PK\x03\x04" + b"streamed-payload"
+
+        response = client.post(
+            "/upload",
+            files={"file": ("streamed.pptx", io.BytesIO(payload), VALID_PPTX_MIME)},
+        )
+
+        assert response.status_code == 202
+        assert len(submitted) == 1
+        assert submitted[0].read_bytes() == payload
+        assert not list(submitted[0].parent.glob("*.uploading"))
+
+    def test_magic_bytes_can_span_read_chunks(self, client, monkeypatch):
+        import worship_catalog.web.app as app_module
+
+        submitted: list[Path] = []
+        monkeypatch.setattr(app_module, "_UPLOAD_CHUNK_SIZE", 2)
+        monkeypatch.setattr(
+            app_module._import_executor,
+            "submit",
+            lambda _fn, _job_id, path: submitted.append(path),
+        )
+
+        response = client.post(
+            "/upload",
+            files={"file": ("split.pptx", io.BytesIO(b"PK\x03\x04body"), VALID_PPTX_MIME)},
+        )
+
+        assert response.status_code == 202
+        assert submitted[0].read_bytes() == b"PK\x03\x04body"
+
+    def test_bad_magic_removes_partial_upload(self, client, monkeypatch):
+        import worship_catalog.web.app as app_module
+
+        monkeypatch.setattr(app_module._import_executor, "submit", pytest.fail)
+        response = client.post(
+            "/upload",
+            files={"file": ("fake.pptx", io.BytesIO(b"not-a-zip"), VALID_PPTX_MIME)},
+        )
+
+        assert response.status_code == 400
+        assert not list(Path(os.environ["INBOX_DIR"]).iterdir())
+
+    def test_oversize_body_removes_partial_upload(self, client, monkeypatch):
+        import worship_catalog.web.app as app_module
+
+        monkeypatch.setattr(app_module, "MAX_UPLOAD_BYTES", 8)
+        monkeypatch.setattr(app_module, "_UPLOAD_CHUNK_SIZE", 4)
+        monkeypatch.setattr(app_module._import_executor, "submit", pytest.fail)
+        response = client.post(
+            "/upload",
+            headers={"content-length": "8"},
+            files={
+                "file": (
+                    "large.pptx",
+                    io.BytesIO(b"PK\x03\x04too-large"),
+                    VALID_PPTX_MIME,
+                )
+            },
+        )
+
+        assert response.status_code == 413
+        assert not list(Path(os.environ["INBOX_DIR"]).iterdir())
+
+
 # ---------------------------------------------------------------------------
 # Build date formatting (#331)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- stream `/upload` request bodies directly into a hidden inbox file instead of retaining all chunks and joining a second full-size byte string
- validate the four-byte ZIP signature across chunk boundaries and atomically rename only validated uploads
- delete partial files after oversize, invalid-signature, or write failures
- enforce a 512 MB Compose memory limit for the Pi web service
- add regression coverage for streaming behavior, cleanup, chunk-boundary validation, and the production memory limit

## Why

A maximum-size 200 MB PPTX previously consumed the chunk list plus another contiguous 200 MB allocation from `b"".join(...)`. That transient duplication could exhaust the public Pi container's 512 MB budget.

## Validation

- `uv run pytest -q -m 'not e2e'` — 1,381 passed, 9 skipped, 2 xfailed
- focused E2E selection — 1 passed, 58 environment-skipped
- `uv run ruff check src tests/test_pi_compose.py`
- `uv run mypy src`
- `uv run pip-audit`
- `docker compose -f deploy/pi/docker-compose.yml config --quiet`

Closes #503