### PR TITLE
deploy: pin the Pi stack to v1.6.0 (Sprint 7 batch close)

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -46,8 +46,15 @@ services:
     # :latest silently swaps running app code with no digest record and no
     # rollback target. Pin to the sha- tag + digest CI publishes; Dependabot's
     # `docker` ecosystem entry (#502) bumps this on a reviewed PR.
-    # Tag sha-<commit> = main@042ef75; digest resolved from GHCR 2026-08-02.
-    image: ghcr.io/mshirel/song-history:sha-042ef75ed9d981ac5f4c48b24b51b5bc1f875497@sha256:6250446b861a41f73faa486f7cf582957263a8da1f6ed2844e79d92082c2f3b5
+    # Tag sha-<commit> = main@1af1d57, released as v1.6.0. Digest is from the
+    # release build (run 30729704380), which bakes version `1.6.0`.
+    #
+    # The sha- TAG is not immutable in practice: the release workflow (#583)
+    # rebuilds the same commit for the version tags and re-pushes sha-<commit>
+    # along with them, so it moved from sha256:2df310d1 (the main-ref build) to
+    # the digest below for identical source. The digest is what actually pins —
+    # this is the drift #512 was about, observed rather than theorised.
+    image: ghcr.io/mshirel/song-history:sha-1af1d5723fb61ad8a3de59c1458009ad7d65d011@sha256:9266dc8db785cc1553d2e9290d9602e64db62d915634ef80f1df8f2ac28d68dd
     restart: unless-stopped
     init: true
     # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
@@ -88,8 +95,9 @@ services:
   song-history:
     # Immutably pinned (#512) — was the mutable :latest. Keep this in lockstep
     # with the `watcher` service above; Dependabot (#502) bumps both.
-    # Tag sha-<commit> = main@042ef75; digest resolved from GHCR 2026-08-02.
-    image: ghcr.io/mshirel/song-history:sha-042ef75ed9d981ac5f4c48b24b51b5bc1f875497@sha256:6250446b861a41f73faa486f7cf582957263a8da1f6ed2844e79d92082c2f3b5
+    # Tag sha-<commit> = main@1af1d57, released as v1.6.0 (see the note above on
+    # why the digest, not the tag, is the pin).
+    image: ghcr.io/mshirel/song-history:sha-1af1d5723fb61ad8a3de59c1458009ad7d65d011@sha256:9266dc8db785cc1553d2e9290d9602e64db62d915634ef80f1df8f2ac28d68dd
     restart: unless-stopped
     # Bound the public upload process on the 512 MB Pi host (#503). Uploads are
     # streamed to disk, so even the 200 MB maximum file fits this budget.


### PR DESCRIPTION
Sprint 7's batch-close deploy. Pins `deploy/pi/docker-compose.yml` (both `watcher` and `song-history`, in lockstep) to the **v1.6.0** release build of `main@1af1d57`, replacing the v1.3.6 pin at `main@042ef75`.

## What reaches production

| Card | Change |
|---|---|
| #586 | favicon / app icon set (ICO + PNG + maskable + apple-touch) |
| #585 | leaders report gains a repeated-songs count column |
| #598 | the weekly scheduled rebuild now files an issue when it fails |
| #601 | releases publish a container image (this deploy is downstream of that fix working) |

## Which digest, and why it is not the obvious one

The build I watched (`--ref main`, run 30729619768) published `sha256:2df310d1`. The pin here is `sha256:9266dc8d`, from run **30729704380** — the release workflow's rebuild at `--ref v1.6.0`.

Both are the same source commit. The release build is the better pin for two reasons:

- it is what `ghcr.io/mshirel/song-history:sha-1af1d57…` currently resolves to, so the tag and the digest agree;
- its version resolver takes the tag branch, baking a clean **`1.6.0`** instead of `1.6.0+1af1d57`.

**And it exposes something worth recording:** the `sha-<commit>` tag is *not* immutable in practice. `release.yml` (#583) re-dispatches CI on the version tag, which rebuilds and re-pushes `sha-<commit>` along with `1.6.0` / `1.6` / `latest` — so the tag moved for byte-identical source. This is precisely the drift #512 introduced digest pinning to prevent, now observed rather than argued. The code comment says so at the pin.

## Validation

- `uv run --frozen pytest tests/test_ci_config.py` — 38 passed (the `deploy/pi/**` mandatory suite)
- compose parses; both app services resolve to one identical image reference
- digest verified against GHCR directly (`/v2/.../manifests/sha-1af1d57…` → `sha256:9266dc8d…`), and the manifest is a 4-child OCI index carrying `linux/arm64` — the Pi's architecture

## Review routing

`deploy/pi/**` is a repo-specific routing row in `docs/dev-loop-config.md` (production host config), so this gets an adversarial review before merge even though validation is green.

Deploy and prod verification follow the merge, per the config's `batch_close` steps.