### PR TITLE
deploy(pi): ship Sprint 6 — main@042ef75

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -46,8 +46,8 @@ services:
     # :latest silently swaps running app code with no digest record and no
     # rollback target. Pin to the sha- tag + digest CI publishes; Dependabot's
     # `docker` ecosystem entry (#502) bumps this on a reviewed PR.
-    # Tag sha-<commit> = main@8b61c9b; digest resolved from GHCR 2026-08-01.
-    image: ghcr.io/mshirel/song-history:sha-8b61c9b7e71d334b4f3d2bb5bf615ba038ab2812@sha256:19baabac392afedb00c967b20b994b61bcb8d100c53607cc63b2eb1d40d7a639
+    # Tag sha-<commit> = main@042ef75; digest resolved from GHCR 2026-08-02.
+    image: ghcr.io/mshirel/song-history:sha-042ef75ed9d981ac5f4c48b24b51b5bc1f875497@sha256:6250446b861a41f73faa486f7cf582957263a8da1f6ed2844e79d92082c2f3b5
     restart: unless-stopped
     init: true
     # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
@@ -88,8 +88,8 @@ services:
   song-history:
     # Immutably pinned (#512) — was the mutable :latest. Keep this in lockstep
     # with the `watcher` service above; Dependabot (#502) bumps both.
-    # Tag sha-<commit> = main@8b61c9b; digest resolved from GHCR 2026-08-01.
-    image: ghcr.io/mshirel/song-history:sha-8b61c9b7e71d334b4f3d2bb5bf615ba038ab2812@sha256:19baabac392afedb00c967b20b994b61bcb8d100c53607cc63b2eb1d40d7a639
+    # Tag sha-<commit> = main@042ef75; digest resolved from GHCR 2026-08-02.
+    image: ghcr.io/mshirel/song-history:sha-042ef75ed9d981ac5f4c48b24b51b5bc1f875497@sha256:6250446b861a41f73faa486f7cf582957263a8da1f6ed2844e79d92082c2f3b5
     restart: unless-stopped
     # Bound the public upload process on the 512 MB Pi host (#503). Uploads are
     # streamed to disk, so even the 200 MB maximum file fits this budget.


### PR DESCRIPTION
Pins `sha-042ef75@sha256:6250446b`, built by [run 30726439743](https://github.com/mshirel/song-history/actions/runs/30726439743) — Trivy clean, smoke test green, amd64 + arm64.

Sprint 6 work reaching the runtime image:

- **#595** — pip removed, so the image no longer carries vendored `msgpack 1.1.2` / `setuptools 70.3.0` advisories
- **#572/#574** — the baked version now describes the build. The publish log shows `Resolved version: 1.3.6+042ef75`; the previous deploy reported a bare `1.3.3` while running a later commit
- **#591** — fastapi 0.140.7, prometheus-client 0.26.0, anthropic 0.120.0

Rollback: `sha-8b61c9b@sha256:19baabac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)