### PR TITLE
docs: switch the brand mark to a song book (#586)

### DIFF
--- a/docs/brand-icon.md
+++ b/docs/brand-icon.md
@@ -5,89 +5,75 @@ Design spec for the square Song History mark. Tracked by
 planned sprint, this document is the decision record the implementer works from.
 
 The app ships **no favicon today** — there is no `rel="icon"` link, no `/favicon.ico` route, and
-no icon assets under `src/worship_catalog/web/static/`. Browsers currently request `/favicon.ico`,
-get the SPA 404, and fall back to a generic page glyph.
+no icon assets under `src/worship_catalog/web/static/`. Browsers request `/favicon.ico`, get the
+catch-all 404, and fall back to a generic page glyph.
 
-## The source motif
+## The mark
 
-The mark derives from the existing wordmark, `static/highland-logo.png` (375 x 81). That file is a
-**horizontal lockup** — a glyph on the left, then "HIGHLAND" over "CHURCH OF CHRIST" in serif caps —
-so it cannot be reused as a square icon. But its left glyph is separable and is the identity carrier.
+**A song book: a music note on a book cover.** A white portrait cover, corners lightly rounded,
+carrying a single knocked-out eighth note, on a rounded navy tile.
 
-Measured off the PNG (glyph bounding box `x 7..117`, `y 16..70`):
+It is chosen for being unambiguous at the size that matters. A tab favicon is a ~16px glyph, and at
+that size an icon gets one idea, not two — this one reads as a hymnal or sheet-music cover, which is
+what the app catalogues.
 
-| Property | Measurement |
-|---|---|
-| Construction | Four round-capped monoline strokes — a stylised mountain range |
-| Flank slope | `dx/dy ≈ 0.625` (constant across all four strokes) |
-| Stroke weight | 6px against a 52px peak height — a ratio of **0.115** |
-| Stroke feet | `x = 10, 28, 48, 114.5` at the baseline |
-| Apexes | `x = 39.5, 60.5, 80.5` |
+Colour is **`#1a1a2e`**, taken from the app chrome rather than invented: it is already the navy used
+for the nav bar, header and footer in `base.html`. A solid navy tile makes the icon look native to
+the app and holds contrast against both light and dark browser chrome, which a transparent or
+white-ground mark would not.
 
-Left to right the strokes are: one bare ascending flank, a small peak, then a large peak. The small
-peak's **right shoulder terminates where it crosses the large peak's left flank** — the peaks
-overlap, one tucked behind the other. That overlap is the glyph's most distinctive feature and the
-square mark keeps it.
+The mark is **not** derived from the Highland wordmark. See
+[Rejected direction](#rejected-direction-the-wordmark-peaks) below for why, and for what to do if a
+visual tie to the church's mark is wanted later.
 
-Colour comes from the app chrome, not the PNG (which is flat black): **`#1a1a2e`**, the navy already
-used for the nav bar, header and footer in `base.html`. A navy tile makes the icon read as part of
-the app and holds contrast against both light and dark browser chrome.
+## Decision: two masters
 
-## Decision: one skyline, two masters
+| Master | Used at | Why |
+|---|---|---|
+| `icon.svg` | 32px and above | The mark as drawn |
+| `icon-16.svg` | the 16px `.ico` frame only | The same mark, redrawn for the pixel grid |
 
-**Two masters, both drawing the same skyline.** The `>=32px` master is monoline and brand-faithful;
-the 16px master is the same skyline filled solid. Same motif, hinted for size — not two marks.
-
-### Why the monoline cannot be used at 16px
-
-This was tested, not assumed. Rendering the monoline at true 16px and sweeping the stroke weight
-from 6 to 11 units (of a 64 viewBox) produced **no usable window**:
-
-- at `w <= 8` the strokes land under 2 device pixels and grey out into mush;
-- at `w >= 10` the flanks bleed together and the notch between the peaks fills in — the mark stops
-  reading as two peaks at all.
-
-The cause is spatial, not stylistic: three flanks plus their gaps have to fit across roughly 11px of
-content width. There is not enough resolution. Carrying the wordmark's own 0.115 weight ratio is
-even worse — at a 26-unit peak height that is a 3-unit stroke, which renders sub-pixel.
-
-The filled silhouette has no such problem: solid mass survives where line does not.
+Scaled straight down, the note's **stem falls under two device pixels and greys out** — the note
+stops reading as a note. The 16px master therefore redraws it with a fatter stem and a slightly
+larger head, on a marginally larger cover. This is icon hinting: at 16px you redraw for the grid
+rather than resample onto it. Both were rasterised at true 16px and compared before this was
+settled; the hinted one is legibly better, not theoretically better.
 
 ### Geometry
 
-Both masters use a 64 x 64 viewBox and a `rx="14"` tile filled `#1a1a2e`, marks in `#ffffff`.
+Both masters use a 64 x 64 viewBox, a `rx="14"` tile filled `#1a1a2e`, and a white cover with the
+note knocked out in the tile navy.
 
-**Monoline master** (`icon.svg`) — used at 32px and above.
-Apex `y=20`, baseline `y=46`, apexes at `x=26` and `x=40`, flank slope **0.625** (the wordmark's own
-angle, unchanged), stroke weight **7.5**. The weight is deliberately hinted — it is ~2.5x the
-wordmark's proportional weight, which is the minimum that holds up at 32px.
+| | Cover | Note scale | Stem width | Head radii |
+|---|---|---|---|---|
+| `icon.svg` | `x 15, y 10`, `34 x 44`, `rx 3` | 1.35 | 3.2 | 6.0 x 4.6 |
+| `icon-16.svg` | `x 14, y 9`, `36 x 46`, `rx 3` | 1.45 | 4.4 | 6.6 x 5.2 |
 
-**Silhouette master** (`icon-16.svg`) — used for the 16px `.ico` frame only.
-Apex `y=16`, baseline `y=48`, apexes at `x=24` and `x=40`, flank slope **0.52**.
-
-The 16px master's geometry intentionally departs from the monoline's: taller, a wider apex gap, and
-a shallower flank. All three changes exist to keep the **notch between the two summits** open
-through rasterisation. At 16px the flank angle is unmeasurable by eye; the notch is the entire read,
-so it is what the hinting protects. A sweep of five proportion sets confirmed this one separates the
-summits most cleanly.
+The cover's ~3:4 proportion is deliberate — squarer reads as a card, narrower wastes the tile. The
+note is sized to the largest that still leaves margin; one step larger and the flag touches the
+cover edge.
 
 ### The masters
 
 `icon.svg`:
 
 ```svg
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><rect width="64" height="64" rx="14" fill="#1a1a2e"/><g fill="none" stroke="#ffffff" stroke-width="7.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9.75 46 L26 20 L42.25 46"/><path d="M26 20 L33 31.2"/><path d="M23.75 46 L40 20 L56.25 46"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><rect width="64" height="64" rx="14" fill="#1a1a2e"/><rect x="15" y="10" width="34" height="44" rx="3" fill="#ffffff"/><g fill="#1a1a2e" transform="translate(32 32) scale(1.35)"><rect x="-1.6" y="-13" width="3.2" height="17" rx="1"/><path d="M1.6 -13 L10 -9.6 L10 -3.4 L1.6 -6.8 Z"/><ellipse cx="-4.6" cy="5" rx="6" ry="4.6" transform="rotate(-20 -4.6 5)"/></g></svg>
 ```
 
 `icon-16.svg`:
 
 ```svg
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><rect width="64" height="64" rx="14" fill="#1a1a2e"/><path d="M7.36 48 L24 16 L40.64 48 Z M23.36 48 L40 16 L56.64 48 Z" fill="#ffffff"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><rect width="64" height="64" rx="14" fill="#1a1a2e"/><rect x="14" y="9" width="36" height="46" rx="3" fill="#ffffff"/><g fill="#1a1a2e" transform="translate(32 32) scale(1.45)"><rect x="-2.2" y="-13" width="4.4" height="17" rx="1"/><path d="M2.2 -13 L10 -9.6 L10 -3.4 L2.2 -6.8 Z"/><ellipse cx="-4.6" cy="5" rx="6.6" ry="5.2" transform="rotate(-20 -4.6 5)"/></g></svg>
 ```
 
-`icon-maskable.svg` — the monoline master with a **square** tile (`rx="0"`, the platform applies its
-own mask) and the artwork scaled to `0.72` about the centre. Verified: at a 192px render the ink
-bounding box is `x 40..156, y 62..134`, comfortably inside the 80% safe zone (`19..173`).
+`icon-maskable.svg` — `icon.svg` with a **square** tile (no `rx`; the platform applies its own mask)
+and the artwork scaled to `0.72` about the centre. Verified: at a 192px render the ink bounding box
+is `x 59..132, y 48..143`, comfortably inside the 80% safe zone (`19..173`).
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64"><rect width="64" height="64" fill="#1a1a2e"/><g transform="translate(32 32) scale(0.72) translate(-32 -32)"><rect x="15" y="10" width="34" height="44" rx="3" fill="#ffffff"/><g fill="#1a1a2e" transform="translate(32 32) scale(1.35)"><rect x="-1.6" y="-13" width="3.2" height="17" rx="1"/><path d="M1.6 -13 L10 -9.6 L10 -3.4 L1.6 -6.8 Z"/><ellipse cx="-4.6" cy="5" rx="6" ry="4.6" transform="rotate(-20 -4.6 5)"/></g></g></svg>
+```
 
 ## Asset set to produce
 
@@ -111,7 +97,7 @@ Only `base.html` owns a `<head>` in this app, so the link markup has exactly one
 needed (unlike espn-ff, which has three `<head>`-owning templates).
 
 Serve `/favicon.ico` from the **root path** as well as `/static/`: browsers request the root path
-directly, and the SPA's catch-all would otherwise answer it with a 404.
+directly, and the catch-all would otherwise answer it with a 404.
 
 ## Open decision for the implementer: the SVG `rel="icon"` link
 
@@ -119,17 +105,45 @@ Issue #586 asks to "keep the `.svg` as `rel="icon"`". **That conflicts with the 
 should not be done as written.**
 
 Where a browser honours `<link rel="icon" type="image/svg+xml">` it prefers that SVG over the `.ico`
-**at every size**, including the 16px tab slot. The hinted 16px frame would then never be used and
-the tab icon would be the monoline mush the sweep above rejected.
+**at every size**, including the 16px tab slot. The hinted 16px master would then never be used and
+the tab icon would be the greyed-out stem the hinting exists to prevent.
 
 Recommended: **ship the `.ico` only** and keep the SVG masters in the repo as sources, not as a
-served `rel="icon"`. The tab favicon is overwhelmingly rendered at 16-20px, and that is the one size
-the mark must not fail at.
+served `rel="icon"`.
 
 Worth knowing before deciding: the failure is scoped to 1x displays. On a HiDPI screen a 16px CSS
 favicon is 32 device pixels and the browser picks the 32px frame, which is fine. If the SVG link is
 wanted anyway, that is a legitimate call — just make it knowingly, and don't rely on size-based media
 queries inside the SVG to switch forms, which is not reliably supported.
+
+## Rejected direction: the wordmark peaks
+
+The first attempt derived the icon from the existing wordmark, `static/highland-logo.png`. That file
+is a horizontal lockup — a glyph, then "HIGHLAND" over "CHURCH OF CHRIST" — so the lockup itself
+cannot be squared, but its **left glyph** is separable: a monoline mountain range of four
+round-capped strokes on a constant `dx/dy ≈ 0.625` flank, the small peak's right shoulder tucking
+behind the large peak.
+
+Two problems killed it, in order:
+
+1. **The monoline could not survive 16px.** Sweeping stroke weight from 6 to 11 units of a 64
+   viewBox found no usable window — thin weights grey out below two device pixels, heavy weights
+   bleed the flanks together and fill the notch between the summits. Three flanks plus their gaps do
+   not fit across ~11px of content width. A filled silhouette of the same skyline was drawn to solve
+   this.
+2. **The silhouette read as anatomy, not mountains.** Two rounded summits either side of a central
+   notch is an unfortunate shape at 16px, and no amount of proportion tuning fixed the underlying
+   form.
+
+Do not re-propose a two-lobed silhouette for this icon. If a visual tie to the church's mark is
+wanted, pursue it somewhere the monoline has room to work — the app header or an about page — not a
+16px favicon.
+
+Other shapes tried and dropped in the song-book round, so they are not re-litigated: a stacked pair
+of books (reads as a list/hamburger icon at 16px), a cover with a gold ribbon marker (the ribbon
+merges into the cover and adds a third colour for no gain), a cover with a spine stripe (the spine
+crowds the note), an open book with a note above it (top-heavy, two competing elements), and a plain
+open book (clean, but carries no musical cue).
 
 ## Deployment
 


### PR DESCRIPTION
Replaces the mountain-peaks design in `docs/brand-icon.md`. **Documentation only** — no assets, no
markup, no route. Those land in the planned sprint.

## Why the peaks were dropped

The peaks came from the Highland wordmark's left glyph and failed twice:

1. **The monoline couldn't survive 16px.** Sweeping stroke weight 6→11 (of a 64 viewBox) found no
   usable window — thin weights grey out below 2 device pixels, heavy weights bleed the flanks
   together and fill the notch. Three flanks plus gaps don't fit across ~11px of content width.
2. **The filled silhouette that fixed that read as anatomy, not mountains.** Two rounded summits
   either side of a central notch. Proportion tuning didn't fix the underlying form.

Both failures stay in the doc, along with an explicit *don't re-propose a two-lobed silhouette* rule,
so the direction isn't retried by someone reading only the final spec.

## The mark now

A music note knocked out of a book cover, on the same `#1a1a2e` tile (the navy already used by the
app's nav, header and footer). At ~16px an icon gets one idea rather than two, and this one reads as
a hymnal or sheet-music cover — which is what the app catalogues.

The two-master structure survives the redesign, for a different reason: scaled straight down the
note's **stem falls under two device pixels and greys out**, so the 16px `.ico` frame uses a redrawn
note — fatter stem, larger head, marginally larger cover.

The doc also records the song-book shapes tried and dropped (stacked books → reads as a list icon;
gold ribbon → merges into the cover; spine stripe → crowds the note; open book + note → top-heavy;
plain open book → no musical cue), so those aren't re-litigated either.

## Unchanged from the previous revision

The conflict with this card's "keep the `.svg` as `rel=\"icon\"`" request still stands and is still
flagged — where honoured, the SVG wins at every size and the hinted 16px frame is never used. Ditto
the Pillow multi-resolution `.ico` trap, the root-path `/favicon.ico` requirement, and the note that
only `base.html` owns a `<head>`.

## Validation

- Docs-only; §12 routing → no AI review.
- All three SVG masters embedded in the doc were rendered and confirmed **pixel-identical** to the
  masters actually tested, at 16/32/48/192.
- Maskable variant verified inside the 80% safe zone (ink bbox `x 59..132, y 48..143` at 192px).
- No test pins the docs tree except `docs/pi-deploy.md`, which is untouched.

Refs #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)