### PR TITLE
fix(docker): drop pip from the runtime image to clear vendored CVEs (#595)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,23 @@ RUN chmod +x scripts/import-new.sh
 # then install the package itself (--no-deps: deps already in lockfile) (#294).
 RUN pip install --no-cache-dir -r requirements.lock && pip install --no-cache-dir --no-deps .
 
+# Remove pip from the runtime image (#595).  pip bundles its own dependencies
+# under pip/_vendor — currently msgpack 1.1.2 (GHSA-6v7p-g79w-8964) and
+# setuptools 70.3.0 (CVE-2025-47273, CVE-2026-59890).  They are invisible to
+# `pip list` because vendored code is not an installed distribution, but they
+# are real files in the image and Trivy flags them, blocking every push.
+#
+# `pip install --upgrade pip` above means the vendored set changes with
+# whatever pip is newest at build time, so pinning would only defer this.
+# Nothing needs pip at runtime — every dependency is installed above, and the
+# HEALTHCHECK uses urllib from the stdlib — so drop it entirely.  This also
+# removes the ability to install packages into a running container.
+RUN python -m pip uninstall --yes pip \
+    && rm -rf /usr/local/lib/python3.12/site-packages/pip \
+              /usr/local/lib/python3.12/site-packages/pip-*.dist-info \
+              /usr/local/bin/pip /usr/local/bin/pip3 /usr/local/bin/pip3.12 \
+    && ! command -v pip
+
 # Bake version and build date so the About page shows real values (#261, #262)
 RUN echo "${APP_VERSION}" > /app/.version \
     && echo "${BUILD_DATE}" > /app/.build-date

--- a/tests/test_dockerfile.py
+++ b/tests/test_dockerfile.py
@@ -22,6 +22,41 @@ class TestNoMaliciousFastapi:
         )
 
 
+class TestRuntimeImageHasNoPip:
+    """pip is removed from the runtime image (#595).
+
+    pip vendors its own dependencies under `pip/_vendor` — msgpack 1.1.2 and
+    setuptools 70.3.0 at the time of writing, both carrying advisories.  They
+    do not appear in `pip list` (vendored code is not an installed
+    distribution) and are not in uv.lock, but they are real files in the image
+    and Trivy fails the publish job on them, so nothing can ship.
+    """
+
+    def test_dockerfile_removes_pip_from_the_runtime_image(self):
+        dockerfile = (_PROJECT_ROOT / "Dockerfile").read_text()
+        assert "pip uninstall" in dockerfile, (
+            "the runtime image must not ship pip — its vendored dependencies "
+            "carry CVEs and nothing needs pip at runtime (#595)"
+        )
+
+    def test_pip_is_removed_after_dependencies_are_installed(self):
+        """Removing pip before the install step would break the build."""
+        lines = (_PROJECT_ROOT / "Dockerfile").read_text().splitlines()
+        install_at = next(
+            i for i, line in enumerate(lines) if "-r requirements.lock" in line
+        )
+        remove_at = next(i for i, line in enumerate(lines) if "pip uninstall" in line)
+        assert install_at < remove_at, "pip must be removed only after it has installed everything"
+
+    def test_removal_is_verified_in_the_same_layer(self):
+        """A silent no-op removal would let the vendored CVEs ship anyway."""
+        dockerfile = (_PROJECT_ROOT / "Dockerfile").read_text()
+        assert "! command -v pip" in dockerfile, (
+            "the build must assert pip is actually gone, or a failed removal "
+            "ships the vulnerable vendored packages while the build stays green"
+        )
+
+
 class TestDependencyReproducibility:
     """A lockfile must exist and be used in the Dockerfile (#174)."""
 


### PR DESCRIPTION
Closes #595. **Unblocks all image publishing** — nothing has been able to ship since this started.

## Problem

Trivy was failing `publish` on three advisories, so every push was blocked:

| Rule | Package | Installed | Fixed in | Severity |
|---|---|---|---|---|
| CVE-2025-47273 | setuptools | 70.3.0 | 78.1.1 | HIGH |
| CVE-2026-59890 | setuptools | 70.3.0 | 83.0.0 | MEDIUM |
| GHSA-6v7p-g79w-8964 | msgpack | 1.1.2 | 1.2.1 | HIGH |

Neither package is in `uv.lock`. Neither shows up in `pip list` inside the running production container (34 packages, none of them these). That initially looked like the scanner reading the wrong input — **it wasn't**. They are bundled inside pip:

```
$ ssh pi-songs 'docker exec song-history-song-history-1 \
    cat /usr/local/lib/python3.12/site-packages/pip/_vendor/vendor.txt'
msgpack==1.1.2
setuptools==70.3.0
CacheControl==0.14.4
```

Vendored code is not an installed distribution, so `pip list` can't see it — but the files are genuinely in the image, and Trivy is right to flag them.

**Why it started with no repo change:** `Dockerfile:24` runs `pip install --upgrade pip`, so the vendored set tracks whatever pip is newest at build time. The last green build (2026-07-27) picked up an older pip. Pinning pip would only defer this.

## Change

Remove pip after it has installed everything. Nothing needs it at runtime — all dependencies are installed at build time and the `HEALTHCHECK` uses stdlib `urllib`.

The removal asserts `! command -v pip` in the same layer, so a removal that silently no-ops fails the build rather than shipping the vulnerable files. Side benefit: packages can no longer be installed into a running container.

## Validation

A `workflow_dispatch` build at this exact tree ran the **full publish pipeline** — the path that cannot run on a PR:

| Step | Result |
|---|---|
| Build image (local, for CVE scan) | success |
| **Scan image for CVEs (Trivy)** | **success** — previously the failing step |
| Smoke test image | success — `/health`, `/songs`, `/reports`, `/reports/ccli` all OK |
| Build and push (multi-platform) | success |

Published `ghcr.io/mshirel/song-history:sha-2279ce11a702232db507c0b3552729d218984390` (amd64 + arm64). Also `test`, `security`, `e2e` green; `ruff`/`mypy` clean.

3 tests written first and confirmed failing (removal present, ordered after the install, and verified in-layer).

## Note

Trivy still logs `Third-party SBOM may lead to inaccurate vulnerability detection` — that appears to be how it characterises `pip/_vendor/vendor.txt`, and it now reports no findings. I chased a wrong hypothesis first (a cached SBOM attestation reaching the scanned build via a shared `type=gha` cache scope); separating the cache scopes changed nothing, which refuted it. That dead end is recorded in #595 rather than in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)