### PR TITLE
feat(ci): raise an issue when the weekly rebuild fails (#598)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,3 +442,55 @@ jobs:
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
             BUILD_DATE=${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
+
+  # The Monday cron exists to pick up base-image security patches. It failed on
+  # 2026-06-29, 07-06 and 07-13 with nothing raised, and #595 would have
+  # recurred every week unnoticed — a security job that fails silently gives the
+  # appearance of patching, which is worse than not having it (#598).
+  #
+  # Deliberately scoped to `schedule`: a human is already watching a PR or a
+  # release, so alerting on those would be noise that gets muted.
+  notify-scheduled-failure:
+    needs: [test, security, e2e, publish]
+    # always() is load-bearing — without it this job is itself skipped when an
+    # ancestor fails, which is the exact bug being fixed. contains() rather than
+    # failure() because `publish` can be skipped, and a skipped dependency must
+    # not swallow the alert.
+    if: ${{ always() && github.event_name == 'schedule' && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Open or update the rebuild-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="ci: weekly rebuild failed"
+          # Reuse one open issue rather than filing 52 a year — a notifier that
+          # buries the board stops being read.
+          existing="$(gh issue list --state open --label ci-failure \
+                        --search "$title in:title" --json number --jq '.[0].number // empty')"
+
+          body="The scheduled rebuild failed.
+
+          Run: $RUN_URL
+          Commit: \`${GITHUB_SHA}\`
+
+          Job results: test=${{ needs.test.result }}, security=${{ needs.security.result }}, e2e=${{ needs.e2e.result }}, publish=${{ needs.publish.result }}
+
+          This cron rebuilds the image to pick up base-image security patches, so
+          while it is red the published image may be missing them. Nothing else
+          reports this — see #598."
+
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+            echo "commented on existing #$existing"
+          else
+            gh label list --limit 200 | grep -qx 'ci-failure' \
+              || gh label create ci-failure --color B60205 \
+                   --description "An unattended CI run failed and needs attention"
+            gh issue create --title "$title" --label ci-failure --body "$body"
+          fi

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -129,6 +129,70 @@ class TestDependencyLockAuthority:
 
 
 @pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
+class TestScheduledRebuildFailureIsAnnounced:
+    """A failing weekly rebuild must tell someone (#598).
+
+    The Monday cron exists to pick up base-image security patches.  It failed on
+    2026-06-29, 07-06 and 07-13 with nothing raised, and the #595 breakage would
+    have recurred every week unnoticed — it was found only because a build was
+    dispatched by hand for an unrelated reason.  A security-patch job that can
+    fail silently provides the appearance of patching.
+    """
+
+    def _notify_job(self) -> dict:
+        jobs = yaml.safe_load(CI_PATH.read_text())["jobs"]
+        for name, job in jobs.items():
+            if "notify" in name:
+                return job
+        raise AssertionError("no notify job in ci.yml — a silent failure is the bug (#598)")
+
+    def test_a_notify_job_exists(self) -> None:
+        assert self._notify_job()
+
+    def test_it_fires_when_any_job_fails(self) -> None:
+        """`failure()` alone is not enough — a skipped dependency can swallow it."""
+        condition = str(self._notify_job()["if"])
+        assert "needs.*.result" in condition and "failure" in condition, (
+            "gate on contains(needs.*.result, 'failure') so a skipped job "
+            "(publish skips on branch pushes) cannot suppress the alert"
+        )
+        assert "always()" in condition, (
+            "without always() the job is itself skipped when an ancestor fails — "
+            "the alert would never run, which is exactly the bug being fixed"
+        )
+
+    def test_it_is_limited_to_scheduled_runs(self) -> None:
+        """PR and tag failures are already visible; issue-spamming them is noise."""
+        condition = str(self._notify_job()["if"])
+        assert "github.event_name == 'schedule'" in condition, (
+            "only the unattended cron needs an alert — a human is already watching "
+            "a PR or a release"
+        )
+
+    def test_it_can_write_the_alert(self) -> None:
+        permissions = self._notify_job().get("permissions", {})
+        assert permissions.get("issues") == "write", (
+            "opening an issue needs issues: write; without it the notifier 403s "
+            "and the failure stays silent"
+        )
+
+    def test_it_waits_for_the_jobs_it_reports_on(self) -> None:
+        needs = self._notify_job().get("needs", [])
+        for job in ("test", "security", "e2e", "publish"):
+            assert job in needs, f"notify must depend on {job} to observe its result"
+
+    def test_it_does_not_open_a_duplicate_every_week(self) -> None:
+        """An unbounded notifier files 52 issues a year and gets muted."""
+        run = " ".join(
+            step.get("run", "") for step in self._notify_job().get("steps", [])
+        )
+        assert "gh issue list" in run, (
+            "look for an existing open alert before creating one, or a persistent "
+            "failure buries the board and the alert stops being read"
+        )
+
+
+@pytest.mark.skipif(not CI_PATH.exists(), reason="CI config not present")
 class TestVulnerabilitySuppressionsExpire:
     """A suppressed CVE must carry a review date the build enforces (#592).
 


### PR DESCRIPTION
Closes #598.

## Problem

The Monday cron rebuilds the image to pick up base-image security patches. When it fails, nothing says so:

| Date | Result |
|---|---|
| 2026-07-27 | success |
| 2026-07-20 | success |
| 2026-07-13 | **failure** |
| 2026-07-06 | **failure** |
| 2026-06-29 | **failure** |

Three consecutive failures passed unremarked. Today's #595 breakage would have recurred every Monday indefinitely — it surfaced only because a build was dispatched by hand for an unrelated reason. A security-patch job that fails silently is worse than none: the absence of alerts reads as *"the base image is current"*.

## Why GitHub issues rather than Pushover or Telegram

`gh secret list` returns **nothing** — the repo has no Actions secrets. Any external route would need credentials added before it could work, which would have parked this card behind an input I can't provide. Issues need only the built-in `GITHUB_TOKEN`, are already this project's tracking system, and work immediately. A Pushover/Telegram route can layer on later if secrets get added.

## Three details that decide whether it works

- **`always()` in the condition.** Without it the notify job is itself skipped whenever an ancestor fails — the alert would never fire, which is precisely the bug being fixed.
- **`contains(needs.*.result, 'failure')` rather than `failure()`**, because `publish` can be `skipped` and a skipped dependency must not swallow the alert.
- **Reuses one open issue** rather than filing weekly. An unbounded notifier files 52 issues a year, buries the board, and stops being read.

Scoped to `schedule` deliberately — a human is already watching a PR or a release, so alerting there is noise.

## Tests

6, written first and confirmed failing. They pin each of the above rather than merely asserting a job exists: the `always()` requirement, the `needs.*.result` form, the schedule-only gate, `issues: write` (without it the notifier 403s and the failure stays silent), the `needs` list, and the dedup lookup.

## Validation

| Check | Result |
|---|---|
| `pytest` (full) | 1441 passed, 12 failed |
| `ruff check src/` | clean |
| `ci.yml` parses | valid; jobs now `test, e2e, security, publish, notify-scheduled-failure` |

All 12 failures are the documented `sqlite3` set; zero outside it, explicitly checked.

Also verified the issue body's continuation lines are flush-left after YAML dedent — indented lines would have rendered as a Markdown code block.

## Not verifiable on a PR

By construction this only fires on a failing `schedule` run. The condition logic is asserted by tests; the true end-to-end proof is the next Monday failure, or a deliberate one. Worth noting rather than claiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)