### PR TITLE
test(ccli): pin the export's real contract, and record that CCLI has no spec

### DIFF
--- a/src/worship_catalog/import_service.py
+++ b/src/worship_catalog/import_service.py
@@ -16,6 +16,33 @@ from worship_catalog.db import Database
 
 _log = logging.getLogger(__name__)
 
+# The reproduction-type vocabulary written into copy_events and, from there,
+# straight into the CCLI report (#86). These were bare literals at their only call
+# site, so `reproduction_type="projecton"` would have been written to the database
+# and submitted to a licensing body with nothing to catch it.
+#
+# These are OUR terms, not CCLI's. CCLI's four categories are Print, Digital,
+# Record and Translation: `projection` is their Digital, `recording` is their
+# Record, and custom arrangements fold into Print rather than having a category of
+# their own. Mapping our vocabulary onto theirs on export is a separate change --
+# see docs/ccli-requirements.md, which also records that CCLI publishes no file
+# format at all, so this is a contract with ourselves and not with them.
+#
+# `print` and `translation` are listed because config/reporting.yml already names
+# them as configurable counts (defaulting to 0, not yet wired up -- #6). Leaving
+# them out would make the enum wrong the moment that config is honoured.
+REPRODUCTION_PROJECTION = "projection"
+REPRODUCTION_RECORDING = "recording"
+REPRODUCTION_PRINT = "print"
+REPRODUCTION_TRANSLATION = "translation"
+
+REPRODUCTION_TYPES: tuple[str, ...] = (
+    REPRODUCTION_PROJECTION,
+    REPRODUCTION_RECORDING,
+    REPRODUCTION_PRINT,
+    REPRODUCTION_TRANSLATION,
+)
+
 
 @dataclass
 class ImportedSong:
@@ -146,7 +173,7 @@ def run_import(
                 service_id=service_id,
                 song_id=song_id,
                 song_edition_id=edition_id,
-                reproduction_type="projection",
+                reproduction_type=REPRODUCTION_PROJECTION,
                 count=1,
                 reportable=True,
             )
@@ -155,7 +182,7 @@ def run_import(
                 service_id=service_id,
                 song_id=song_id,
                 song_edition_id=edition_id,
-                reproduction_type="recording",
+                reproduction_type=REPRODUCTION_RECORDING,
                 count=1,
                 reportable=True,
             )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4515,3 +4515,147 @@ class TestBuildDateFormatting:
     def test_format_build_date_invalid(self):
         from worship_catalog.web.app import _format_build_date
         assert _format_build_date("not-a-date") == "not-a-date"
