### PR TITLE
feat(extractor): say so when a score group's tail was never classified

### DIFF
--- a/src/worship_catalog/extractor.py
+++ b/src/worship_catalog/extractor.py
@@ -610,6 +610,10 @@ def _group_song_slides_with_score_ocr(
     score_canonical: str | None = None
     score_slides: list[Slide] = []
     score_info: ScoreGroupInfo | None = None
+    # Slides appended to the CURRENT score group without ever being classified,
+    # because the shared budget ran out (#554). Reset with the group, not with the
+    # run: a later group that fits inside the budget must not inherit the warning.
+    unverified_tail: list[Slide] = []
 
     def flush_ordinary() -> None:
         nonlocal ordinary
@@ -618,7 +622,7 @@ def _group_song_slides_with_score_ocr(
             ordinary = []
 
     def flush_score() -> None:
-        nonlocal score_canonical, score_slides, score_info
+        nonlocal score_canonical, score_slides, score_info, unverified_tail
         if score_canonical and score_slides and score_info:
             result.groups.append((score_canonical, score_slides))
             first_index = score_slides[0].index
@@ -632,9 +636,36 @@ def _group_song_slides_with_score_ocr(
                     "model": score_info.model,
                 }
             )
+            # #553 keeps the tail of a confirmed score once the budget is gone,
+            # because the 30-page Goodness of God score needs more pages than the
+            # default 25-call web budget allows. That trade is deliberate and is
+            # not changed here. What it costs is a boundary the classifier can no
+            # longer see: every following image-only slide joins this song until a
+            # text-bearing slide appears, so a score followed by another score
+            # silently inflates this range and can hide the next song entirely.
+            # Nothing said so, which made an inflated range indistinguishable from
+            # a genuinely long one. Now it does.
+            if unverified_tail:
+                result.anomalies.append(
+                    {
+                        "type": "score_image_ocr_budget_exhausted",
+                        "message": (
+                            "OCR budget ran out mid-score: the last "
+                            f"{len(unverified_tail)} slide(s) were added to this song "
+                            "without being classified. The song's range may be too "
+                            "long, and a following song may be hidden inside it. "
+                            "Review these slides, or re-run with a larger OCR budget."
+                        ),
+                        "title": score_info.display_title,
+                        "first_slide_index": first_index,
+                        "first_unverified_slide_index": unverified_tail[0].index,
+                        "unverified_slides": len(unverified_tail),
+                    }
+                )
         score_canonical = None
         score_slides = []
         score_info = None
+        unverified_tail = []
 
     for slide in slides:
         is_image_only = bool(slide.images) and not any(
@@ -651,6 +682,7 @@ def _group_song_slides_with_score_ocr(
             # cap is reached mid-song. Otherwise preserve legacy gap handling.
             if score_canonical:
                 score_slides.append(slide)
+                unverified_tail.append(slide)
             elif pending_score:
                 pending_score.append(slide)
             else:

--- a/tests/test_score_image_extraction.py
+++ b/tests/test_score_image_extraction.py
@@ -232,3 +232,105 @@ class TestScoreOccurrenceMetadata:
                 "model": "google/gemini-2.5-flash-lite",
             }
         ]
+
+
+class TestScoreGroupingAfterBudgetExhaustion:
+    """The tail of a confirmed score is retained past the budget — say so (#554).
+
+    #553 deliberately keeps appending image-only slides to a confirmed score once
+    the shared OCR budget runs out, because the known 30-page Goodness of God
+    score needs more pages than the default 25-call web budget allows. That is the
+    right trade, and these tests do not change it.
+
+    What it costs is a boundary the classifier can no longer see. Every following
+    image-only slide joins the current song until a text-bearing slide appears —
+    so a score followed immediately by another score, or by an image-only
+    non-song, silently inflates the first song's range and can hide the second
+    song entirely. Nothing in the output said so, which made an inflated range
+    indistinguishable from a genuinely long one.
+    """
+
+    def test_unverified_tail_is_reported_as_an_anomaly(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The issue's reproduction: budget covers only the first two slides, and
+        # the run continues with an unclassifiable image and a second score.
+        slides = [_slide(i, blob=f"score-{i}".encode()) for i in range(5)]
+        vision = MagicMock(side_effect=[_header("Goodness Of God"), _header(None)])
+        monkeypatch.setattr(extractor, "extract_score_header_via_vision", vision)
+
+        result = extractor._group_song_slides_with_score_ocr(
+            slides, OcrBudget(max_calls=2)
+        )
+
+        # Grouping is unchanged: the tail is still retained, on purpose.
+        assert [(title, len(group)) for title, group in result.groups] == [
+            ("goodness of god", 5)
+        ]
+        assert vision.call_count == 2
+
+        budget_anomalies = [
+            a for a in result.anomalies if a["type"] == "score_image_ocr_budget_exhausted"
+        ]
+        assert budget_anomalies, (
+            "a score group whose tail was assembled without OCR must say so — "
+            f"got only {[a['type'] for a in result.anomalies]}"
+        )
+        anomaly = budget_anomalies[0]
+        assert anomaly["title"] == "Goodness Of God"
+        assert anomaly["first_unverified_slide_index"] == 2
+        assert anomaly["unverified_slides"] == 3
+
+    def test_no_anomaly_when_the_budget_covered_every_slide(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The negative case, or the assertion above proves nothing.
+
+        Every slide classified means every boundary was observed, so there is
+        nothing to warn about and a warning here would be noise on every import.
+        """
+        slides = [_slide(i, blob=f"score-{i}".encode()) for i in range(4)]
+        vision = MagicMock(
+            side_effect=[_header(), _header(None), _header(None), _header(None)]
+        )
+        monkeypatch.setattr(extractor, "extract_score_header_via_vision", vision)
+
+        result = extractor._group_song_slides_with_score_ocr(
+            slides, OcrBudget(max_calls=10)
+        )
+
+        assert [(title, len(group)) for title, group in result.groups] == [
+            ("goodness of god", 4)
+        ]
+        assert not [
+            a for a in result.anomalies if a["type"] == "score_image_ocr_budget_exhausted"
+        ]
+
+    def test_a_text_slide_ends_the_unverified_tail_and_bounds_the_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The count must be the tail actually taken, not everything after the budget.
+
+        A text-bearing slide flushes the score group, so slides beyond it were
+        never at risk of being swallowed. Reporting them would overstate the
+        problem and train the reader to ignore the anomaly.
+        """
+        slides = [
+            _slide(0, blob=b"score-0"),
+            _slide(1, blob=b"score-1"),
+            _slide(2, blob=b"score-2"),
+            _slide(3, lines=["Amazing Grace", "how sweet the sound"]),
+            _slide(4, blob=b"score-4"),
+        ]
+        vision = MagicMock(side_effect=[_header("Goodness Of God"), _header(None)])
+        monkeypatch.setattr(extractor, "extract_score_header_via_vision", vision)
+
+        result = extractor._group_song_slides_with_score_ocr(
+            slides, OcrBudget(max_calls=2)
+        )
+
+        anomaly = next(
+            a for a in result.anomalies if a["type"] == "score_image_ocr_budget_exhausted"
+        )
+        assert anomaly["first_unverified_slide_index"] == 2
+        assert anomaly["unverified_slides"] == 1


### PR DESCRIPTION
Closes #554.

## What is not changing

#553 deliberately keeps appending image-only slides to a confirmed score once the shared OCR budget runs out, because the known 30-page *Goodness of God* score needs more pages than the default 25-call web budget allows. **That trade is right and is not touched here** — truncating the tail would break the case #553 was written for.

## What it costs, and what this adds

The retained tail is a boundary the classifier can no longer see. Every following image-only slide joins the current song until a text-bearing slide appears, so a score followed immediately by another score — or by an image-only non-song — silently inflates the first song's range and can hide the second song entirely.

Nothing in the output said so. An inflated range was indistinguishable from a genuinely long one, and the reviewer had no signal to act on. Now the group carries:

```
score_image_ocr_budget_exhausted
  "OCR budget ran out mid-score: the last 3 slide(s) were added to this song
   without being classified. The song's range may be too long, and a following
   song may be hidden inside it. Review these slides, or re-run with a larger
   OCR budget."
  title, first_slide_index, first_unverified_slide_index, unverified_slides
```

Of the four directions the issue proposed this is the first — **no grouping change, no extra OCR calls**, which is what the issue asked for (*"keep the current safe text-only behavior and shared cost cap intact"*). Reserving calls to probe the end of a run, adapting the cap, and batching all change cost or behaviour and deserve their own decision.

Anomalies are already persisted to `import_jobs.anomalies_json` and printed by the CLI, so this reaches a human with no new plumbing.

## Two details that make the anomaly trustworthy

- **The counter resets with the group, not the run**, so a later score that fits inside the budget does not inherit an earlier group's warning.
- **It is emitted at flush**, so the count is the tail *actually taken*. A text-bearing slide ends the group and slides beyond it were never at risk — counting them would overstate the problem and train the reader to ignore the anomaly. There is a test for precisely that.

## Tests

| Test | Proves |
|---|---|
| `test_unverified_tail_is_reported_as_an_anomaly` | the issue's own reproduction: budget 2 over five image-only slides → still one five-slide group, plus an anomaly naming slide 2 and a count of 3 |
| `test_no_anomaly_when_the_budget_covered_every_slide` | the negative case — otherwise the assertion above proves nothing and every import would carry noise |
| `test_a_text_slide_ends_the_unverified_tail_and_bounds_the_count` | the count is the tail taken, not everything after exhaustion |

The first and third failed before the change.

`ruff check src/` and `mypy src/` clean; extractor + OCR suites **180 passed**; full suite running locally alongside CI.