### PR TITLE
fix(web): put rate_limits.db in WAL mode so contended writes cannot corrupt it

### DIFF
--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -524,6 +524,11 @@ _PPTX_MIME = (
 # Per-client upload rate limiting (#173)
 _UPLOAD_RATE_LIMIT: int = 10  # max uploads per window
 _UPLOAD_RATE_WINDOW_SECONDS: int = 3600  # 1 hour
+# How long a limiter write waits for a competing writer before giving up (#541).
+# The limiters share one SQLite file across connections and workers, so a
+# contended write is routine; failing it fast would 500 a request whose entire
+# purpose is to keep the site standing.
+_RATE_LIMIT_BUSY_TIMEOUT_MS: int = 5000
 # Env-configurable trusted proxy support (#283, #404).  When TRUSTED_PROXY=1 the
 # rate limiter identifies clients via Cloudflare's unspoofable CF-Connecting-IP
 # (or, failing that, the proxy-appended rightmost X-Forwarded-For entry) instead
@@ -599,7 +604,27 @@ class _UploadRateLimiter:
     def _init_db(self) -> None:
         import sqlite3
 
-        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)  # type: ignore[arg-type]
+        self._conn = sqlite3.connect(
+            self._db_path,  # type: ignore[arg-type]
+            check_same_thread=False,
+            timeout=_RATE_LIMIT_BUSY_TIMEOUT_MS / 1000,
+        )
+        # Two limiters (upload + report) share this one file through two separate
+        # connections, and the app can run multi-worker, so write contention is
+        # the normal case here (#541).
+        #
+        # WAL: the default rollback journal is created and deleted on every
+        # commit, makes readers and writers block each other, and can leave the
+        # file needing recovery if a worker is killed mid-write. Under WAL a
+        # reader never blocks a writer, and a torn write is replayed from the
+        # log rather than losing the database.
+        #
+        # busy_timeout is set explicitly even though sqlite3.connect's own
+        # `timeout` already produces the same 5s: it is set from ONE constant
+        # here so the two cannot drift, and so the value is visible to anyone
+        # reading this method rather than being an implicit library default.
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(f"PRAGMA busy_timeout={_RATE_LIMIT_BUSY_TIMEOUT_MS}")
         self._conn.execute(
             f"CREATE TABLE IF NOT EXISTS {self._table} "
             "(client_ip TEXT NOT NULL, timestamp REAL NOT NULL)"

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4107,6 +4107,121 @@ class TestUploadRateLimiterPersistence:
 
 
 # ---------------------------------------------------------------------------
+# Rate limiter under write contention (#541)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadRateLimiterContention:
+    """rate_limits.db must survive concurrent writers (#541).
+
+    Two limiters (upload + report) share one file through two separate
+    connections, and the app can run multi-worker, so contention is the normal
+    case here rather than the exceptional one.
+
+    A note on what was actually broken, because #541 got half of it wrong: the
+    busy timeout was never 0. ``sqlite3.connect`` defaults to ``timeout=5.0``,
+    which sets ``PRAGMA busy_timeout=5000``, so a contended write already waited
+    rather than failing. The real defect was the journal mode — the default
+    rollback journal is deleted and recreated on every commit, readers and
+    writers block each other, and a worker killed mid-write can leave the file
+    needing recovery. The tests below are split accordingly: the WAL ones fail
+    without the fix, the timeout one is a regression guard for a property that
+    currently holds only by library default.
+    """
+
+    def test_journal_mode_is_wal(self, tmp_path):
+        from worship_catalog.web.app import _UploadRateLimiter
+
+        limiter = _UploadRateLimiter(db_path=tmp_path / "rate_limits.db")
+        mode = limiter._conn.execute("PRAGMA journal_mode").fetchone()[0]
+        assert mode.lower() == "wal", (
+            f"expected WAL, got {mode!r} — the rollback journal truncates on every "
+            "commit and a worker killed mid-write can leave the file corrupt"
+        )
+
+    def test_wal_is_actually_in_use_on_disk(self, tmp_path):
+        """PRAGMA reporting 'wal' is not the same as WAL being used.
+
+        The mode is persisted in the file header, so a stale pre-WAL file could
+        report one thing while the write path did another. The -wal sidecar
+        appearing after a real write is the observable difference.
+        """
+        from worship_catalog.web.app import _UploadRateLimiter
+
+        db_path = tmp_path / "rate_limits.db"
+        limiter = _UploadRateLimiter(db_path=db_path)
+        assert limiter.is_allowed("10.0.0.5")[0]
+        assert db_path.with_name(db_path.name + "-wal").exists(), (
+            "no -wal sidecar after a committed write, so the write did not go "
+            "through the write-ahead log"
+        )
+
+    def test_busy_timeout_is_set(self, tmp_path):
+        """Regression guard, not a bug fix — see the class docstring.
+
+        This passes before the change too, because Python's default supplies it.
+        It is pinned so that an explicit ``timeout=0``, or a driver whose default
+        differs, cannot silently reintroduce immediate ``database is locked``
+        failures in a request path.
+        """
+        from worship_catalog.web.app import _UploadRateLimiter
+
+        limiter = _UploadRateLimiter(db_path=tmp_path / "rate_limits.db")
+        timeout_ms = limiter._conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert timeout_ms >= 5000, (
+            f"busy_timeout is {timeout_ms}ms — a contended write should wait for "
+            "the other writer, not raise OperationalError immediately"
+        )
+
+    def test_write_waits_out_a_competing_writer(self, tmp_path):
+        """Behavioural counterpart to the timeout pragma, and also a guard.
+
+        Hold the write lock from a second connection, then let the limiter try
+        to record a request. With a busy timeout it blocks and then succeeds;
+        without one it raises ``sqlite3.OperationalError: database is locked``
+        the moment it touches the table.
+        """
+        import sqlite3
+        import threading
+
+        from worship_catalog.web.app import _UploadRateLimiter
+
+        db_path = tmp_path / "rate_limits.db"
+        limiter = _UploadRateLimiter(db_path=db_path)
+        # Seed the table so the schema exists before the blocker takes the lock.
+        assert limiter.is_allowed("10.0.0.1")[0]
+
+        blocker = sqlite3.connect(db_path)
+        blocker.execute("BEGIN IMMEDIATE")  # RESERVED lock: no other writer may commit
+        blocker.execute(
+            "INSERT INTO rate_limit_events (client_ip, timestamp) VALUES (?, ?)",
+            ("10.0.0.99", 0.0),
+        )
+
+        result: list[object] = []
+
+        def _attempt() -> None:
+            try:
+                result.append(limiter.is_allowed("10.0.0.2"))
+            except Exception as exc:  # noqa: BLE001 - the failure mode under test
+                result.append(exc)
+
+        worker = threading.Thread(target=_attempt)
+        worker.start()
+        # Long enough that a zero busy_timeout has certainly already failed.
+        worker.join(timeout=0.5)
+        blocker.rollback()
+        blocker.close()
+        worker.join(timeout=5)
+
+        assert result, "limiter never returned"
+        assert not isinstance(result[0], Exception), (
+            f"contended write failed instead of waiting: {result[0]!r}"
+        )
+        assert result[0] == (True, 0)
+
+
+# ---------------------------------------------------------------------------
 # Proxy-aware rate limiter (#283)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #541.

## What was actually wrong

Two limiters (upload + report) share one SQLite file through **two separate connections**, and the app can run multi-worker, so write contention here is routine. The file was using SQLite's default rollback journal: created and deleted on every commit, readers and writers block each other, and a worker killed mid-write can leave the database needing recovery.

## What was not wrong — and the tests say so rather than pretending otherwise

#541 also claims there is no busy timeout and that contention *"leads to immediate `database is locked` errors"*. That is not the case. `sqlite3.connect` defaults to `timeout=5.0`, which sets `PRAGMA busy_timeout=5000`. Verified on this interpreter (Python 3.12 / SQLite 3.45.1):

```
default busy_timeout: 5000
default journal_mode: delete
```

So a contended write already waited; only the journal mode was wrong. The timeout is still set **explicitly**, from one named constant shared with the `connect()` call, so the two cannot drift and the value is visible to anyone reading `_init_db` rather than being an implicit library default.

I have kept the tests honest about this rather than shipping two green assertions that would have passed before the change and let the PR overstate itself.

| Test | Before the change |
|---|---|
| `test_journal_mode_is_wal` | **FAILS** |
| `test_wal_is_actually_in_use_on_disk` | **FAILS** |
| `test_busy_timeout_is_set` | passes — regression guard, labelled as one in the class docstring |
| `test_write_waits_out_a_competing_writer` | passes — behavioural counterpart to the pragma |

The second one exists because `PRAGMA journal_mode` reporting `wal` is not proof that WAL is in use: the mode lives in the file header, so a stale pre-WAL file could report one thing while the write path did another. The `-wal` sidecar appearing after a committed write is the observable difference.

`test_write_waits_out_a_competing_writer` holds `BEGIN IMMEDIATE` on a second connection while the limiter records a request from a thread, then releases it — with a busy timeout the limiter blocks and succeeds; without one it raises `OperationalError` the moment it touches the table.

## Validation

- `ruff check src/` clean, `mypy src/` clean (19 files).
- New tests 4/4.
- Mandatory suites for `src/worship_catalog/web/**` — `test_web.py`, `test_web_security.py`, `test_accessibility.py` — **477 passed**.
- Full suite: **1482 passed, 12 failed**, and all 12 are the documented baseline in `test_backup_sh.py`, `test_backup_restore.py` and `test_seed_pi_db_sh.py` — the three files that shell out to the `sqlite3` CLI, which this workstation does not have. CI does.

## Deployment note

Not a backup concern: `scripts/backup.sh` dumps `worship.db`, not `rate_limits.db`, and uses `sqlite3 .dump`, which is WAL-safe regardless. On the Pi the existing `rate_limits.db` converts to WAL on first open and gains `-wal`/`-shm` sidecars in the same directory, which the app already writes to.