### PR TITLE
fix(ci): bake a version that describes the build, not the newest tag (#572, #574)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,11 +299,30 @@ jobs:
         id: version
         if: startsWith(github.ref, 'refs/tags/v') || steps.changes.outputs.app == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
-          version="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | sed 's/^v//')"
+          # The baked version must describe THIS build (#572, #574).
+          #
+          # This previously took the highest semver tag in the repo
+          # (`git tag --sort=-v:refname | head -1`) regardless of whether the
+          # build was that tag — so a scheduled or dispatched build of main
+          # baked a release number it was not.  Production showed /about =
+          # 1.3.3 while running an image built from a later commit.
+          if [ "${GITHUB_REF#refs/tags/v}" != "$GITHUB_REF" ]; then
+            # Release build: the tag being built IS the answer, so the image
+            # tag and the baked version cannot disagree.
+            version="${GITHUB_REF#refs/tags/v}"
+          else
+            # Not a release. Describe from the nearest tag REACHABLE from HEAD
+            # (never a later tag made on another commit) and append the commit,
+            # so the value can never be mistaken for a published release.
+            base="$(git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
+            [ -n "$base" ] || base="0.0.0"
+            version="${base}+${GITHUB_SHA:0:7}"
+          fi
           if [ -z "$version" ]; then
-            echo "ERROR: no semantic version tag found"
+            echo "ERROR: could not resolve a version"
             exit 1
           fi
+          echo "Resolved version: $version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # --- Container image vulnerability scanning (#32, #66) ---------------

--- a/tests/test_release_versioning.py
+++ b/tests/test_release_versioning.py
@@ -190,3 +190,69 @@ class TestPublishWorkflowVersionSource:
         assert "github.ref_name" not in text or "APP_VERSION=${{ github.ref_name }}" not in text
         assert "Resolve release version" in text
         assert "steps.version.outputs.version" in text
+
+
+@pytest.mark.skipif(not CI_WORKFLOW_PATH.exists(), reason="ci workflow not present")
+class TestBakedVersionDescribesThisBuild:
+    """The baked version must describe the build it is in (#572, #574).
+
+    The resolver took the highest semver tag in the whole repo, reachable or
+    not, so any non-tag build (schedule, workflow_dispatch, a rebuild of an old
+    commit) baked a release number it was not.  Production showed `/about` =
+    `1.3.3` while running image `sha-8b61c9b`, a commit after that tag — the
+    page claimed a release the build was not.
+    """
+
+    def _version_step_run(self) -> str:
+        workflow = yaml.safe_load(CI_WORKFLOW_PATH.read_text())
+        for step in workflow["jobs"]["publish"]["steps"]:
+            if step.get("id") == "version":
+                return step["run"]
+        raise AssertionError("publish job has no `version` step")
+
+    def _version_step_code(self) -> str:
+        """The step's executable lines, with comments stripped.
+
+        The comment above the resolver quotes the old broken command to explain
+        why it was replaced; asserting against the raw text would forbid
+        documenting that, so reachability is checked against code only.
+        """
+        return "\n".join(
+            line
+            for line in self._version_step_run().splitlines()
+            if not line.strip().startswith("#")
+        )
+
+    def test_tag_builds_use_the_tag_being_built(self) -> None:
+        """On refs/tags/vX.Y.Z the answer is that tag — not a sorted-tags guess."""
+        run = self._version_step_run()
+        assert "refs/tags/v" in run and "GITHUB_REF" in run, (
+            "a tag build must take its version from the ref it is building, so the "
+            "image tag and the baked version cannot disagree"
+        )
+
+    def test_untagged_builds_are_not_passed_off_as_a_release(self) -> None:
+        """A non-tag build must carry a build suffix, never a bare release number."""
+        run = self._version_step_run()
+        assert "GITHUB_SHA" in run, (
+            "a non-tag build must include the commit in its version, or it reports "
+            "a release number for a build that is not that release (#572)"
+        )
+
+    def test_resolver_does_not_use_unreachable_tags(self) -> None:
+        """`git tag --sort=-v:refname | head -1` returns the newest tag in the repo.
+
+        That is wrong for any build that is not at that tag — including a rebuild
+        of an older commit, which would claim a release made after it.
+        """
+        code = self._version_step_code()
+        assert "git tag --sort=-v:refname" not in code, (
+            "sorting all tags ignores reachability; use the ref being built, or "
+            "`git describe` which only considers tags reachable from HEAD"
+        )
+        assert "git describe" in code, "the fallback must be reachability-aware"
+
+    def test_resolver_still_fails_loudly_when_it_cannot_resolve(self) -> None:
+        """Silently emitting an empty version would bake a blank /about."""
+        run = self._version_step_run()
+        assert "exit 1" in run, "the resolver must fail the build rather than bake nothing"


### PR DESCRIPTION
Closes #572 and #574 — one root cause, so one change. (#573, the third card in that trio, was already resolved by `ed4ccb8` and is closed with evidence.)

## The defect, observed in production

`/about` on `songs.highland-coc.com` reported **`1.3.3`** while the Pi was running image **`sha-8b61c9b`** — a commit *later* than that tag. The page asserted a release the build was not.

Cause, in the publish job's version resolver:

```bash
version="$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 | sed 's/^v//')"
```

That is the highest semver tag **in the whole repo**, reachable or not. It never consults the ref being built. So:

- a `schedule` or `workflow_dispatch` build of `main` bakes whatever the newest tag happens to be;
- a rebuild of an **older** commit bakes a release made *after* it — the version goes backwards in time relative to the code.

This is precisely what #572 means by "never regresses to something that isn't a real release number for this build", and what #574 means by "the published image and baked runtime metadata agree on the release number".

## The fix

```bash
if [ "${GITHUB_REF#refs/tags/v}" != "$GITHUB_REF" ]; then
  version="${GITHUB_REF#refs/tags/v}"          # release build: the tag IS the answer
else
  base="$(git describe --tags --match 'v[0-9]*.[0-9]*.[0-9]*' --abbrev=0 | sed 's/^v//')"
  version="${base}+${GITHUB_SHA:0:7}"          # otherwise: reachable tag + commit
fi
```

- **Release build** — the tag being built is the version, so the image tag and the baked value *cannot* disagree.
- **Any other build** — nearest tag **reachable from HEAD** (`git describe`, never a later tag on another commit), plus the short commit. `1.3.5+8b61c9b` is unmistakable for a release while still saying which release it descends from.

Verified by running the resolver directly:

```
refs/tags/v1.3.4  -> 1.3.4
refs/heads/main   -> 1.3.5+8b61c9b
```

It still fails the build rather than baking an empty version.

## Tests

4 written first, 3 confirmed failing, all green after; then re-checked against a restored copy of the old resolver, where 3 fail again. Both directions.

They assert on the step's **executable lines with comments stripped** — the comment quotes the old command to explain why it was replaced, and asserting on raw text would forbid documenting the change. (I hit that exact trap twice today and it is worth naming.)

## Validation

| Check | Result |
|---|---|
| `pytest` (full) | 1436 passed, 11 failed |
| `ruff check src/` / `mypy src/` | clean |
| `ci.yml` parses | valid |

All 11 failures are the documented `sqlite3` set; **zero outside it**, explicitly checked.

## Note on end-to-end proof

The baked value only exists in a real image, and `publish` does not run on PRs — so the true confirmation is `/about` reporting `1.3.6+<sha>` (or a clean `1.3.6` for a tagged release) after the next deploy. That is part of this batch's close-out, not a claim I am making now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)