### PR TITLE
chore(deploy): pin Sprint 5 Pi release

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -46,8 +46,8 @@ services:
     # :latest silently swaps running app code with no digest record and no
     # rollback target. Pin to the sha- tag + digest CI publishes; Dependabot's
     # `docker` ecosystem entry (#502) bumps this on a reviewed PR.
-    # Tag sha-<commit> = main@68eaf57; digest resolved from GHCR 2026-07-18.
-    image: ghcr.io/mshirel/song-history:sha-68eaf57d3740a2180d3201786d423b2d924f1f69@sha256:4e6e472601d6957ecbc6ec2d7e8f4a9f22117e3503d2a7c40161651856dd1b26
+    # Tag sha-<commit> = main@66a07ae; digest resolved from GHCR 2026-07-18.
+    image: ghcr.io/mshirel/song-history:sha-66a07ae98556411e9e74cefc451cac18dcdaf433@sha256:192ca716e7ef1a04d0f99c57bad3a82e2d9306fbbee272d3651f5ca9f4aae4f0
     restart: unless-stopped
     init: true
     # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
@@ -88,8 +88,8 @@ services:
   song-history:
     # Immutably pinned (#512) — was the mutable :latest. Keep this in lockstep
     # with the `watcher` service above; Dependabot (#502) bumps both.
-    # Tag sha-<commit> = main@68eaf57; digest resolved from GHCR 2026-07-18.
-    image: ghcr.io/mshirel/song-history:sha-68eaf57d3740a2180d3201786d423b2d924f1f69@sha256:4e6e472601d6957ecbc6ec2d7e8f4a9f22117e3503d2a7c40161651856dd1b26
+    # Tag sha-<commit> = main@66a07ae; digest resolved from GHCR 2026-07-18.
+    image: ghcr.io/mshirel/song-history:sha-66a07ae98556411e9e74cefc451cac18dcdaf433@sha256:192ca716e7ef1a04d0f99c57bad3a82e2d9306fbbee272d3651f5ca9f4aae4f0
     restart: unless-stopped
     # Bound the public upload process on the 512 MB Pi host (#503). Uploads are
     # streamed to disk, so even the 200 MB maximum file fits this budget.


### PR DESCRIPTION
## Summary
- pin both Pi app services to the final Sprint 5 application commit `66a07ae98556411e9e74cefc451cac18dcdaf433`
- pin the exact GHCR OCI index digest `sha256:192ca716e7ef1a04d0f99c57bad3a82e2d9306fbbee272d3651f5ca9f4aae4f0`
- keep the web and watcher services in lockstep for the #565 rollout

## Validation
- final application main CI run 29637748814: test, security, E2E, CVE scan, image smoke, and multi-platform publish green
- GHCR manifest contains `linux/arm64` and `linux/amd64`
- `uv run pytest -q tests/test_pi_compose.py tests/test_pi_deploy_doc.py tests/test_backup_sh.py tests/test_backup_restore.py` (37 passed)
- `docker compose --env-file deploy/pi/.env.example -f deploy/pi/docker-compose.yml config --quiet`
- final-main local suite: 1388 non-E2E passed; E2E marker, Ruff, mypy, and pip-audit green

Part of #565. The issue remains open until the Pi is backed up, deployed, and production-verified.