### PR TITLE
fix(arch): offload stats report work

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -16,9 +16,9 @@ import secrets
 import threading
 import time
 from collections import defaultdict
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterator
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from datetime import date, datetime
 from pathlib import Path
 from typing import Any
@@ -587,6 +587,21 @@ async def get_db() -> AsyncGenerator[Database, None]:
         db.close()
 
 
+@contextmanager
+def _thread_confined_db() -> Iterator[Database]:
+    """Open and close a DB in the calling worker thread.
+
+    Sync report handlers run in FastAPI's worker pool.  Their SQLite connection
+    must therefore be created, used, and closed inside that same handler rather
+    than by the async ``get_db`` dependency on the event-loop thread (#501).
+    """
+    db = _get_db()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -719,17 +734,17 @@ def _compute_stats(
 
 
 @app.post("/reports/stats", response_class=HTMLResponse)
-async def reports_stats(
+def reports_stats(
     request: Request,
     start_date: str = Form(...),
     end_date: str = Form(...),
     leader: str = Form(default=""),
     all_songs: bool = Form(default=False),
-    db: Database = Depends(get_db),  # noqa: B008
     _rl: None = Depends(_report_rate_limit),  # noqa: B008
 ) -> HTMLResponse:
     _validate_date_range(start_date, end_date)
-    data = _compute_stats(db, start_date, end_date, leader, all_songs)
+    with _thread_confined_db() as db:
+        data = _compute_stats(db, start_date, end_date, leader, all_songs)
 
     _log.info(
         "Stats report generated",
@@ -750,16 +765,16 @@ async def reports_stats(
 
 
 @app.post("/reports/stats/csv")
-async def reports_stats_csv(
+def reports_stats_csv(
     start_date: str = Form(...),
     end_date: str = Form(...),
     leader: str = Form(default=""),
     all_songs: bool = Form(default=False),
-    db: Database = Depends(get_db),  # noqa: B008
     _rl: None = Depends(_report_rate_limit),  # noqa: B008
 ) -> StreamingResponse:
     _validate_date_range(start_date, end_date)
-    data = _compute_stats(db, start_date, end_date, leader, all_songs)
+    with _thread_confined_db() as db:
+        data = _compute_stats(db, start_date, end_date, leader, all_songs)
 
     output = io.StringIO()
     writer = csv.writer(output)
@@ -777,12 +792,11 @@ async def reports_stats_csv(
 
 
 @app.post("/reports/stats/xlsx")
-async def reports_stats_xlsx(
+def reports_stats_xlsx(
     start_date: str = Form(...),
     end_date: str = Form(...),
     leader: str = Form(default=""),
     all_songs: bool = Form(default=False),
-    db: Database = Depends(get_db),  # noqa: B008
     _rl: None = Depends(_report_rate_limit),  # noqa: B008
 ) -> StreamingResponse:
     _validate_date_range(start_date, end_date)
@@ -795,7 +809,8 @@ async def reports_stats_xlsx(
             detail="Excel export requires openpyxl. Install with: pip install openpyxl",
         ) from exc
 
-    data = _compute_stats(db, start_date, end_date, leader, all_songs)
+    with _thread_confined_db() as db:
+        data = _compute_stats(db, start_date, end_date, leader, all_songs)
 
     wb = openpyxl.Workbook()
     ws = wb.active

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -3778,6 +3778,121 @@ class TestDbConnectionCleanup:
         )
 
 
+class TestReportEventLoopOffloadIssue501:
+    """Heavy stats aggregation and workbook builds must not block the event loop."""
+
+    _FORM = {
+        "start_date": "2026-01-01",
+        "end_date": "2026-12-31",
+        "leader": "",
+        "all_songs": "true",
+    }
+
+    def test_heavy_stats_routes_are_sync_worker_handlers(self) -> None:
+        """FastAPI offloads ordinary ``def`` handlers to its worker pool."""
+        import inspect
+
+        import worship_catalog.web.app as app_module
+
+        endpoints = {
+            route.path: route.endpoint
+            for route in app_module.app.routes
+            if hasattr(route, "endpoint")
+        }
+        for path in (
+            "/reports/stats",
+            "/reports/stats/csv",
+            "/reports/stats/xlsx",
+        ):
+            assert not inspect.iscoroutinefunction(endpoints[path]), (
+                f"{path} must be a sync handler so blocking report work runs off-loop"
+            )
+
+    def test_health_not_blocked_by_slow_stats_report(
+        self, db_with_songs, tmp_path, monkeypatch
+    ) -> None:
+        import threading
+        import time
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(tmp_path / "inbox"))
+        reload(app_module)
+
+        original_compute = app_module._compute_stats
+        report_started = threading.Event()
+
+        def slow_compute(*args: object, **kwargs: object) -> object:
+            report_started.set()
+            time.sleep(1.0)
+            return original_compute(*args, **kwargs)
+
+        monkeypatch.setattr(app_module, "_compute_stats", slow_compute)
+        report_result: dict[str, object] = {}
+
+        with TestClient(app_module.app) as raw:
+            shared_client = CsrfAwareClient(raw)
+            shared_client._ensure_token()
+
+            def run_report() -> None:
+                report_result["response"] = shared_client.post(
+                    "/reports/stats", data=self._FORM
+                )
+
+            report_thread = threading.Thread(target=run_report)
+            report_thread.start()
+            assert report_started.wait(timeout=2.0), "slow report never started"
+
+            started = time.monotonic()
+            health_response = shared_client.get("/health")
+            health_latency = time.monotonic() - started
+            report_thread.join(timeout=3.0)
+
+        assert not report_thread.is_alive()
+        assert health_response.status_code == 200
+        assert health_latency < 0.5, (
+            f"/health waited {health_latency:.2f}s for blocking report work"
+        )
+        assert report_result["response"].status_code == 200
+
+    def test_worker_database_closes_when_stats_computation_fails(
+        self, db_with_songs, tmp_path, monkeypatch
+    ) -> None:
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(tmp_path / "inbox"))
+        reload(app_module)
+
+        close_calls: list[bool] = []
+        original_close = Database.close
+
+        def tracking_close(self: Database) -> None:
+            close_calls.append(True)
+            original_close(self)
+
+        def fail_compute(*args: object, **kwargs: object) -> object:
+            raise RuntimeError("simulated report failure")
+
+        monkeypatch.setattr(Database, "close", tracking_close)
+        monkeypatch.setattr(app_module, "_compute_stats", fail_compute)
+
+        with TestClient(app_module.app, raise_server_exceptions=False) as raw:
+            shared_client = CsrfAwareClient(raw)
+            shared_client._ensure_token()
+            close_calls.clear()
+            response = shared_client.post("/reports/stats", data=self._FORM)
+
+        assert response.status_code == 500
+        assert close_calls == [True], (
+            "report worker must close exactly its own per-request database connection"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Pushover notifications on early upload rejections (#267)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- make the HTML, CSV, and XLSX stats endpoints synchronous worker handlers so FastAPI moves their complete blocking workloads off the event loop
- create, use, and close each report database connection inside the same worker thread to preserve SQLite thread confinement
- add a shared-event-loop concurrency regression proving `/health` remains responsive during a deliberately slow report
- verify all three heavy endpoints are worker-dispatched and report connections close on failure

## Why

The async handlers performed synchronous SQLite aggregation and openpyxl workbook construction directly on the single web event loop. A slow all-time report could therefore stall health checks and unrelated requests.

## Validation

- `uv run pytest -q -m 'not e2e'` — 1,384 passed, 9 skipped, 2 xfailed
- focused E2E selection — 1 passed, 58 environment-skipped
- `uv run ruff check src`
- `uv run mypy src`
- `uv run pip-audit`

Closes #501