+
+
+class TestCcliCsvContract:
+    """What the CCLI export guarantees — and what it deliberately does not (#86).
+
+    #86 asked for this CSV to be contract-tested "against the CCLI CSV
+    specification". Researched 2026-08-02: **there is no such specification.**
+    CCLI reports usage through a web portal — search a song, click REPORT SONG,
+    enter 0-9 in each of four category boxes — or machine-to-machine through
+    auto-reporting integrations. No published column list, no schema, no sample
+    file, and a third-party vendor states outright that CCLI "does not support or
+    allow a 'file upload' facility for copyright reporting". Full write-up with
+    sources in docs/ccli-requirements.md.
+
+    So these tests assert **this project's own contract**, which is the only thing
+    that can honestly be asserted. A test claiming conformance to an external spec
+    that does not exist would report confidence about legal compliance while
+    proving nothing but self-consistency — worse than no test at all.
+
+    The columns #86 proposed (Words By / Music By / Arranger / Publisher) are song
+    *credits*: CCLI already holds them and never asks a church to report them, and
+    that proposal drops the CCLI song number, which is the one identifier CCLI and
+    every auto-reporting integration key on. Asserting them would have failed
+    immediately and then been "fixed" by changing the export to match an invented
+    format.
+
+    Header names, order and column count are already pinned by
+    TestCsvHeaderContracts above; these cover what that does not.
+    """
+
+    RANGE = {"start_date": "2020-01-01", "end_date": "2030-12-31"}
+
+    def _rows(self, client):
+        import csv
+        import io
+
+        resp = client.post("/reports/ccli", data=self.RANGE)
+        assert resp.status_code == 200
+        return resp, list(csv.DictReader(io.StringIO(resp.text)))
+
+    def test_dates_are_iso_8601(self, client):
+        """A locale-formatted date would be ambiguous in a compliance record.
+
+        03/04/2026 is two different days depending on who reads it. The portal is
+        filled in by hand from this file, so the date has to be unambiguous.
+        """
+        import re
+
+        _, rows = self._rows(client)
+        assert rows, "fixture should yield at least one CCLI row"
+        for row in rows:
+            assert re.fullmatch(r"\d{4}-\d{2}-\d{2}", row["Date"]), (
+                f"Date {row['Date']!r} is not ISO 8601 (YYYY-MM-DD)"
+            )
+
+    def test_filename_carries_the_iso_range(self, client):
+        """The file leaves the app and lands in a downloads folder.
+
+        Without the range in the name, two exports for different periods are
+        indistinguishable — and submitting the wrong period is a reporting error
+        nobody would catch.
+        """
+        resp = client.post("/reports/ccli", data=self.RANGE)
+        cd = resp.headers.get("content-disposition", "")
+        assert "ccli_report_2020-01-01_2030-12-31.csv" in cd, cd
+
+    def test_ccli_number_column_is_always_present_even_when_empty(self, client):
+        """Blank, never missing.
+
+        CCLI's portal keys on the song number, and Planning Center's auto-reporting
+        silently drops songs that lack one. A row that omits the column entirely
+        would shift every later field left; a blank one is honest about what is not
+        known yet. `spec.md` puts the mapping out of scope for v1, so blanks are
+        expected — their absence is not.
+        """
+        _, rows = self._rows(client)
+        for row in rows:
+            assert "CCLI#" in row, f"CCLI# column missing from row: {row}"
+            assert row["CCLI#"] is not None
+
+    def test_reproduction_type_is_drawn_from_the_closed_vocabulary(self, client):
+        """A typo must not reach a licensing document.
+
+        The values were bare string literals at their only call site, so
+        `reproduction_type="projecton"` would have written silently to the database
+        and straight into this report. They are now module constants, and this
+        pins the CSV to that vocabulary.
+
+        Note these are OUR terms, not CCLI's. CCLI's four categories are Print,
+        Digital, Record and Translation — `projection` maps to Digital and
+        `recording` to Record. Mapping on export is a separate change; see
+        docs/ccli-requirements.md.
+        """
+        from worship_catalog.import_service import REPRODUCTION_TYPES
+
+        _, rows = self._rows(client)
+        seen = {row["Reproduction Type"] for row in rows}
+        assert seen, "fixture should yield at least one CCLI row"
+        assert seen <= set(REPRODUCTION_TYPES), (
+            f"CSV contains reproduction types outside the known vocabulary: "
+            f"{seen - set(REPRODUCTION_TYPES)}"
+        )
+
+    def test_title_is_the_display_title_not_the_canonical_form(self, client):
+        """Canonical titles are lowercased, punctuation-stripped matching keys.
+
+        Submitting them would make a licensing report unreadable, and worse, hard
+        to match against CCLI's catalogue during the portal search.
+        """
+        _, rows = self._rows(client)
+        titles = [row["Title"] for row in rows]
+        assert any(t != t.lower() for t in titles), (
+            f"every title is lowercase, which suggests canonical forms leaked "
+            f"into the report: {titles}"
+        )
+
+    def test_response_is_utf8_csv(self, client):
+        """Pinned because song titles carry non-ASCII characters.
+
+        Curly apostrophes and accented names arrive from the source decks; a
+        mis-declared encoding turns them into mojibake in a document that goes to
+        a licensing body.
+        """
+        resp = client.post("/reports/ccli", data=self.RANGE)
+        assert resp.headers["content-type"].startswith("text/csv")
+        resp.text.encode("utf-8").decode("utf-8")
+
+    def test_empty_range_returns_headers_only_not_an_error(self, client):
+        """"Nothing to report" is a real CCLI answer, not a failure.
+
+        CCLI asks churches to confirm nothing was used rather than stay silent, so
+        an empty period must produce a valid, well-formed file with the header row
+        intact — not a 404, a 500, or a zero-byte download.
+        """
+        import csv
+        import io
+
+        resp = client.post(
+            "/reports/ccli", data={"start_date": "1990-01-01", "end_date": "1990-12-31"}
+        )
+        assert resp.status_code == 200
+        rows = list(csv.reader(io.StringIO(resp.text)))
+        assert len(rows) == 1, f"expected header row only, got {rows}"
+        assert rows[0][0] == "Date"


