### PR TITLE
fix(data): bound copy event service filter

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -19,6 +19,10 @@ _log = logging.getLogger("worship_catalog.db")
 # on-disk version is *higher* than this value (DB created by a newer release).
 _SCHEMA_VERSION: int = 7
 
+# Leave room below legacy SQLite's 999-variable ceiling for the date bounds and
+# future fixed predicates. Larger service filters are intersected in Python.
+_COPY_EVENTS_SERVICE_ID_SQL_LIMIT: int = 900
+
 # Ordered dict of version → list of SQL statements.  Each migration brings the
 # DB from version (N-1) to version N.  Migration 1 is the baseline — it
 # creates the import_jobs table that was added in #45.  For a fresh database
@@ -841,12 +845,29 @@ class Database:
         cursor.execute(base, params)
         return cursor
 
+    @staticmethod
+    def _copy_event_service_filter(
+        service_ids: list[int] | None,
+    ) -> tuple[list[int] | None, set[int] | None]:
+        """Return the SQL filter and any overflow filter to apply in Python."""
+        if (
+            service_ids is not None
+            and len(service_ids) > _COPY_EVENTS_SERVICE_ID_SQL_LIMIT
+        ):
+            return None, set(service_ids)
+        return service_ids, None
+
     def query_copy_events(
         self, start_date: str, end_date: str, service_ids: list[int] | None = None
     ) -> list[dict]:
         """Query copy events for date range, optionally restricted to given service IDs."""
-        cursor = self._execute_copy_events_query(start_date, end_date, service_ids)
-        return [dict(row) for row in cursor.fetchall()]
+        sql_service_ids, overflow_filter = self._copy_event_service_filter(service_ids)
+        cursor = self._execute_copy_events_query(start_date, end_date, sql_service_ids)
+        return [
+            dict(row)
+            for row in cursor
+            if overflow_filter is None or row["service_id"] in overflow_filter
+        ]
 
     def iter_copy_events(
         self, start_date: str, end_date: str, service_ids: list[int] | None = None
@@ -857,10 +878,12 @@ class Database:
         individually so callers can process large result sets without
         materialising the entire list (#27).
         """
-        cursor = self._execute_copy_events_query(start_date, end_date, service_ids)
+        sql_service_ids, overflow_filter = self._copy_event_service_filter(service_ids)
+        cursor = self._execute_copy_events_query(start_date, end_date, sql_service_ids)
         row = cursor.fetchone()
         while row is not None:
-            yield dict(row)
+            if overflow_filter is None or row["service_id"] in overflow_filter:
+                yield dict(row)
             row = cursor.fetchone()
 
     # --- Service exclusions (missing-services report) ---

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -639,6 +639,45 @@ class TestQueryOperations:
         assert len(results) == 1
         assert results[0]["service_id"] == service_id_1
 
+    def test_copy_event_service_filter_survives_low_sqlite_variable_limit(
+        self, temp_db
+    ):
+        """Large service filters fall back without exceeding SQLite's bind cap (#511)."""
+        service_id_1 = temp_db.insert_or_update_service(
+            service_date="2026-02-15",
+            service_name="Morning Worship",
+            source_file="file1.pptx",
+            source_hash="hash1",
+        )
+        service_id_2 = temp_db.insert_or_update_service(
+            service_date="2026-02-22",
+            service_name="Evening Worship",
+            source_file="file2.pptx",
+            source_hash="hash2",
+        )
+        song_id = temp_db.insert_or_get_song("majesty", "Majesty")
+        temp_db.insert_or_get_copy_event(service_id_1, song_id, "projection")
+        temp_db.insert_or_get_copy_event(service_id_2, song_id, "projection")
+
+        # Include one real ID and enough absent IDs to exceed the forced legacy
+        # SQLite limit.  The second real service must still be excluded.
+        service_ids = [service_id_1, *range(10_000, 11_000)]
+        previous_limit = temp_db.conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 100)
+        try:
+            queried = temp_db.query_copy_events(
+                "2026-01-01", "2026-12-31", service_ids=service_ids
+            )
+            streamed = list(
+                temp_db.iter_copy_events(
+                    "2026-01-01", "2026-12-31", service_ids=service_ids
+                )
+            )
+        finally:
+            temp_db.conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, previous_limit)
+
+        assert [event["service_id"] for event in queried] == [service_id_1]
+        assert [event["service_id"] for event in streamed] == [service_id_1]
+
 
 @pytest.mark.integration
 class TestMissingCredits:


### PR DESCRIPTION
## Summary
- cap copy-event SQL `IN` filters below legacy SQLite variable limits
- fall back to an ordered cursor scan with set membership for oversized filters
- cover both list and streaming query APIs under a forced low SQLite bind limit

## Validation
- `uv run pytest -q -m 'not e2e'` (1387 passed)
- `uv run pytest -q -m e2e` (1 passed, 58 skipped)
- `uv run ruff check src --output-format concise`
- `uv run mypy src`
- `uv run pip-audit`
- `graphify update .`

Closes #511