### PR TITLE
fix(extractor): enforce wall-clock timeout

### DIFF
--- a/src/worship_catalog/extractor.py
+++ b/src/worship_catalog/extractor.py
@@ -293,15 +293,20 @@ def extract_songs(
         TimeoutError: If extraction exceeds _MAX_EXTRACT_SECONDS.
         ValueError: If file exceeds size/slide-count limits.
     """
-    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-        future = executor.submit(_extract_songs_impl, file_path, use_ocr, ocr_budget, library_index)
-        try:
-            return future.result(timeout=_MAX_EXTRACT_SECONDS)
-        except concurrent.futures.TimeoutError as exc:
-            raise TimeoutError(
-                f"extract_songs exceeded {_MAX_EXTRACT_SECONDS}s time limit for "
-                f"{Path(file_path).name}"
-            ) from exc
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(_extract_songs_impl, file_path, use_ocr, ocr_budget, library_index)
+    try:
+        return future.result(timeout=_MAX_EXTRACT_SECONDS)
+    except concurrent.futures.TimeoutError as exc:
+        # A running Python thread cannot be killed safely.  Crucially, do not
+        # wait for it here: that would defeat the caller-visible timeout (#498).
+        future.cancel()
+        raise TimeoutError(
+            f"extract_songs exceeded {_MAX_EXTRACT_SECONDS}s time limit for "
+            f"{Path(file_path).name}"
+        ) from exc
+    finally:
+        executor.shutdown(wait=False, cancel_futures=True)
 
 
 def _extract_songs_impl(

--- a/src/worship_catalog/extractor.py
+++ b/src/worship_catalog/extractor.py
@@ -38,6 +38,13 @@ _MAX_SLIDE_COUNT: int = 500
 
 # Wall-clock timeout for a single file extraction (#73 — prevents runaway on adversarial PPTX)
 _MAX_EXTRACT_SECONDS: int = 120
+# Keep abandoned timed-out workers bounded to the web import pool's concurrency.
+# Queued futures are canceled on timeout before they begin (#498).
+_MAX_CONCURRENT_EXTRACTIONS: int = 4
+_extract_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_MAX_CONCURRENT_EXTRACTIONS,
+    thread_name_prefix="song-extract",
+)
 
 # Consecutive slides with no text after which the current song group is closed
 _NO_TEXT_STREAK_THRESHOLD: int = 5
@@ -293,8 +300,9 @@ def extract_songs(
         TimeoutError: If extraction exceeds _MAX_EXTRACT_SECONDS.
         ValueError: If file exceeds size/slide-count limits.
     """
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-    future = executor.submit(_extract_songs_impl, file_path, use_ocr, ocr_budget, library_index)
+    future = _extract_executor.submit(
+        _extract_songs_impl, file_path, use_ocr, ocr_budget, library_index
+    )
     try:
         return future.result(timeout=_MAX_EXTRACT_SECONDS)
     except concurrent.futures.TimeoutError as exc:
@@ -305,8 +313,6 @@ def extract_songs(
             f"extract_songs exceeded {_MAX_EXTRACT_SECONDS}s time limit for "
             f"{Path(file_path).name}"
         ) from exc
-    finally:
-        executor.shutdown(wait=False, cancel_futures=True)
 
 
 def _extract_songs_impl(

--- a/tests/test_extractor_unit.py
+++ b/tests/test_extractor_unit.py
@@ -622,6 +622,36 @@ class TestExtractionTimeout:
         with pytest.raises(TimeoutError):
             ext_module.extract_songs(pptx_path)
 
+    def test_timeout_returns_without_waiting_for_stuck_worker(
+        self, tmp_path, monkeypatch
+    ):
+        """Executor shutdown must not defeat the public wall-clock timeout (#498)."""
+        import threading
+        import time
+
+        import worship_catalog.extractor as ext_module
+
+        worker_started = threading.Event()
+
+        def slow_impl(*args, **kwargs):
+            worker_started.set()
+            time.sleep(0.5)
+
+        monkeypatch.setattr(ext_module, "_MAX_EXTRACT_SECONDS", 0.05)
+        monkeypatch.setattr(ext_module, "_extract_songs_impl", slow_impl)
+        pptx_path = tmp_path / "stuck.pptx"
+        pptx_path.write_bytes(b"PK\x03\x04")
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            ext_module.extract_songs(pptx_path)
+        elapsed = time.monotonic() - started
+
+        assert worker_started.is_set()
+        assert elapsed < 0.25, (
+            f"extract_songs waited {elapsed:.2f}s for its timed-out worker to finish"
+        )
+
     def test_normal_extraction_completes_within_limit(self, tmp_path):
         """A minimal PPTX completes well within the default time limit."""
         from pptx import Presentation

--- a/tests/test_extractor_unit.py
+++ b/tests/test_extractor_unit.py
@@ -652,6 +652,39 @@ class TestExtractionTimeout:
             f"extract_songs waited {elapsed:.2f}s for its timed-out worker to finish"
         )
 
+    def test_timed_out_extractions_cannot_grow_worker_threads_without_bound(
+        self, tmp_path, monkeypatch
+    ):
+        """Repeated timeouts must remain capped by the shared extraction pool."""
+        import threading
+        import time
+
+        import worship_catalog.extractor as ext_module
+
+        state = {"active": 0, "peak": 0}
+        lock = threading.Lock()
+
+        def slow_impl(*args, **kwargs):
+            with lock:
+                state["active"] += 1
+                state["peak"] = max(state["peak"], state["active"])
+            try:
+                time.sleep(0.3)
+            finally:
+                with lock:
+                    state["active"] -= 1
+
+        monkeypatch.setattr(ext_module, "_MAX_EXTRACT_SECONDS", 0.01)
+        monkeypatch.setattr(ext_module, "_extract_songs_impl", slow_impl)
+        pptx_path = tmp_path / "repeated-timeouts.pptx"
+        pptx_path.write_bytes(b"PK\x03\x04")
+
+        for _ in range(8):
+            with pytest.raises(TimeoutError):
+                ext_module.extract_songs(pptx_path)
+
+        assert state["peak"] <= ext_module._MAX_CONCURRENT_EXTRACTIONS
+
     def test_normal_extraction_completes_within_limit(self, tmp_path):
         """A minimal PPTX completes well within the default time limit."""
         from pptx import Presentation


### PR DESCRIPTION
## What changed

- run extraction through one shared four-worker pool, matching the web import concurrency bound
- return `TimeoutError` immediately at the configured wall-clock limit instead of waiting for a runaway worker during context-manager shutdown
- cancel timed-out work when it has not started, while capping still-running timed-out workers
- add timing and repeated-timeout regressions proving prompt return and bounded worker growth

## Why

`future.result(timeout=...)` raised on time, but leaving the per-call executor context called `shutdown(wait=True)`. Simply abandoning each per-call executor would return promptly but permit repeated pathological uploads to accumulate unlimited runaway threads. The shared bounded executor preserves both the timeout and the process resource ceiling.

## Validation

- `uv run pytest -q -m 'not e2e'` — 1,386 passed, 9 skipped, 2 xfailed
- focused E2E selection — 1 passed, 58 environment-skipped
- `uv run ruff check src`
- `uv run mypy src`
- `uv run pip-audit`

Closes #498