### PR DESCRIPTION
Closes #86.

## The premise did not survive contact

#86 asked for the CCLI CSV to be contract-tested *"against the CCLI CSV specification"*. **There is no such specification.** CCLI reports usage through a web portal — search a song, click **REPORT SONG**, enter 0–9 in each of four category boxes, repeat — or machine-to-machine through auto-reporting integrations. No published column list, no schema, no sample file, no developer docs. A third-party vendor states it outright: *"CCLI does not support or allow a 'file upload' facility for copyright reporting."* Sources in [`docs/ccli-requirements.md`](https://github.com/mshirel/song-history/blob/main/docs/ccli-requirements.md).

So these tests assert **this project's own contract**. A test claiming conformance to a spec that does not exist would report confidence about legal compliance while proving nothing but self-consistency — worse than no test.

The proposed columns are wrong on the merits too. `Words By | Music By | Arranger | Publisher` are song *credits*: CCLI already holds them and never asks a church to report them. And the proposal **drops the CCLI song number**, the one identifier CCLI and every auto-reporting integration key on. Implemented as written, the test would have failed immediately and then been "fixed" by changing the export to match an invention.

#86 is also stale in one respect: it says the tests check only "a header row and song data". `TestCsvHeaderContracts` already pins the exact header list, order and column count. These cover what it does not.

## One real fix, six regression guards

**The fix:** the reproduction-type vocabulary was bare string literals at its only call site, so `reproduction_type="projecton"` would have been written to the database and submitted to a licensing body with nothing to catch it. Now module constants, with the CSV pinned to them. `print` and `translation` are included because `config/reporting.yml` already names them as configurable counts (#6) — omitting them would make the enum wrong the moment that config is honoured.

**The guards** — these six pass before the change, and are labelled as guards in the docstrings rather than dressed up as fixes:

| Test | Why it is worth pinning |
|---|---|
| ISO 8601 dates | `03/04/2026` is two different days depending on the reader |
| filename carries the ISO range | two exports for different periods are otherwise indistinguishable in a downloads folder |
| `CCLI#` present-or-blank, never missing | an omitted column shifts every later field left; Planning Center silently drops songs with no number |
| display title, not canonical | canonical titles are lowercased and punctuation-stripped — unreadable, and hard to match in the portal search |
| UTF-8 `text/csv` | curly apostrophes and accented names arrive from the source decks |
| empty range → headers only, 200 | *"nothing to report"* is a real CCLI answer, so it must produce a well-formed file rather than a 404 |

## Note on vocabulary

`projection` and `recording` are ours, not CCLI's. CCLI's four categories are **Print, Digital, Record, Translation** — `projection` is their Digital, `recording` their Record, and custom arrangements fold into **Print** rather than having a category of their own. Mapping on export is a separate change; so is a per-song aggregate view, which is what actually maps 1:1 onto the portal's data entry. Both are recorded in the doc.

`ruff check src/` and `mypy src/` clean; new tests 7/7.