### PR TITLE
fix(ci): drop the indefinite pip-audit CVE suppression, enforce expiry (#592)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,10 +189,16 @@ jobs:
         run: uv lock --check
 
       - name: Dependency audit (pip-audit)
-        # CVE-2026-3219 affects pip itself; no fix released upstream yet.
-        # Re-evaluate at every Dependabot bump of requirements.lock and remove
-        # this --ignore-vuln once a fixed pip ships. Tracked by #408.
-        run: uv run --frozen pip-audit --skip-editable --ignore-vuln CVE-2026-3219
+        # No suppressions.  CVE-2026-3219 (pip) was ignored here indefinitely;
+        # pip-audit is clean without it now, so the flag is gone rather than
+        # carried forward (#592).
+        #
+        # If a suppression ever becomes necessary it MUST carry an explicit
+        # `review-by=YYYY-MM-DD`, which tests/test_ci_config.py enforces and
+        # which fails the build once the date passes.  The old flag's stated
+        # trigger — "re-evaluate at every Dependabot bump of requirements.lock"
+        # — could never fire, so it aged unreviewed for two months.
+        run: uv run --frozen pip-audit --skip-editable
 
       # --- Static security analysis ----------------------------------------
       - name: Static security scan (bandit)

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -1,6 +1,8 @@
 """Tests for CI configuration — ensure action pins and steps stay current."""
 
+import re
 import subprocess
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -124,6 +126,68 @@ class TestDependencyLockAuthority:
         assert "pip-compile" not in ci, (
             "pip-compile independently resolves dependencies and must not be a lock validator"
         )
+
+
+@pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
+class TestVulnerabilitySuppressionsExpire:
+    """A suppressed CVE must carry a review date the build enforces (#592).
+
+    `pip-audit --ignore-vuln CVE-2026-3219` was carried indefinitely with the
+    comment "re-evaluate at every Dependabot bump of requirements.lock".  That
+    trigger could never fire: no Dependabot bump had ever merged (#589 shows
+    they were deadlocked), and requirements.lock stopped being a committed file
+    entirely.  A permanently-suppressed CVE whose review trigger cannot fire is
+    indistinguishable from not scanning for it.
+    """
+
+    # Any suppression must carry `review-by=YYYY-MM-DD` in its command or comment.
+    _REVIEW_BY = re.compile(r"review-by=(\d{4}-\d{2}-\d{2})")
+
+    def _ignore_lines(self) -> list[str]:
+        return [ln for ln in CI_PATH.read_text().splitlines() if "--ignore-vuln" in ln]
+
+    def test_cve_2026_3219_suppression_is_gone(self) -> None:
+        """pip-audit reports no vulnerabilities without it — nothing left to suppress.
+
+        Asserts on the *flag*, not the string: the comment above the step still
+        names the CVE to explain why the suppression was dropped, and forbidding
+        that would punish documenting the decision.
+        """
+        assert "--ignore-vuln CVE-2026-3219" not in CI_PATH.read_text(), (
+            "pip-audit is clean without this suppression; carrying it hides any "
+            "future advisory against the same package"
+        )
+
+    def test_every_suppression_carries_a_review_date(self) -> None:
+        for line in self._ignore_lines():
+            assert self._REVIEW_BY.search(line), (
+                f"suppressed CVE has no machine-checkable expiry: {line.strip()}"
+            )
+
+    def test_no_suppression_is_past_its_review_date(self) -> None:
+        """A lapsed suppression fails the build instead of ageing silently."""
+        today = date.today()
+        for line in CI_PATH.read_text().splitlines():
+            match = self._REVIEW_BY.search(line)
+            if match:
+                review_by = date.fromisoformat(match.group(1))
+                assert review_by >= today, (
+                    f"CVE suppression lapsed on {review_by} — re-evaluate it or "
+                    f"re-date it deliberately: {line.strip()}"
+                )
+
+    def test_no_reference_to_the_closed_tracking_issue(self) -> None:
+        """#408 was closed 2026-05-25 while the suppression it tracked stayed."""
+        assert "Tracked by #408" not in CI_PATH.read_text(), (
+            "the suppression's tracking issue is closed — a comment pointing at a "
+            "closed issue is how this went unreviewed for two months"
+        )
+
+    def test_pip_audit_still_runs_and_can_fail(self) -> None:
+        """Removing the suppression must not have removed the scan."""
+        ci = CI_PATH.read_text()
+        assert "pip-audit --skip-editable" in ci, "the dependency audit must still run"
+        assert "--exit-zero" not in ci, "pip-audit must remain able to fail the build"
 
 
 @pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")


### PR DESCRIPTION
Closes #592.

## The suppression had no working review trigger

```yaml
# CVE-2026-3219 affects pip itself; no fix released upstream yet.
# Re-evaluate at every Dependabot bump of requirements.lock and remove
# this --ignore-vuln once a fixed pip ships. Tracked by #408.
run: uv run --frozen pip-audit --skip-editable --ignore-vuln CVE-2026-3219
```

Every clause had stopped holding:

- **No Dependabot bump had ever merged.** #589 showed they were deadlocked by the `requirements.lock` drift guard, so the trigger had never fired once in the ~3 months the comment existed.
- **`requirements.lock` is no longer committed** (#589), so "a Dependabot bump of requirements.lock" became *impossible*, not merely rare.
- **#408 was closed 2026-05-25** while the suppression it tracked stayed in place.

## It is no longer needed at all

Rather than re-date it, I checked whether it was still doing anything:

```
$ uv run --frozen pip-audit --skip-editable
No known vulnerabilities found
```

(pip 26.1.2 in the dev environment.) So the flag is **deleted**. Nothing is suppressed, and any future advisory against pip or anything else now surfaces instead of being silently swallowed by a stale ignore.

## The guard, so this cannot recur

Any future `--ignore-vuln` must carry `review-by=YYYY-MM-DD`. `TestVulnerabilitySuppressionsExpire` fails the build when a suppression has no date, or once its date passes.

Written first, confirmed failing (3 red → green). Both directions verified:

- re-adding `--ignore-vuln CVE-2026-3219` → `test_cve_2026_3219_suppression_is_gone` and `test_every_suppression_carries_a_review_date` fail
- adding a suppression dated `review-by=2020-01-01` → `test_no_suppression_is_past_its_review_date` fails

A test that only passes proves nothing; these were checked in the failing direction too.

`test_pip_audit_still_runs_and_can_fail` guards the obvious way to "fix" a future failure — deleting the scan or making it non-blocking.

## Validation

| Check | Result |
|---|---|
| `pytest` (full) | 1426 passed, 12 failed |
| `ruff check src/` | clean |
| `mypy src/` | clean (19 files) |
| `ci.yml` parses | valid |

The 12 failures are pre-existing and environmental — the three `sqlite3`-dependent files fail identically on unmodified `main` in the canonical checkout (this host has no `sqlite3` CLI). Note the real baseline is **12**, not the 11 I recorded in `docs/dev-loop-config.md` earlier today; that count came from a truncated log tail. Correcting the config separately rather than widening this PR.

## Review routing

Validation green; no §12 routing row matches. The change *removes* a suppression and adds enforcement, so it strengthens the gate rather than relaxing it — merge candidate without an AI reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)