### PR TITLE
test: pin the UptimeRobot keyword literally, and prove it discriminates

### DIFF
--- a/tests/test_health_render_proof.py
+++ b/tests/test_health_render_proof.py
@@ -22,6 +22,11 @@ import pytest
 from fastapi.testclient import TestClient
 from starlette.routing import Route
 
+# The literal string configured as the UptimeRobot keyword for songs.highland-coc.com
+# (`keyword_type: 2` — alert when ABSENT). UptimeRobot matches it against the raw response
+# bytes, so it must appear verbatim. Do not normalise whitespace when asserting on it.
+_MONITOR_KEYWORD = '"render":"ok"'
+
 
 @pytest.fixture
 def app_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Any:
@@ -158,8 +163,35 @@ class TestRenderProof:
         assert client.get("/health").json() == {"status": "ok", "render": "ok"}
 
     def test_keyword_monitor_can_match_the_body(self, client: TestClient) -> None:
-        """UptimeRobot matches a substring, so the serialised form matters, not just the dict."""
-        assert '"render":"ok"' in client.get("/health").text.replace(" ", "")
+        """The keyword must appear in the RAW body, byte for byte.
+
+        Normalising whitespace before asserting (``.replace(" ", "")``) is what this test
+        used to do, and it is worse than no test: a change to FastAPI's JSON separators
+        would keep it green while silently breaking the monitor, returning us to the
+        bare-200 blindness this endpoint exists to fix. The monitor fails OPEN — a keyword
+        it can never match reports the site as down, and a keyword it always matches
+        reports nothing at all — so the literal is a contract, not a formatting detail.
+        """
+        assert _MONITOR_KEYWORD in client.get("/health").text
+
+    def test_keyword_is_absent_when_degraded(
+        self,
+        app_module: Any,
+        client: TestClient,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The other half of the contract: the keyword has to actually discriminate.
+
+        Asserting only that it is present on a healthy deployment would pass for a keyword
+        that is present unconditionally — a monitor that can never fire.
+        """
+        empty = tmp_path / "no_static_kw"
+        empty.mkdir()
+        monkeypatch.setattr(app_module, "_STATIC_DIR", empty)
+        resp = client.get("/health")
+        assert resp.status_code == 200, "degraded must stay 200 — only the body differs"
+        assert _MONITOR_KEYWORD not in resp.text
 
     def test_missing_vendored_asset_is_degraded(
         self,


### PR DESCRIPTION
Follow-up to #582 / #581.

## The weakness

`test_keyword_monitor_can_match_the_body` asserted against the response body with whitespace stripped:

```python
assert '"render":"ok"' in client.get("/health").text.replace(" ", "")
```

UptimeRobot matches the keyword against the **raw** bytes, so that assertion tests something the monitor does not do. A change to FastAPI's JSON separators would keep the test green while silently breaking the monitor — and it fails open in both directions: a keyword it can never match reports the site down, and a keyword it always matches reports nothing at all.

Demonstrated for a body of `{"status": "ok", "render": "ok"}`:

```
old (space-stripped) assertion would pass: True
new (literal) assertion correctly fails:   False
```

## The fix

- Assert the literal against the raw `.text`, no normalisation.
- Hoist the keyword into `_MONITOR_KEYWORD`, documented as the string configured on the monitor, so the coupling is visible to whoever edits `/health` next.
- Add `test_keyword_is_absent_when_degraded`. Asserting only that the keyword is present on a healthy deployment would also pass for a keyword present unconditionally — a monitor that can never fire. This pins that it disappears when `render` degrades, while the status stays 200.

## Validation

| Check | Result |
|---|---|
| `uv run --frozen pytest -m "not e2e"` | 1420 passed, 9 skipped, 2 xfailed |
| `uv run --frozen ruff check tests/…` | clean |
| `ruff format --check` | already formatted |

Test-only — no source change, no redeploy needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)