### PR TITLE
deploy(pi): pin the current main build, reconciling git with what is deployed

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -46,8 +46,8 @@ services:
     # :latest silently swaps running app code with no digest record and no
     # rollback target. Pin to the sha- tag + digest CI publishes; Dependabot's
     # `docker` ecosystem entry (#502) bumps this on a reviewed PR.
-    # Tag sha-<commit> = main@66a07ae; digest resolved from GHCR 2026-07-18.
-    image: ghcr.io/mshirel/song-history:sha-66a07ae98556411e9e74cefc451cac18dcdaf433@sha256:192ca716e7ef1a04d0f99c57bad3a82e2d9306fbbee272d3651f5ca9f4aae4f0
+    # Tag sha-<commit> = main@8b61c9b; digest resolved from GHCR 2026-08-01.
+    image: ghcr.io/mshirel/song-history:sha-8b61c9b7e71d334b4f3d2bb5bf615ba038ab2812@sha256:19baabac392afedb00c967b20b994b61bcb8d100c53607cc63b2eb1d40d7a639
     restart: unless-stopped
     init: true
     # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
@@ -88,8 +88,8 @@ services:
   song-history:
     # Immutably pinned (#512) — was the mutable :latest. Keep this in lockstep
     # with the `watcher` service above; Dependabot (#502) bumps both.
-    # Tag sha-<commit> = main@66a07ae; digest resolved from GHCR 2026-07-18.
-    image: ghcr.io/mshirel/song-history:sha-66a07ae98556411e9e74cefc451cac18dcdaf433@sha256:192ca716e7ef1a04d0f99c57bad3a82e2d9306fbbee272d3651f5ca9f4aae4f0
+    # Tag sha-<commit> = main@8b61c9b; digest resolved from GHCR 2026-08-01.
+    image: ghcr.io/mshirel/song-history:sha-8b61c9b7e71d334b4f3d2bb5bf615ba038ab2812@sha256:19baabac392afedb00c967b20b994b61bcb8d100c53607cc63b2eb1d40d7a639
     restart: unless-stopped
     # Bound the public upload process on the 512 MB Pi host (#503). Uploads are
     # streamed to disk, so even the 200 MB maximum file fits this budget.


### PR DESCRIPTION
Bumps both app services on the Pi to `main@8b61c9b`:

```
ghcr.io/mshirel/song-history:sha-8b61c9b7e71d334b4f3d2bb5bf615ba038ab2812
@sha256:19baabac392afedb00c967b20b994b61bcb8d100c53607cc63b2eb1d40d7a639
```

Built and published by [run 30717573894](https://github.com/mshirel/song-history/actions/runs/30717573894) — Trivy clean, smoke test green, amd64 + arm64.

## What ships

- **#581** — HEAD answered on every GET route (the visible app change since the last deploy)
- **#595** — pip removed from the runtime image, so it no longer carries pip's vendored `msgpack 1.1.2` / `setuptools 70.3.0` advisories
- #586 brand mark, #589/#590 CI lockfile work (no runtime effect)

## Drift being reconciled

The repo pinned `sha-66a07ae`, but the Pi has actually been running `1.3.1@sha256:2526ff91` since that release was rescued by hand (#583). The pin was changed on the host and never committed back, so **git has been describing an image that has not run for two weeks**.

I diffed the live `/opt/song-history/docker-compose.yml` against the repo copy before touching anything — the image pin was the *only* difference (16 diff lines, all of it those two `image:` lines and their comments). So nothing host-side is being overwritten.

## Rollback

```
ghcr.io/mshirel/song-history:1.3.1@sha256:2526ff911040bc0a037acb5b93f63592ce80edf8c3ef8137f60dd86590c0cb11
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)