### PR TITLE
test(web): make the inline-script CSP guard case-insensitive (#599)

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -15,6 +15,35 @@ from starlette.testclient import TestClient
 from conftest import CsrfAwareClient
 from worship_catalog.db import Database
 
+# Matches an inline <script> — one with no `src` attribute, which CSP blocks.
+# IGNORECASE is load-bearing: without it the guard silently misses <SCRIPT>,
+# so a page could grow an inline script and the CSP tests would still pass
+# (CodeQL py/bad-tag-filter, #599).  The negative lookahead stays correct under
+# IGNORECASE, so `<SCRIPT SRC=...>` is still treated as external and ignored.
+INLINE_SCRIPT_RE = re.compile(r"<script(?![^>]*\bsrc\b)[^>]*>", re.IGNORECASE)
+
+
+class TestInlineScriptGuard:
+    """The CSP guard used by the tests below must itself be trustworthy (#599)."""
+
+    @pytest.mark.parametrize(
+        "markup",
+        ["<script>x</script>", "<SCRIPT>x</SCRIPT>", "<ScRiPt>x</ScRiPt>"],
+    )
+    def test_detects_inline_script_in_any_case(self, markup: str) -> None:
+        assert INLINE_SCRIPT_RE.findall(markup), (
+            f"guard missed an inline script: {markup} — a page could add one unnoticed"
+        )
+
+    @pytest.mark.parametrize(
+        "markup",
+        ['<script src="/static/nav.js"></script>', '<SCRIPT SRC="/static/nav.js"></SCRIPT>'],
+    )
+    def test_ignores_external_scripts_in_any_case(self, markup: str) -> None:
+        assert not INLINE_SCRIPT_RE.findall(markup), (
+            f"guard wrongly flagged an external script: {markup}"
+        )
+
 
 @pytest.fixture
 def client(db_with_songs, tmp_path, monkeypatch):
@@ -3387,7 +3416,7 @@ class TestResponsiveLayout:
         assert 'aria-expanded="false"' in html, "Nav toggle must expose collapsed state"
         assert "/static/nav.js" in html, "Nav toggle state script must be loaded from /static/"
         # The toggle must not introduce any new inline script (CSP blocks inline JS).
-        inline_scripts = re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", html)
+        inline_scripts = INLINE_SCRIPT_RE.findall(html)
         assert not inline_scripts, (
             f"Nav added {len(inline_scripts)} inline <script> tag(s) blocked by CSP"
         )
@@ -3461,7 +3490,7 @@ class TestUploadFormCSPCompatible:
         assert resp.status_code == 200
         # All <script> tags must have a src= attribute (external files)
         import re
-        inline_scripts = re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", resp.text)
+        inline_scripts = INLINE_SCRIPT_RE.findall(resp.text)
         assert not inline_scripts, (
             f"Page has {len(inline_scripts)} inline <script> tag(s) "
             "which are blocked by CSP script-src 'self'"
@@ -3491,7 +3520,7 @@ class TestReportFormsCSPCompatible:
         resp = client.get("/reports")
         assert resp.status_code == 200
         import re
-        inline_scripts = re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", resp.text)
+        inline_scripts = INLINE_SCRIPT_RE.findall(resp.text)
         assert not inline_scripts, (
             "Reports page has inline scripts blocked by CSP"
         )


### PR DESCRIPTION
Closes #599 — triage of the five CodeQL alerts raised when code scanning was enabled. **One fixed, two dismissed as false positives with written reasons**, each judged from its actual call site rather than its rule name.

## Fixed — `py/bad-tag-filter` ×3 (`tests/test_web.py`)

Three copies of:

```python
re.findall(r"<script(?![^>]*\bsrc\b)[^>]*>", html)
```

which does not match `<SCRIPT>`. The guard asserts a page carries **no inline script**, because CSP blocks them — so a page could grow an uppercase inline script and all three tests would still pass. A test that cannot fail for the case it exists to catch is worse than no test.

Replaced with one module-level `INLINE_SCRIPT_RE` carrying `re.IGNORECASE`, plus `TestInlineScriptGuard` which tests the guard itself. Verified in both directions:

| markup | old | new |
|---|---|---|
| `<script>x</script>` | match | match |
| `<SCRIPT>x</SCRIPT>` | **miss** | match |
| `<ScRiPt>x</ScRiPt>` | **miss** | match |
| `<script src="/static/a.js">` | ignored | ignored |
| `<SCRIPT SRC="/static/a.js">` | ignored | ignored |

The negative lookahead stays correct under `IGNORECASE`, so external scripts are still not flagged in either case.

## Dismissed — not "fixed", because they are not defects

**`py/incomplete-url-substring-sanitization`** — `normalize.py:507` is inside `detect_publisher()`, which classifies raw PPTX slide text and returns a publisher *name*:

```python
if "paperlesshymnal.com" in lower or "paperless hymnal" in lower:
    return "Paperless Hymnal"
```

It never validates a URL and gates no security decision — the value becomes song metadata that is displayed. Worst case of a lookalike match is a mislabelled hymn, not SSRF or an open redirect. CodeQL matched a domain-shaped literal in an `in` test.

**`js/incomplete-sanitization`** — `service_detail.html:37` is a **Jinja2** template, so `replace()` is Python's `str.replace`, which replaces *all* occurrences. The query assumes JavaScript's `String.replace`, which replaces only the first. Confirmed by rendering it:

```
input:  C:\dir\sub\file.pptx
output: file.pptx
```

It is also display-only basename extraction, autoescaped by Jinja2, and `source_file` comes from the operator-controlled import path rather than public input.

Both dismissed in the Security tab with `false positive` and a rationale, so they do not silently linger.

## Validation

| Check | Result |
|---|---|
| `pytest` (full) | 1431 passed, 12 failed |
| `TestInlineScriptGuard` + the 3 CSP tests | 8 passed |
| `ruff check src/` | clean |
| CodeQL open alerts | 0 |

All 12 failures are the documented `sqlite3` set (`test_backup_sh`, `test_backup_restore`, `test_seed_pi_db_sh`); **zero failures outside it**, explicitly checked rather than assumed.

Tests-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)