### PR TITLE
fix(web): answer HEAD on every GET route, and prove /health can render (#581)

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -16,7 +16,7 @@ import secrets
 import threading
 import time
 from collections import defaultdict
-from collections.abc import AsyncGenerator, Iterator
+from collections.abc import AsyncGenerator, Callable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from datetime import date, datetime
@@ -34,6 +34,7 @@ from fastapi import (
     UploadFile,
 )
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, StreamingResponse
+from fastapi.routing import APIRoute
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, Counter, Histogram, generate_latest
@@ -106,6 +107,79 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 
 app = FastAPI(title="Worship Catalog", lifespan=_lifespan)
+
+
+class _HeadAwareAPIRoute(APIRoute):
+    """An ``APIRoute`` that answers ``HEAD`` wherever it answers ``GET`` (#581).
+
+    FastAPI takes ``methods`` literally, unlike plain Starlette's ``Route``, which adds
+    ``HEAD`` whenever ``GET`` is present. Every ``@app.get`` route therefore answered
+    ``405 Method Not Allowed`` to a HEAD request — and UptimeRobot probes with HEAD by
+    default, so the external monitor read a perfectly healthy site as hard-down. RFC 9110
+    also requires HEAD of any general-purpose server, and link checkers and ``curl -I``
+    expect it.
+
+    Fixing it on the route *class* rather than per-route is the point: it holds for every
+    route registered afterwards, so a new ``@app.get`` cannot quietly reintroduce the gap.
+    A HEAD response must carry no body, which Starlette and uvicorn already handle.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        endpoint: Callable[..., Any],
+        *,
+        methods: list[str] | set[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if methods is not None:
+            upper = {m.upper() for m in methods}
+            if "GET" in upper and "HEAD" not in upper:
+                methods = [*methods, "HEAD"]
+        super().__init__(path, endpoint, methods=methods, **kwargs)
+
+
+app.router.route_class = _HeadAwareAPIRoute
+
+# Routing HEAD and *documenting* it are different things. FastAPI derives one operation id
+# per route and reuses it for every method, so a route carrying both GET and HEAD emits two
+# operations sharing an id — 16 duplicate `operationId`s in a schema that is served publicly
+# at /openapi.json, which makes the document invalid and breaks client generators. HEAD is a
+# protocol affordance of the GET operation, not a separate operation, so it is stripped for
+# schema generation only. The lock keeps a concurrent request from matching a route during
+# the brief window when HEAD is removed; the schema is built once and cached thereafter.
+_openapi_lock = threading.Lock()
+_default_openapi = app.openapi
+
+
+def _openapi_without_head() -> dict[str, Any]:
+    """The generated schema, minus the HEAD methods added by :class:`_HeadAwareAPIRoute`."""
+    if app.openapi_schema:
+        return app.openapi_schema
+    with _openapi_lock:
+        if app.openapi_schema:
+            return app.openapi_schema
+        # Keep each route's ORIGINAL method set and restore that verbatim, rather than
+        # re-adding HEAD afterwards — restoring what was actually there cannot invent a
+        # method that a future route never declared.
+        patched: list[tuple[APIRoute, set[str]]] = [
+            (route, set(route.methods))
+            for route in app.routes
+            if isinstance(route, APIRoute)
+            and route.methods
+            and "HEAD" in route.methods
+            and route.methods != {"HEAD"}
+        ]
+        for route, methods in patched:
+            route.methods = methods - {"HEAD"}
+        try:
+            return _default_openapi()
+        finally:
+            for route, methods in patched:
+                route.methods = methods
+
+
+app.openapi = _openapi_without_head  # type: ignore[method-assign]
 
 # CSRF protection — must be added BEFORE RequestLoggingMiddleware so that 403
 # responses are logged correctly. A stable CSRF_SECRET is REQUIRED in
@@ -230,6 +304,91 @@ _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _STATIC_DIR = Path(__file__).parent / "static"
 templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
 app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
+
+# ---------------------------------------------------------------------------
+# Render proof (#581) — ported from espn-ff #1093
+# ---------------------------------------------------------------------------
+
+# Pieces whose absence leaves the catalog visibly broken while the process stays perfectly
+# healthy: base.html wraps every page, and both scripts are VENDORED rather than pulled from
+# a CDN (the #197 CSP allows 'self' only), so a bad Dockerfile COPY ships a site that returns
+# 200 on every request with dead search, dead pagination and dead nav. The stylesheet needs no
+# entry here — it is inline in base.html, so loading the template already covers it.
+_RENDER_PROOF_TEMPLATE = "base.html"
+_RENDER_PROOF_ASSETS: tuple[str, ...] = ("htmx.min.js", "nav.js")
+
+# Last result logged, so a degraded deployment does not reprint its warning on every probe.
+# /health is hit every 30s by the container healthcheck, every 60s by the Prometheus scrape
+# and every 300s by UptimeRobot — roughly three lines a minute, forever, shipped to Loki.
+# That is not a log, it is a denial of service against the log: the one signal worth seeing
+# would be buried in thousands of copies of itself. Logging only on TRANSITION keeps both
+# edges (broke / recovered) while costing two lines per incident.
+_LAST_RENDER_PROOF: str | None = None
+
+
+def _log_render_proof_transition(result: str, detail: str) -> None:
+    """Log a render-proof result only when it CHANGES, at a level matching the direction."""
+    global _LAST_RENDER_PROOF
+    if result == _LAST_RENDER_PROOF:
+        return
+    previous, _LAST_RENDER_PROOF = _LAST_RENDER_PROOF, result
+    if result == "ok":
+        # Only announce a recovery if there was something to recover from — otherwise every
+        # process start logs a "recovered" line for a deployment that was never broken.
+        if previous is not None:
+            _log.warning("render proof RECOVERED — the app can produce a page again")
+        return
+    _log.warning(
+        "render proof DEGRADED — %s. /health still returns 200 (liveness is fine); "
+        "the catalog cannot render correctly.",
+        detail,
+    )
+
+
+def _render_proof() -> str:
+    """``"ok"`` if this deployment can still produce a page, else ``"degraded"`` (#581).
+
+    Deliberately narrow. It answers "is this image intact?" — the failure mode where the
+    process is alive, every page 500s or renders unusable, and bare-200 monitoring reports
+    perfect health. It does NOT check catalog contents: an empty database is a legitimate
+    state for a fresh deployment, and a proof that reported ``degraded`` until the first
+    import landed would train everyone to ignore it.
+
+    Constraints it has to respect, being on a public, unauthenticated path hit every 30s
+    (container healthcheck), 60s (Prometheus) and 300s (UptimeRobot):
+
+    * **I/O-free beyond two stats.** ``get_template`` is served from Jinja's compiled-template
+      cache after the first call, so steady state is a cache hit plus two ``is_file()`` calls.
+      In particular it must never touch the database — ``status`` already covers that, and
+      doubling the query rate on a Pi's SD card to say the same thing twice is not a trade.
+    * **Cannot raise.** The caller returns its status code either way, but a raise here would
+      escape into the 500 handler and take the status code with it, which is the one thing
+      that must not happen. Hence the broad ``except``.
+
+    Loading the template compiles it, so a Jinja syntax error in base.html is caught here;
+    ``{% include %}`` targets resolve at render time and are not, which is the honest limit.
+    """
+    try:
+        templates.get_template(_RENDER_PROOF_TEMPLATE)
+        for asset in _RENDER_PROOF_ASSETS:
+            if not (_STATIC_DIR / asset).is_file():
+                _log_render_proof_transition(
+                    "degraded", f"vendored asset {asset} is missing from {_STATIC_DIR}"
+                )
+                return "degraded"
+        if not _TEMPLATES_DIR.is_dir():
+            _log_render_proof_transition(
+                "degraded", f"template dir {_TEMPLATES_DIR} is not present"
+            )
+            return "degraded"
+    except Exception:
+        # exc_info on the transition only — a permanently-broken deployment must not ship a
+        # traceback every 30s. The message names the cause; the traceback is on the first one.
+        _log.debug("render proof raised", exc_info=True)
+        _log_render_proof_transition("degraded", "loading the base template raised")
+        return "degraded"
+    _log_render_proof_transition("ok", "")
+    return "ok"
 
 
 # Headers added by the public proxy chain (Cloudflare tunnel → Traefik). Their
@@ -609,21 +768,41 @@ def _thread_confined_db() -> Iterator[Database]:
 
 @app.get("/health")
 async def health(response: Response) -> dict[str, str]:
-    """Return 200 if DB is reachable; 503 otherwise (issue #31).
+    """Liveness (``status``) plus a render proof (``render``) — issue #31, #581.
 
-    Uses manual _get_db()/close() instead of Depends(get_db) because
-    the health check must return 503 (not 500) when the DB is unreachable,
-    including when _get_db() itself raises.
+    ``status`` is 200 if the DB is reachable, 503 otherwise. Uses manual
+    _get_db()/close() instead of Depends(get_db) because the health check must return
+    503 (not 500) when the DB is unreachable, including when _get_db() itself raises.
+
+    ``render`` is a readiness-of-content signal — whether this deployment still has the
+    pieces it needs to produce a page at all. **It never changes the status code.** The
+    Dockerfile HEALTHCHECK and the compose healthcheck both call ``urlopen``, which raises
+    on any non-2xx, so letting a missing stylesheet drop the code would restart the
+    container in production — trading a monitoring gap for a real availability bug. The
+    distinction lives in the body, where the UptimeRobot keyword monitor reads it.
+
+    Why the proof is served *here* rather than on a real page: ``/health`` is the one path
+    an external, unauthenticated vantage point is guaranteed to be able to observe.
     """
     try:
         db = _get_db()
         db.cursor().execute("SELECT 1")
         db.close()
-        return {"status": "ok"}
+        status = "ok"
     except Exception as exc:
         _log.warning("Health check DB failure", extra={"error": str(exc)})
         response.status_code = 503
-        return {"status": "error"}
+        status = "error"
+    # The no-raise guarantee is enforced HERE, at the route, not only inside _render_proof.
+    # If it lived only in the helper, a future refactor that let an exception escape would
+    # silently convert this endpoint into a 500 — restarting the container in prod. The
+    # helper guards itself too; this is the one that must never be removed.
+    try:
+        render = _render_proof()
+    except Exception:
+        _log.warning("render proof raised", exc_info=True)
+        render = "degraded"
+    return {"status": status, "render": render}
 
 
 @app.get("/", response_class=RedirectResponse)

--- a/tests/test_health_render_proof.py
+++ b/tests/test_health_render_proof.py
@@ -1,0 +1,284 @@
+"""HEAD support on every GET route, and the ``/health`` render proof (#581).
+
+Two related defects, both of the same shape — the process is perfectly healthy while
+monitoring is blind or actively wrong:
+
+* **HEAD 405.** FastAPI's ``APIRoute`` does not add ``HEAD`` to a ``GET`` route the way
+  plain Starlette's ``Route`` does, so every route answered ``405 Method Not Allowed``.
+  UptimeRobot probes with HEAD by default, so a healthy site read as hard-down.
+* **Bare 200 proves nothing.** ``/health`` returned ``{"status": "ok"}`` whenever the
+  process was up and the DB answered, which stays true when a bad image ships without
+  templates or vendored assets — every page 500s or renders unusable, and the monitor
+  reports perfect health. Ported from espn-ff #1093.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.routing import Route
+
+
+@pytest.fixture
+def app_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """The web app with a real, initialised DB, so ``status`` is never the failing half."""
+    db_path = tmp_path / "health.db"
+    monkeypatch.setenv("DB_PATH", str(db_path))
+    monkeypatch.setenv("TESTING", "1")
+
+    from worship_catalog.db import Database
+
+    db = Database(db_path)
+    db.connect()
+    db.init_schema()
+    db.close()
+
+    import worship_catalog.web.app as module
+
+    module._schema_ready = False
+    # The transition logger keeps its last result in a module global; reset it so each
+    # test starts from a known edge rather than inheriting the previous test's state.
+    monkeypatch.setattr(module, "_LAST_RENDER_PROOF", None)
+    # Register the sound paths for restoration even though every test below patches them
+    # through monkeypatch. The module is imported once per session, so a single direct
+    # assignment leaks a broken deployment into every later test.
+    monkeypatch.setattr(module, "_STATIC_DIR", module._STATIC_DIR)
+    monkeypatch.setattr(module, "_TEMPLATES_DIR", module._TEMPLATES_DIR)
+    return module
+
+
+@pytest.fixture
+def client(app_module: Any) -> TestClient:
+    return TestClient(app_module.app)
+
+
+class TestHeadParity:
+    """A GET route must answer HEAD — RFC 9110 requires it, and probes rely on it."""
+
+    def test_head_health_returns_200(self, client: TestClient) -> None:
+        assert client.head("/health").status_code == 200
+
+    def test_head_songs_returns_200(self, client: TestClient) -> None:
+        assert client.head("/songs").status_code == 200
+
+    def test_head_root_redirects_exactly_like_get(self, app_module: Any) -> None:
+        """HEAD / must behave as GET / does — a 307 to /songs, not a 405."""
+        with TestClient(app_module.app, follow_redirects=False) as c:
+            head, get = c.head("/"), c.get("/")
+        assert head.status_code == get.status_code == 307
+        assert head.headers["location"] == get.headers["location"] == "/songs"
+
+    def test_head_is_never_405(self, client: TestClient) -> None:
+        """The exact symptom UptimeRobot reported: 405 with ``allow: GET``."""
+        for path in ("/", "/health", "/songs", "/services", "/reports", "/about"):
+            resp = client.head(path)
+            assert resp.status_code != 405, (
+                f"HEAD {path} returned 405 (allow: {resp.headers.get('allow')!r}) — "
+                "a HEAD-based monitor reads this whole site as down"
+            )
+
+    def test_every_get_route_also_allows_head(self, app_module: Any) -> None:
+        """Regression guard: a new ``@app.get`` must not silently reintroduce the gap.
+
+        This is the test that makes the fix durable. Asserting only on today's handful
+        of paths would pass forever while the next route added quietly 405s.
+        """
+        offenders = [
+            f"{route.path} {sorted(route.methods)}"
+            for route in app_module.app.routes
+            if isinstance(route, Route) and route.methods and "GET" in route.methods
+            if "HEAD" not in route.methods
+        ]
+        assert not offenders, "these GET routes do not accept HEAD:\n  " + "\n  ".join(offenders)
+
+
+class TestOpenApiStaysValid:
+    """Routing HEAD must not corrupt the publicly-served schema.
+
+    FastAPI derives ONE operation id per route and reuses it for every method, so a route
+    carrying both GET and HEAD emits two operations sharing an id. ``/openapi.json`` is
+    served publicly (200 on the live site), and duplicate ``operationId``s make the document
+    invalid and break client generators.
+    """
+
+    def test_no_duplicate_operation_ids(self, client: TestClient) -> None:
+        from collections import Counter
+
+        spec = client.get("/openapi.json").json()
+        ids = Counter(
+            op["operationId"]
+            for item in spec["paths"].values()
+            for op in item.values()
+            if "operationId" in op
+        )
+        dupes = {k: v for k, v in ids.items() if v > 1}
+        assert not dupes, f"duplicate operationIds in the served schema: {dupes}"
+
+    def test_head_is_routed_but_not_documented(self, client: TestClient) -> None:
+        """HEAD is an affordance of the GET operation, not a separate documented one."""
+        spec = client.get("/openapi.json").json()
+        documented_heads = [p for p, item in spec["paths"].items() if "head" in item]
+        assert not documented_heads, f"HEAD leaked into the schema for: {documented_heads}"
+        assert "get" in spec["paths"]["/health"]
+        assert client.head("/health").status_code == 200
+
+    def test_schema_generation_is_warning_free(self, app_module: Any) -> None:
+        """The duplicate-id collision surfaced as 16 UserWarnings; none should remain."""
+        import warnings
+
+        app_module.app.openapi_schema = None  # defeat the cache so generation really runs
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                app_module.app.openapi()
+        finally:
+            app_module.app.openapi_schema = None
+        assert not [w for w in caught if "Duplicate Operation ID" in str(w.message)]
+
+    def test_head_still_routes_after_schema_generation(self, app_module: Any) -> None:
+        """The generator strips HEAD from route.methods; it must put every one back."""
+        app_module.app.openapi_schema = None
+        try:
+            app_module.app.openapi()
+            with TestClient(app_module.app) as c:
+                assert c.head("/health").status_code == 200
+                assert c.head("/songs").status_code == 200
+        finally:
+            app_module.app.openapi_schema = None
+
+
+class TestRenderProof:
+    """``render`` answers "can this deployment still produce a page?"."""
+
+    def test_health_reports_render_ok_on_a_sound_deployment(self, client: TestClient) -> None:
+        assert client.get("/health").json() == {"status": "ok", "render": "ok"}
+
+    def test_keyword_monitor_can_match_the_body(self, client: TestClient) -> None:
+        """UptimeRobot matches a substring, so the serialised form matters, not just the dict."""
+        assert '"render":"ok"' in client.get("/health").text.replace(" ", "")
+
+    def test_missing_vendored_asset_is_degraded(
+        self,
+        app_module: Any,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A bad image COPY drops htmx.min.js — every page still returns 200, unusably."""
+        empty = tmp_path / "no_static"
+        empty.mkdir()
+        monkeypatch.setattr(app_module, "_STATIC_DIR", empty)
+        assert client.get("/health").json()["render"] == "degraded"
+
+    def test_missing_template_dir_is_degraded(
+        self,
+        app_module: Any,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(app_module, "_TEMPLATES_DIR", tmp_path / "gone")
+        assert client.get("/health").json()["render"] == "degraded"
+
+    def test_unloadable_base_template_is_degraded(
+        self, app_module: Any, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A Jinja syntax error in base.html is caught by loading (and so compiling) it."""
+
+        def _boom(_name: str) -> None:
+            raise RuntimeError("template is broken")
+
+        monkeypatch.setattr(app_module.templates, "get_template", _boom)
+        assert client.get("/health").json()["render"] == "degraded"
+
+    def test_degraded_still_returns_http_200(
+        self,
+        app_module: Any,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The single most important assertion in this file.
+
+        The container HEALTHCHECK and the compose healthcheck both call ``urlopen``, which
+        raises on any non-2xx. If a degraded render dropped the status code, a cosmetic
+        asset fault would restart the container in production — trading a monitoring gap
+        for a real availability bug. The distinction lives in the body only.
+        """
+        empty = tmp_path / "no_static2"
+        empty.mkdir()
+        monkeypatch.setattr(app_module, "_STATIC_DIR", empty)
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["render"] == "degraded"
+
+    def test_render_proof_never_raises(
+        self, app_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """It sits behind a public unauthenticated path; a raise would become a 500."""
+
+        def _boom(_name: str) -> None:
+            raise RuntimeError("nope")
+
+        monkeypatch.setattr(app_module.templates, "get_template", _boom)
+        monkeypatch.setattr(app_module, "_STATIC_DIR", None)  # make .is_file() blow up too
+        assert app_module._render_proof() == "degraded"
+
+    def test_head_health_runs_the_proof_without_error(self, client: TestClient) -> None:
+        """The probe method that started all this must exercise the same path."""
+        assert client.head("/health").status_code == 200
+
+
+class TestRenderProofLogging:
+    """``/health`` is hit every 30s/60s/300s — a degraded deployment must not flood Loki."""
+
+    def test_degraded_logs_once_not_once_per_probe(
+        self,
+        app_module: Any,
+        client: TestClient,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        empty = tmp_path / "no_static3"
+        empty.mkdir()
+        monkeypatch.setattr(app_module, "_STATIC_DIR", empty)
+        with caplog.at_level(logging.WARNING, logger="worship_catalog.web"):
+            for _ in range(5):
+                client.get("/health")
+        degraded = [r for r in caplog.records if "DEGRADED" in r.getMessage()]
+        assert len(degraded) == 1, (
+            f"logged {len(degraded)} times for 5 probes — at 3 probes/minute forever, "
+            "the one line worth seeing is buried in copies of itself"
+        )
+
+    def test_recovery_is_logged(
+        self,
+        app_module: Any,
+        client: TestClient,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Both edges matter: a silent recovery leaves an operator chasing a fixed fault."""
+        empty = tmp_path / "no_static4"
+        empty.mkdir()
+        sound = app_module._STATIC_DIR
+        monkeypatch.setattr(app_module, "_STATIC_DIR", empty)
+        with caplog.at_level(logging.WARNING, logger="worship_catalog.web"):
+            client.get("/health")
+            monkeypatch.setattr(app_module, "_STATIC_DIR", sound)
+            client.get("/health")
+        assert any("RECOVERED" in r.getMessage() for r in caplog.records)
+
+    def test_a_sound_deployment_logs_nothing_on_startup(
+        self, client: TestClient, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No "recovered" line for a deployment that was never broken."""
+        with caplog.at_level(logging.WARNING, logger="worship_catalog.web"):
+            client.get("/health")
+        assert not [r for r in caplog.records if "render proof" in r.getMessage()]


### PR DESCRIPTION
Closes #581.

## HEAD returned 405 on every route

FastAPI's `APIRoute` takes `methods` literally, unlike plain Starlette's `Route`, which adds `HEAD` whenever `GET` is present. Every `@app.get` route therefore answered `405 Method Not Allowed` with `allow: GET`:

```
before                          after
/health   HEAD  -> 405          /health   HEAD  -> 200  (0 body bytes, content-length: 29)
/         HEAD  -> 405          /         HEAD  -> 307 -> /songs
/songs    HEAD  -> 405          /songs    HEAD  -> 200
```

UptimeRobot probes with `HEAD` by default, which is how `songs.highland-coc.com` came to page as hard-down while serving 200 to every real visitor. RFC 9110 also requires `HEAD` of any general-purpose server, and link checkers and `curl -I` expect it.

Fixed on the **route class** rather than per route, so a new `@app.get` cannot quietly reintroduce the gap. `test_every_get_route_also_allows_head` asserts that parity across `app.routes` — asserting on today's handful of paths would pass forever while the next route added silently 405s.

Chosen over rewriting HEAD→GET in middleware so `request.method` stays accurate; verified on the wire that the request log still records `"method": "HEAD"`.

## …which would have corrupted the public OpenAPI schema

FastAPI derives **one** operation id per route and reuses it for every method, so a route carrying both GET and HEAD emits two operations sharing an id — 16 duplicate `operationId`s, plus 16 `UserWarning`s. `/openapi.json` is served publicly (200 on the live site), so that is an invalid document that breaks client generators.

HEAD is a protocol affordance of the GET operation, not a separate operation, so it is stripped for schema generation only, under a lock, restoring each route's original method set verbatim.

## /health now proves the app can render

`{"status": "ok"}` was true whenever the process was up and the DB answered — which stays true when a bad image ships without templates or vendored assets, i.e. every page 500s or renders unusable and the monitor reports perfect health. Ported from espn-ff #1093.

```
{"status":"ok","render":"ok"}
```

`render` is `degraded` when `base.html` will not load (loading compiles it, so a Jinja syntax error is caught) or a vendored script is missing. It does **not** check catalog contents — an empty DB is legitimate for a fresh deployment, and a proof that reported `degraded` until the first import landed would train everyone to ignore it.

Two properties worth calling out:

- **`render` never changes the status code.** The Dockerfile HEALTHCHECK and the compose healthcheck both call `urlopen`, which raises on any non-2xx. Letting a missing stylesheet drop the code would restart the container in production — trading a monitoring gap for a real availability bug. `test_degraded_still_returns_http_200` pins this.
- **It logs on transition only.** `/health` is hit every 30s (container), 60s (Prometheus) and 300s (UptimeRobot). Logging every result is ~3 lines a minute forever into Loki, burying the one line worth seeing in copies of itself.

## Validation

| Check | Result |
|---|---|
| `uv run --frozen pytest -m "not e2e"` | 1419 passed, 9 skipped, 2 xfailed |
| `uv run --frozen ruff check src/` | clean |
| `uv run --frozen mypy src/` | clean (strict) |
| new tests | 20, written first and confirmed failing |
| wire check (uvicorn + `curl -I`) | `HEAD /health` 200, 0 body bytes; log shows `method: HEAD` |

## Follow-up, not in this PR

`/docs` and `/openapi.json` are both publicly reachable on `songs.highland-coc.com` — noticed while verifying the schema fix, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)