### PR TITLE
docs: correct the sqlite3 failure baseline in dev-loop config

### DIFF
--- a/docs/dev-loop-config.md
+++ b/docs/dev-loop-config.md
@@ -180,10 +180,10 @@ is for the ESPN fantasy football connector.
 
 Each of these has cost a wake or would have. One line, plus how to tell environmental from real.
 
-- **11 tests fail on any host without the `sqlite3` CLI.** `tests/test_backup_sh.py`,
+- **12 tests fail on any host without the `sqlite3` CLI.** `tests/test_backup_sh.py`,
   `tests/test_backup_restore.py`, `tests/test_seed_pi_db_sh.py` shell out to `sqlite3` and report
   `FAIL: integrity check failed`. CI has the binary; the WSL/vm-ai-dev workstations do not. Baseline
-  is **1417 passed, 11 failed**. To tell environmental from real: run the same file in the canonical
+  is **1426 passed, 12 failed** (it moves as the suite grows — the invariant is that every failure is in those three files). To tell environmental from real: run the same file in the canonical
   checkout on `main` — identical failures mean it is the host, not your diff. Never "fix" these.
 
 - **`publish` never runs on a PR.** Its gate is `refs/tags/v*` / `schedule` / `workflow_dispatch`,


### PR DESCRIPTION
A number I got wrong in #600 earlier today.

Recorded the environmental baseline as **11 failed / 1417 passed**; it is actually **12 / 1426**. The 11 came from reading a truncated `tail` of the log, which hid `test_seed_pi_db_sh.py::test_prints_service_count_for_valid_db`.

Verified against unmodified `main` in the canonical checkout — that file fails 3 of 6, not 2, with the same `integrity check failed` cause (no `sqlite3` CLI on this host).

Also reframed the figure as **moving rather than fixed**: the count tracks suite growth, so a future loop matching on an exact total would report a false regression and waste a wake chasing it. The invariant actually worth asserting is that every failure lives in the three `sqlite3`-dependent files.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)