### PR TITLE
feat(web): let the admin remove a misidentified song from a service

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1147,38 +1147,83 @@ class Database:
 
         self._maybe_commit()
 
-    def delete_service_song(self, service_id: int, song_id: int) -> bool:
-        """Remove one song from one service, and its copy events with it (#323).
+    def delete_setlist_entry(self, service_id: int, entry_id: int) -> bool:
+        """Remove ONE setlist entry from a service, and its copy events (#323).
 
-        Returns True if a setlist row was removed, False if that song was not in
-        that service — so a caller can 404 rather than report a success that did
+        Returns True if a row was removed, False if that entry is not in that
+        service — so a caller can 404 rather than report a success that did
         nothing.
+
+        KEYED ON THE SETLIST ROW, NOT ON THE SONG. `service_songs` is
+        UNIQUE(service_id, ordinal), not UNIQUE(service_id, song_id), so one song
+        can legitimately appear several times in one service — and it does exactly
+        when the extractor is wrong in the way this feature exists to correct: a
+        blank slide mid-song closes a group, so one song becomes two entries with
+        the same song_id. Deleting by song_id removed BOTH, so the admin fixing
+        the spurious half silently lost the real one, dropping a genuine
+        performance from the CCLI report. Discovered in review, reproduced
+        directly.
+
+        Copy events are removed only when the LAST entry for that song goes. They
+        are keyed on (service_id, song_id) with no ordinal, so one row covers all
+        the occurrences; deleting them while another entry survives would erase
+        that song's reporting for the service it is still in.
 
         Two things this deliberately does NOT do:
 
         * It does not touch the ``songs`` row. Songs are shared across services;
           deleting it would erase the song's history everywhere it legitimately
-          appears, to fix one slide that was misread.
+          appears, to fix one slide that was misread. A song left with no
+          appearances at all is tracked separately (#618).
         * It does not renumber the remaining ``ordinal`` values. They are unique
           per service but need not be contiguous, and a gap is honest — it says a
-          slide was removed. Renumbering would also have to happen inside this
-          transaction to avoid violating UNIQUE(service_id, ordinal) halfway.
-
-        Copy events go first and are not optional. A copy event that outlives its
-        setlist row keeps the phantom song in the CCLI report, which is the one
-        place a misidentified song does real harm — it would be submitted to a
-        licensing body.
+          slide was removed. (A later re-import is unaffected: ``run_import``
+          calls ``delete_service_data``, which drops the service row entirely and
+          mints a fresh id, so a gap can never collide with the UNIQUE.)
         """
         cursor = self._conn.cursor()
+        row = cursor.execute(
+            "SELECT song_id FROM service_songs WHERE id = ? AND service_id = ?",
+            (entry_id, service_id),
+        ).fetchone()
+        if row is None:
+            return False
+        song_id = row["song_id"]
+
+        # ORDER MATTERS. The setlist row goes FIRST and its rowcount decides
+        # whether anything else happens. Deleting the copy events first would mean
+        # a caller that gets False -- and therefore raises 404 "not in this
+        # service" -- could already have committed the destruction of that song's
+        # CCLI copy events. A 404 that has silently deleted data is the worst
+        # possible signal to an admin correcting records by hand: nothing tells
+        # them a re-import is needed. Nothing at the schema level enforces the
+        # pairing either (copy_events has foreign keys to services, songs and
+        # song_editions, but not to service_songs).
         cursor.execute(
-            "DELETE FROM copy_events WHERE service_id = ? AND song_id = ?",
-            (service_id, song_id),
-        )
-        cursor.execute(
-            "DELETE FROM service_songs WHERE service_id = ? AND song_id = ?",
-            (service_id, song_id),
+            "DELETE FROM service_songs WHERE id = ? AND service_id = ?",
+            (entry_id, service_id),
         )
         removed = cursor.rowcount > 0
+
+        if removed:
+            remaining = cursor.execute(
+                "SELECT COUNT(*) AS n FROM service_songs "
+                "WHERE service_id = ? AND song_id = ?",
+                (service_id, song_id),
+            ).fetchone()["n"]
+            if remaining == 0:
+                # Not optional. A copy event that outlives the last setlist row
+                # keeps the phantom song in the CCLI report, which is where a
+                # misidentified song actually does harm -- it gets submitted to a
+                # licensing body. Both predicates are required: without
+                # service_id this would erase that song's copy events in EVERY
+                # service it has ever appeared in.
+                cursor.execute(
+                    "DELETE FROM copy_events WHERE service_id = ? AND song_id = ?",
+                    (service_id, song_id),
+                )
+        # sqlite3 runs at its default isolation_level, so these statements share
+        # one implicit transaction: a process death between them cannot half-commit.
         self._maybe_commit()
         return removed
 
@@ -1717,7 +1762,7 @@ class Database:
         cursor = self._conn.cursor()
         cursor.execute(
             """
-            SELECT ss.ordinal, ss.occurrences,
+            SELECT ss.id AS entry_id, ss.ordinal, ss.occurrences,
                    s.id AS song_id, s.display_title, s.canonical_title,
                    se.publisher, se.words_by, se.music_by, se.arranger, se.copyright_notice,
                    GROUP_CONCAT(ce.reproduction_type, ', ') AS copy_types

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1147,6 +1147,41 @@ class Database:
 
         self._maybe_commit()
 
+    def delete_service_song(self, service_id: int, song_id: int) -> bool:
+        """Remove one song from one service, and its copy events with it (#323).
+
+        Returns True if a setlist row was removed, False if that song was not in
+        that service — so a caller can 404 rather than report a success that did
+        nothing.
+
+        Two things this deliberately does NOT do:
+
+        * It does not touch the ``songs`` row. Songs are shared across services;
+          deleting it would erase the song's history everywhere it legitimately
+          appears, to fix one slide that was misread.
+        * It does not renumber the remaining ``ordinal`` values. They are unique
+          per service but need not be contiguous, and a gap is honest — it says a
+          slide was removed. Renumbering would also have to happen inside this
+          transaction to avoid violating UNIQUE(service_id, ordinal) halfway.
+
+        Copy events go first and are not optional. A copy event that outlives its
+        setlist row keeps the phantom song in the CCLI report, which is the one
+        place a misidentified song does real harm — it would be submitted to a
+        licensing body.
+        """
+        cursor = self._conn.cursor()
+        cursor.execute(
+            "DELETE FROM copy_events WHERE service_id = ? AND song_id = ?",
+            (service_id, song_id),
+        )
+        cursor.execute(
+            "DELETE FROM service_songs WHERE service_id = ? AND song_id = ?",
+            (service_id, song_id),
+        )
+        removed = cursor.rowcount > 0
+        self._maybe_commit()
+        return removed
+
     # ------------------------------------------------------------------
     # Import job methods (#45)
     # ------------------------------------------------------------------

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -1308,8 +1308,54 @@ async def service_detail(
         raise HTTPException(status_code=404, detail="Service not found")
     songs = db.query_service_songs(service_id)
     return templates.TemplateResponse(
-        request, "service_detail.html", {"service": service, "songs": songs}
+        request,
+        "service_detail.html",
+        {
+            "service": service,
+            "songs": songs,
+            # Same doctrine as the missing-services report (#483): the page stays
+            # publicly readable, the destructive controls only render for a viewer
+            # who is already authenticated. Hiding them is presentation, not
+            # security -- the route enforces auth itself.
+            "can_edit": _upload_credentials_valid(request),
+        },
     )
+
+
+@app.post("/services/{service_id}/songs/{song_id}/delete")
+async def service_song_delete(
+    request: Request,
+    service_id: int,
+    song_id: int,
+    db: Database = Depends(get_db),  # noqa: B008
+) -> RedirectResponse:
+    """Remove one misidentified song from a service (#323).
+
+    The extractor classifies slides and gets things wrong -- service 36 carried a
+    scripture reference and two sermon-outline slides as songs (#313, #314).
+    Until now the only remedy was `cleanup delete-service` plus a full re-import,
+    which needs CLI access the church admin does not have, so every extraction
+    error required a developer.
+
+    Gated by the same upload auth that protects /upload and the missing-services
+    edits (#483): this is a destructive write on a publicly reachable site.
+
+    303 rather than 200 so a refresh after the delete re-issues the GET instead of
+    re-posting a delete that would now 404.
+    """
+    require_upload_auth(request)
+    if not db.query_service_by_id(service_id):
+        raise HTTPException(status_code=404, detail="Service not found")
+    if not db.delete_service_song(service_id, song_id):
+        # Distinguishes "no such song in this service" from a silent no-op, so a
+        # stale page's delete button reports something rather than appearing to
+        # succeed.
+        raise HTTPException(status_code=404, detail="Song not found in this service")
+    _log.info(
+        "service song deleted",
+        extra={"service_id": service_id, "song_id": song_id},
+    )
+    return RedirectResponse(url=f"/services/{service_id}", status_code=303)
 
 
 _LEADER_MIN_SONG_COUNT = 2

--- a/src/worship_catalog/web/app.py
+++ b/src/worship_catalog/web/app.py
@@ -1322,14 +1322,14 @@ async def service_detail(
     )
 
 
-@app.post("/services/{service_id}/songs/{song_id}/delete")
-async def service_song_delete(
+@app.post("/services/{service_id}/setlist/{entry_id}/delete")
+async def setlist_entry_delete(
     request: Request,
     service_id: int,
-    song_id: int,
+    entry_id: int,
     db: Database = Depends(get_db),  # noqa: B008
 ) -> RedirectResponse:
-    """Remove one misidentified song from a service (#323).
+    """Remove one misidentified setlist entry from a service (#323).
 
     The extractor classifies slides and gets things wrong -- service 36 carried a
     scripture reference and two sermon-outline slides as songs (#313, #314).
@@ -1340,20 +1340,26 @@ async def service_song_delete(
     Gated by the same upload auth that protects /upload and the missing-services
     edits (#483): this is a destructive write on a publicly reachable site.
 
+    Addressed by SETLIST ROW, not by song: `service_songs` is
+    UNIQUE(service_id, ordinal), so one song can appear several times in a
+    service -- which is exactly what happens when the extractor splits a song in
+    two, the error class this feature exists to correct. Keying on song_id
+    removed every occurrence at once.
+
     303 rather than 200 so a refresh after the delete re-issues the GET instead of
     re-posting a delete that would now 404.
     """
     require_upload_auth(request)
     if not db.query_service_by_id(service_id):
         raise HTTPException(status_code=404, detail="Service not found")
-    if not db.delete_service_song(service_id, song_id):
-        # Distinguishes "no such song in this service" from a silent no-op, so a
+    if not db.delete_setlist_entry(service_id, entry_id):
+        # Distinguishes "no such entry in this service" from a silent no-op, so a
         # stale page's delete button reports something rather than appearing to
         # succeed.
         raise HTTPException(status_code=404, detail="Song not found in this service")
     _log.info(
-        "service song deleted",
-        extra={"service_id": service_id, "song_id": song_id},
+        "setlist entry deleted",
+        extra={"service_id": service_id, "entry_id": entry_id},
     )
     return RedirectResponse(url=f"/services/{service_id}", status_code=303)
 

--- a/src/worship_catalog/web/static/service_detail.js
+++ b/src/worship_catalog/web/static/service_detail.js
@@ -1,0 +1,104 @@
+/**
+ * Delete-song controls on the service detail page (#323).
+ *
+ * This file exists because the obvious implementation — a plain
+ * `<form method="post">` with an inline `onsubmit="return confirm(...)"` —
+ * is broken twice over on this app, and both failures are silent:
+ *
+ *   1. CSRF. SelfHealingCSRFMiddleware reads the token ONLY from the
+ *      `X-CSRFToken` request header, never from a form field. A native form
+ *      submission sends no such header, so every real-browser click returned
+ *      403 "CSRF token verification failed". Adding a hidden input would not
+ *      help — the middleware does not look there. Every other POST surface in
+ *      this app already goes through fetch or htmx for exactly this reason.
+ *
+ *   2. CSP. The app sends `script-src 'self'` with no `unsafe-inline` and no
+ *      `unsafe-hashes`, so an inline event handler is refused outright by the
+ *      browser. The confirm() never ran — meaning that once the CSRF problem
+ *      was fixed, a single misclick would have destroyed a setlist row and its
+ *      copy events with no prompt at all. The repo has paid for this defect
+ *      class before (review #247, inline JavaScript in upload.html).
+ *
+ * Neither was visible from the test suite: the test client sets the CSRF header
+ * on every POST, so it arranges a precondition a browser never supplies, and it
+ * does not execute JavaScript or enforce CSP at all. Both were found in a real
+ * browser, which is the only place they show up.
+ */
+(function () {
+  "use strict";
+
+  /**
+   * Read the csrftoken cookie fresh on every use. The middleware can replace it
+   * after a secret rotation, so a cached value would keep replaying a stale
+   * token and start 403ing again after an app restart.
+   */
+  function getCsrfToken() {
+    var token = "";
+    document.cookie.split(";").forEach(function (c) {
+      var parts = c.trim().split("=");
+      if (parts[0] === "csrftoken") token = parts[1];
+    });
+    return token;
+  }
+
+  function bindDeleteForms() {
+    var forms = document.querySelectorAll("form[data-song-title]");
+    Array.prototype.forEach.call(forms, function (form) {
+      form.addEventListener("submit", function (e) {
+        e.preventDefault();
+
+        // The title comes from a data attribute, not from JavaScript that the
+        // template generated: song titles arrive from OCR and PowerPoint decks
+        // and are not trusted. Interpolating one into a JS string literal broke
+        // on "I'll Fly Away" and executed on ');alert(1);//.
+        var title = form.getAttribute("data-song-title") || "this song";
+        var message =
+          'Remove "' +
+          title +
+          '" from this service?\n\n' +
+          "This also removes it from the CCLI report. It cannot be undone " +
+          "without re-uploading the slide deck.";
+        if (!window.confirm(message)) return;
+
+        var btn = form.querySelector("button[type=submit]");
+        if (btn) {
+          btn.disabled = true;
+          btn.textContent = "Removing…";
+        }
+
+        fetch(form.action, {
+          method: "POST",
+          headers: { "X-CSRFToken": getCsrfToken() },
+          // Send the session cookie AND the Basic-auth credentials the browser
+          // already holds — this route is behind the same upload auth as
+          // /upload, and fetch omits credentials by default on some paths.
+          credentials: "same-origin",
+        })
+          .then(function (resp) {
+            if (!resp.ok) {
+              return resp.text().then(function (t) {
+                throw new Error(t || resp.statusText);
+              });
+            }
+            // The route answers 303 to the service page; fetch follows it, so
+            // reload rather than trying to swap the row out by hand. A reload
+            // also re-renders every derived number on the page.
+            window.location.reload();
+          })
+          .catch(function (err) {
+            if (btn) {
+              btn.disabled = false;
+              btn.textContent = "Remove";
+            }
+            window.alert("Could not remove the song: " + err.message);
+          });
+      });
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bindDeleteForms);
+  } else {
+    bindDeleteForms();
+  }
+})();

--- a/src/worship_catalog/web/templates/service_detail.html
+++ b/src/worship_catalog/web/templates/service_detail.html
@@ -89,17 +89,22 @@
            and the uploaded deck is deleted after import (#138), so a misclick has
            no cheap undo -- hence the confirm. #}
         <td style="text-align:center;">
-          {# The title goes in a DATA ATTRIBUTE and is read back with dataset, never
-             interpolated into the JS string. Jinja autoescaping is HTML escaping: an
-             apostrophe becomes &#39;, the HTML parser decodes it back to ' BEFORE the
-             attribute is parsed as JavaScript, and the string literal terminates early.
-             "I'll Fly Away" alone would break the handler so the confirm never runs and
-             the form submits unconfirmed; a title of ');alert(1);// would execute. Titles
-             come from OCR and PowerPoint decks, so they are not trusted input. #}
+          {# No inline onsubmit and no fetch here — both live in
+             /static/service_detail.js, which binds the confirm AND attaches the
+             X-CSRFToken header. A plain form POST is rejected 403 (the middleware
+             reads the token only from the header, never a form field) and an inline
+             handler is refused by CSP script-src 'self'. Either one alone breaks
+             this control silently.
+
+             The title travels in a DATA ATTRIBUTE, an HTML context where Jinja's
+             autoescaping is the right escaping. It must never be interpolated into
+             JavaScript: the HTML parser decodes &#39; back to an apostrophe before
+             the attribute is parsed as JS, so "I'll Fly Away" alone broke the
+             handler and a title of ');alert(1);// executed. Titles come from OCR and
+             PowerPoint decks and are not trusted. #}
           <form method="post"
-                action="/services/{{ service.id }}/songs/{{ song.song_id }}/delete"
+                action="/services/{{ service.id }}/setlist/{{ song.entry_id }}/delete"
                 data-song-title="{{ song.display_title }}"
-                onsubmit="return confirm('Remove \u0022' + this.dataset.songTitle + '\u0022 from this service?\n\nThis also removes it from the CCLI report. It cannot be undone without re-uploading the slide deck.');"
                 style="display:inline;">
             <button type="submit"
                     class="btn-link-danger"
@@ -117,5 +122,7 @@
   </div>
 </div>
 {% endif %}
+
+{% if can_edit %}<script src="/static/service_detail.js"></script>{% endif %}
 
 {% endblock %}

--- a/src/worship_catalog/web/templates/service_detail.html
+++ b/src/worship_catalog/web/templates/service_detail.html
@@ -64,6 +64,9 @@
         <th scope="col">Arranger</th>
         <th scope="col">Publisher</th>
         <th scope="col">Reproductions</th>
+        {% if can_edit %}
+        <th scope="col" style="width:5rem;">Actions</th>
+        {% endif %}
       </tr>
     </thead>
     <tbody>
@@ -81,6 +84,24 @@
         <td style="font-size:0.85rem;">{{ song.arranger or '' }}</td>
         <td style="font-size:0.85rem;color:#495057;">{{ song.publisher or '' }}</td>
         <td style="font-size:0.85rem;color:#495057;">{{ song.copy_types or '—' }}</td>
+        {% if can_edit %}
+        {# Removing a misidentified song (#323). Irreversible without a re-import,
+           and the uploaded deck is deleted after import (#138), so a misclick has
+           no cheap undo -- hence the confirm. #}
+        <td style="text-align:center;">
+          <form method="post"
+                action="/services/{{ service.id }}/songs/{{ song.song_id }}/delete"
+                onsubmit="return confirm('Remove &quot;{{ song.display_title }}&quot; from this service?\n\nThis also removes it from the CCLI report. It cannot be undone without re-uploading the slide deck.');"
+                style="display:inline;">
+            <button type="submit"
+                    class="btn-link-danger"
+                    aria-label="Remove {{ song.display_title }} from this service"
+                    style="background:none;border:none;color:#b02a37;cursor:pointer;font-size:0.85rem;padding:0;">
+              Remove
+            </button>
+          </form>
+        </td>
+        {% endif %}
       </tr>
       {% endfor %}
     </tbody>

--- a/src/worship_catalog/web/templates/service_detail.html
+++ b/src/worship_catalog/web/templates/service_detail.html
@@ -89,9 +89,17 @@
            and the uploaded deck is deleted after import (#138), so a misclick has
            no cheap undo -- hence the confirm. #}
         <td style="text-align:center;">
+          {# The title goes in a DATA ATTRIBUTE and is read back with dataset, never
+             interpolated into the JS string. Jinja autoescaping is HTML escaping: an
+             apostrophe becomes &#39;, the HTML parser decodes it back to ' BEFORE the
+             attribute is parsed as JavaScript, and the string literal terminates early.
+             "I'll Fly Away" alone would break the handler so the confirm never runs and
+             the form submits unconfirmed; a title of ');alert(1);// would execute. Titles
+             come from OCR and PowerPoint decks, so they are not trusted input. #}
           <form method="post"
                 action="/services/{{ service.id }}/songs/{{ song.song_id }}/delete"
-                onsubmit="return confirm('Remove &quot;{{ song.display_title }}&quot; from this service?\n\nThis also removes it from the CCLI report. It cannot be undone without re-uploading the slide deck.');"
+                data-song-title="{{ song.display_title }}"
+                onsubmit="return confirm('Remove \u0022' + this.dataset.songTitle + '\u0022 from this service?\n\nThis also removes it from the CCLI report. It cannot be undone without re-uploading the slide deck.');"
                 style="display:inline;">
             <button type="submit"
                     class="btn-link-danger"

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -3551,8 +3551,8 @@ class TestServiceExclusions:
         assert len(rows) == 1 and rows[0]["service_slot"] == "evening"
 
 
-class TestDeleteServiceSong:
-    """Remove one misidentified song from a service, not the whole service (#323).
+class TestDeleteSetlistEntry:
+    """Remove one misidentified entry from a service, not the whole service (#323).
 
     The extractor classifies slides, and it gets things wrong: service 36
     (2026-03-15 PM) carried three non-song entries — a scripture reference and
@@ -3560,13 +3560,22 @@ class TestDeleteServiceSong:
     `cleanup delete-service` plus a full re-import, which needs CLI access the
     church admin does not have.
 
-    The delete has to be surgical in two directions. It must remove the copy
-    events as well as the setlist row, because a copy event that outlives its
-    setlist entry keeps the phantom song in the CCLI report — the one place it
-    does real harm. And it must leave the `songs` row alone: songs are shared
-    across services, so deleting the row would erase the song's history
-    everywhere it legitimately appears.
+    The delete has to be surgical in three directions. It must remove the copy
+    events, because a copy event that outlives its setlist row keeps the phantom
+    song in the CCLI report — the one place it does real harm. It must leave the
+    `songs` row alone, because songs are shared across services. And it must
+    remove exactly ONE occurrence: `service_songs` is UNIQUE(service_id, ordinal),
+    not UNIQUE(service_id, song_id).
     """
+
+    def _entry_id(self, db, service_id, song_id, ordinal=None):
+        rows = [
+            r
+            for r in db.query_service_songs(service_id)
+            if r["song_id"] == song_id and (ordinal is None or r["ordinal"] == ordinal)
+        ]
+        assert rows, f"no setlist entry for song {song_id} in service {service_id}"
+        return rows[0]["entry_id"]
 
     def test_removes_the_setlist_row_and_its_copy_events(self, tmp_path):
         from worship_catalog.db import Database
@@ -3588,7 +3597,7 @@ class TestDeleteServiceSong:
         db.insert_or_get_copy_event(svc, song_b, "projection")
         db.insert_or_get_copy_event(svc, song_b, "recording")
 
-        assert db.delete_service_song(svc, song_b) is True
+        assert db.delete_setlist_entry(svc, self._entry_id(db, svc, song_b)) is True
 
         remaining = {s["song_id"] for s in db.query_service_songs(svc)}
         assert remaining == {song_a}, "the misidentified song is still in the setlist"
@@ -3600,8 +3609,15 @@ class TestDeleteServiceSong:
         )
         db.close()
 
-    def test_leaves_the_song_row_alone_because_songs_are_shared(self, tmp_path):
-        """Deleting from one service must not erase the song's other appearances."""
+    def test_other_services_keep_the_song_AND_its_copy_events(self, tmp_path):
+        """Both halves matter, and the copy-events half is the one that was missed.
+
+        A review mutation that dropped the `service_id` predicate from the
+        copy-events DELETE survived the whole suite, because the isolation test
+        asserted only on `service_songs`. That mutation would erase a song's
+        reporting in EVERY service it has ever appeared in — the mirror image of
+        the harm this feature exists to prevent, and silent.
+        """
         from worship_catalog.db import Database
 
         db = Database(tmp_path / "t.db")
@@ -3619,15 +3635,59 @@ class TestDeleteServiceSong:
         db.insert_or_get_copy_event(svc1, song, "projection")
         db.insert_or_get_copy_event(svc2, song, "projection")
 
-        db.delete_service_song(svc1, song)
+        db.delete_setlist_entry(svc1, self._entry_id(db, svc1, song))
 
         assert [s["song_id"] for s in db.query_service_songs(svc2)] == [song], (
             "the other service lost the song too"
         )
+        surviving = [
+            e
+            for e in db.query_copy_events("2020-01-01", "2030-12-31")
+            if e["service_date"] == "2026-03-22"
+        ]
+        assert surviving, (
+            "the other service's COPY EVENTS were deleted — its CCLI reporting "
+            "for this song is gone"
+        )
         assert db.query_song_by_id(song) is not None, "the shared song row was deleted"
         db.close()
 
-    def test_returns_false_when_the_song_is_not_in_that_service(self, tmp_path):
+    def test_removes_one_occurrence_only_when_a_song_appears_twice(self, tmp_path):
+        """The case the feature exists for, and the one keying on song_id broke.
+
+        A blank slide mid-song closes a group, so the extractor renders one song
+        as two entries with the same song_id. Deleting by song_id removed BOTH —
+        the admin fixing the spurious half silently lost the real performance,
+        dropping it from the CCLI report.
+        """
+        from worship_catalog.db import Database
+
+        db = Database(tmp_path / "t.db")
+        db.connect()
+        db.init_schema()
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+        db.insert_service_song(svc, song, ordinal=1)
+        db.insert_service_song(svc, song, ordinal=4)
+        db.insert_or_get_copy_event(svc, song, "projection")
+
+        db.delete_setlist_entry(svc, self._entry_id(db, svc, song, ordinal=4))
+
+        ordinals = [s["ordinal"] for s in db.query_service_songs(svc)]
+        assert ordinals == [1], f"expected only ordinal 4 removed, setlist is {ordinals}"
+        assert [
+            e
+            for e in db.query_copy_events("2020-01-01", "2030-12-31")
+            if e["display_title"] == "Amazing Grace"
+        ], (
+            "the copy events were removed while the song is still in the setlist — "
+            "a real performance would vanish from the CCLI report"
+        )
+        db.close()
+
+    def test_returns_false_when_the_entry_is_not_in_that_service(self, tmp_path):
         """So the route can 404 instead of silently reporting success."""
         from worship_catalog.db import Database
 
@@ -3638,7 +3698,61 @@ class TestDeleteServiceSong:
         svc = db.insert_or_update_service(
             service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
         )
+        other = db.insert_or_update_service(
+            service_date="2026-03-22", service_name="AM", source_file="b", source_hash="b"
+        )
+        db.insert_service_song(svc, song, ordinal=1)
+        entry = self._entry_id(db, svc, song)
 
-        assert db.delete_service_song(svc, song) is False
-        assert db.delete_service_song(9999, song) is False
+        assert db.delete_setlist_entry(svc, 9999) is False
+        # A real entry id, but belonging to a different service — the service_id
+        # predicate is what stops one service deleting another's rows.
+        assert db.delete_setlist_entry(other, entry) is False
+        assert len(db.query_service_songs(svc)) == 1
+        db.close()
+
+    def test_a_false_return_has_not_already_deleted_the_copy_events(self, tmp_path):
+        """A 404 must never follow a committed destructive write (#617 review)."""
+        from worship_catalog.db import Database
+
+        db = Database(tmp_path / "t.db")
+        db.connect()
+        db.init_schema()
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+        db.insert_or_get_copy_event(svc, song, "projection")
+
+        assert db.delete_setlist_entry(svc, 12345) is False
+
+        events = db.query_copy_events("2020-01-01", "2030-12-31")
+        assert [e for e in events if e["display_title"] == "Amazing Grace"], (
+            "the copy events were deleted even though the method reported that "
+            "the entry was not in this service"
+        )
+        db.close()
+
+    def test_an_entry_with_no_copy_events_still_reports_success(self, tmp_path):
+        """Pins WHICH statement the return value comes from.
+
+        Every other fixture gives each setlist row a copy event, so nothing
+        distinguished rowcount read from the service_songs DELETE (correct) from
+        the copy_events DELETE (wrong). Under the wrong reading this row would be
+        deleted and then reported as False, and the route would answer 404 while
+        the data was gone.
+        """
+        from worship_catalog.db import Database
+
+        db = Database(tmp_path / "t.db")
+        db.connect()
+        db.init_schema()
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+        db.insert_service_song(svc, song, ordinal=1)  # no copy event at all
+
+        assert db.delete_setlist_entry(svc, self._entry_id(db, svc, song)) is True
+        assert db.query_service_songs(svc) == []
         db.close()

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -3549,3 +3549,96 @@ class TestServiceExclusions:
         temp_db.insert_or_update_service("2026-05-31", "Morning Worship", "f.pptx", "h3")
         rows = temp_db.query_exclusions("2026-05-01", "2026-05-31")
         assert len(rows) == 1 and rows[0]["service_slot"] == "evening"
+
+
+class TestDeleteServiceSong:
+    """Remove one misidentified song from a service, not the whole service (#323).
+
+    The extractor classifies slides, and it gets things wrong: service 36
+    (2026-03-15 PM) carried three non-song entries — a scripture reference and
+    two sermon-outline slides (#313, #314). Before this, the only remedy was
+    `cleanup delete-service` plus a full re-import, which needs CLI access the
+    church admin does not have.
+
+    The delete has to be surgical in two directions. It must remove the copy
+    events as well as the setlist row, because a copy event that outlives its
+    setlist entry keeps the phantom song in the CCLI report — the one place it
+    does real harm. And it must leave the `songs` row alone: songs are shared
+    across services, so deleting the row would erase the song's history
+    everywhere it legitimately appears.
+    """
+
+    def test_removes_the_setlist_row_and_its_copy_events(self, tmp_path):
+        from worship_catalog.db import Database
+
+        db = Database(tmp_path / "t.db")
+        db.connect()
+        db.init_schema()
+        song_a = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        song_b = db.insert_or_get_song("micah 6 6 8", "MICAH 6:6 – 8")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15",
+            service_name="PM Worship",
+            source_file="t.pptx",
+            source_hash="h",
+        )
+        db.insert_service_song(svc, song_a, ordinal=1)
+        db.insert_service_song(svc, song_b, ordinal=2)
+        db.insert_or_get_copy_event(svc, song_a, "projection")
+        db.insert_or_get_copy_event(svc, song_b, "projection")
+        db.insert_or_get_copy_event(svc, song_b, "recording")
+
+        assert db.delete_service_song(svc, song_b) is True
+
+        remaining = {s["song_id"] for s in db.query_service_songs(svc)}
+        assert remaining == {song_a}, "the misidentified song is still in the setlist"
+
+        events = db.query_copy_events("2020-01-01", "2030-12-31")
+        assert not [e for e in events if e["display_title"] == "MICAH 6:6 – 8"], (
+            "copy events outlived the setlist row — the phantom song would still "
+            "appear in the CCLI report, which is where it actually does harm"
+        )
+        db.close()
+
+    def test_leaves_the_song_row_alone_because_songs_are_shared(self, tmp_path):
+        """Deleting from one service must not erase the song's other appearances."""
+        from worship_catalog.db import Database
+
+        db = Database(tmp_path / "t.db")
+        db.connect()
+        db.init_schema()
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc1 = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+        svc2 = db.insert_or_update_service(
+            service_date="2026-03-22", service_name="AM", source_file="b", source_hash="b"
+        )
+        db.insert_service_song(svc1, song, ordinal=1)
+        db.insert_service_song(svc2, song, ordinal=1)
+        db.insert_or_get_copy_event(svc1, song, "projection")
+        db.insert_or_get_copy_event(svc2, song, "projection")
+
+        db.delete_service_song(svc1, song)
+
+        assert [s["song_id"] for s in db.query_service_songs(svc2)] == [song], (
+            "the other service lost the song too"
+        )
+        assert db.query_song_by_id(song) is not None, "the shared song row was deleted"
+        db.close()
+
+    def test_returns_false_when_the_song_is_not_in_that_service(self, tmp_path):
+        """So the route can 404 instead of silently reporting success."""
+        from worship_catalog.db import Database
+
+        db = Database(tmp_path / "t.db")
+        db.connect()
+        db.init_schema()
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+
+        assert db.delete_service_song(svc, song) is False
+        assert db.delete_service_song(9999, song) is False
+        db.close()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4659,3 +4659,110 @@ class TestCcliCsvContract:
         rows = list(csv.reader(io.StringIO(resp.text)))
         assert len(rows) == 1, f"expected header row only, got {rows}"
         assert rows[0][0] == "Date"
+
+
+class TestServiceSongDeletion:
+    """The church admin can remove a misidentified song without the CLI (#323).
+
+    The extractor gets things wrong — service 36 (2026-03-15 PM) carried three
+    non-song entries, a scripture reference and two sermon-outline slides
+    (#313, #314). Until now the only remedy was `cleanup delete-service` plus a
+    full re-import, which needs SSH access the primary user does not have. Every
+    extraction error therefore required developer intervention.
+    """
+
+    _CREDS = ("highland", "s3cret")
+
+    @pytest.fixture
+    def auth_client(self, db_with_songs, tmp_path, monkeypatch):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        monkeypatch.setenv("UPLOAD_PASSWORD", "s3cret")
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+
+        reload(app_module)
+        return CsrfAwareClient(TestClient(app_module.app))
+
+    def _song_ids(self, client):
+        """Authenticated on purpose — the controls only render for an editor."""
+        import re
+
+        body = client.get("/services/1", auth=self._CREDS).text
+        return re.findall(r"/services/1/songs/(\d+)/delete", body)
+
+    def test_delete_removes_the_song_from_the_service_page(self, auth_client):
+        before = auth_client.get("/services/1").text
+        assert "How Great Thou Art" in before
+
+        ids = self._song_ids(auth_client)
+        assert len(ids) == 2, f"expected a delete control per song, found {ids}"
+
+        # Harness detail, not behaviour under test: CsrfAwareClient caches the
+        # token it read from the FIRST response's Set-Cookie, and the page fetch
+        # above rotated the cookie. Re-read it from the jar — clearing the cache
+        # would be worse, because the re-fetch sends no Set-Cookie when the client
+        # already holds a valid cookie, and the wrapper would cache an empty token.
+        auth_client._csrf_token = auth_client._inner.cookies.get("csrftoken")
+
+        resp = auth_client.post(
+            "/services/1/songs/2/delete", auth=self._CREDS, follow_redirects=False
+        )
+        assert resp.status_code in (302, 303), resp.status_code
+        assert resp.headers["location"].endswith("/services/1")
+
+        after = auth_client.get("/services/1").text
+        assert "How Great Thou Art" not in after
+        assert "Amazing Grace" in after, "the wrong song was removed"
+
+    def test_deleted_song_no_longer_reaches_the_ccli_report(self, auth_client):
+        """The point of the feature. A phantom song in a licensing report is the
+        harm; removing it from a page the admin looks at is only the symptom."""
+        import csv
+        import io
+
+        auth_client.post("/services/1/songs/2/delete", auth=self._CREDS)
+        resp = auth_client.post(
+            "/reports/ccli", data={"start_date": "2020-01-01", "end_date": "2030-12-31"}
+        )
+        titles = {r["Title"] for r in csv.DictReader(io.StringIO(resp.text))}
+        assert "How Great Thou Art" not in titles
+        assert "Amazing Grace" in titles
+
+    def test_delete_requires_auth(self, auth_client):
+        """A destructive write on a publicly reachable site. Same gate as /upload."""
+        assert auth_client.post("/services/1/songs/2/delete").status_code == 401
+        assert "How Great Thou Art" in auth_client.get("/services/1").text
+
+    def test_delete_of_a_song_not_in_the_service_is_404(self, auth_client):
+        assert (
+            auth_client.post(
+                "/services/1/songs/9999/delete", auth=self._CREDS
+            ).status_code
+            == 404
+        )
+
+    def test_delete_on_an_unknown_service_is_404(self, auth_client):
+        assert (
+            auth_client.post(
+                "/services/9999/songs/1/delete", auth=self._CREDS
+            ).status_code
+            == 404
+        )
+
+    def test_controls_are_hidden_from_an_unauthenticated_viewer(self, auth_client):
+        """Same doctrine as the missing-services report (#483): the page stays
+        publicly readable, the edit controls do not appear."""
+        body = auth_client.get("/services/1").text
+        assert "/songs/2/delete" not in body
+        body_authed = auth_client.get("/services/1", auth=self._CREDS).text
+        assert "/songs/2/delete" in body_authed
+
+    def test_delete_control_asks_for_confirmation(self, auth_client):
+        """It is irreversible without a re-import, and the source file is gone
+        after upload (#138) — so a misclick has no cheap undo."""
+        body = auth_client.get("/services/1", auth=self._CREDS).text
+        assert "confirm" in body.lower()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4692,7 +4692,7 @@ class TestServiceSongDeletion:
         import re
 
         body = client.get("/services/1", auth=self._CREDS).text
-        return re.findall(r"/services/1/songs/(\d+)/delete", body)
+        return re.findall(r"/services/1/setlist/(\d+)/delete", body)
 
     def test_delete_removes_the_song_from_the_service_page(self, auth_client):
         before = auth_client.get("/services/1").text
@@ -4709,7 +4709,7 @@ class TestServiceSongDeletion:
         auth_client._csrf_token = auth_client._inner.cookies.get("csrftoken")
 
         resp = auth_client.post(
-            "/services/1/songs/2/delete", auth=self._CREDS, follow_redirects=False
+            "/services/1/setlist/2/delete", auth=self._CREDS, follow_redirects=False
         )
         assert resp.status_code in (302, 303), resp.status_code
         assert resp.headers["location"].endswith("/services/1")
@@ -4724,7 +4724,7 @@ class TestServiceSongDeletion:
         import csv
         import io
 
-        auth_client.post("/services/1/songs/2/delete", auth=self._CREDS)
+        auth_client.post("/services/1/setlist/2/delete", auth=self._CREDS)
         resp = auth_client.post(
             "/reports/ccli", data={"start_date": "2020-01-01", "end_date": "2030-12-31"}
         )
@@ -4734,13 +4734,13 @@ class TestServiceSongDeletion:
 
     def test_delete_requires_auth(self, auth_client):
         """A destructive write on a publicly reachable site. Same gate as /upload."""
-        assert auth_client.post("/services/1/songs/2/delete").status_code == 401
+        assert auth_client.post("/services/1/setlist/2/delete").status_code == 401
         assert "How Great Thou Art" in auth_client.get("/services/1").text
 
-    def test_delete_of_a_song_not_in_the_service_is_404(self, auth_client):
+    def test_delete_of_an_entry_not_in_the_service_is_404(self, auth_client):
         assert (
             auth_client.post(
-                "/services/1/songs/9999/delete", auth=self._CREDS
+                "/services/1/setlist/9999/delete", auth=self._CREDS
             ).status_code
             == 404
         )
@@ -4748,7 +4748,7 @@ class TestServiceSongDeletion:
     def test_delete_on_an_unknown_service_is_404(self, auth_client):
         assert (
             auth_client.post(
-                "/services/9999/songs/1/delete", auth=self._CREDS
+                "/services/9999/setlist/1/delete", auth=self._CREDS
             ).status_code
             == 404
         )
@@ -4757,30 +4757,47 @@ class TestServiceSongDeletion:
         """Same doctrine as the missing-services report (#483): the page stays
         publicly readable, the edit controls do not appear."""
         body = auth_client.get("/services/1").text
-        assert "/songs/2/delete" not in body
+        assert "/setlist/2/delete" not in body
         body_authed = auth_client.get("/services/1", auth=self._CREDS).text
-        assert "/songs/2/delete" in body_authed
+        assert "/setlist/2/delete" in body_authed
 
-    def test_delete_control_asks_for_confirmation(self, auth_client):
-        """It is irreversible without a re-import, and the source file is gone
-        after upload (#138) — so a misclick has no cheap undo."""
+    def test_delete_control_is_wired_to_its_confirming_script(self, auth_client):
+        """It is irreversible without a re-import, and the source deck is deleted
+        after upload (#138), so a misclick has no cheap undo.
+
+        This used to assert `"confirm" in body` — which was true of an inline
+        handler that CSP refuses to execute, i.e. it passed while no confirmation
+        could possibly appear. It now asserts the control is bound to the external
+        script that does the confirming; TestServiceSongDeleteControlEscaping
+        covers what that script contains.
+        """
         body = auth_client.get("/services/1", auth=self._CREDS).text
-        assert "confirm" in body.lower()
+        assert "/static/service_detail.js" in body
+        assert "onsubmit" not in body, (
+            "an inline handler is silently blocked by CSP script-src 'self'"
+        )
 
 
 class TestServiceSongDeleteControlEscaping:
-    """Song titles are untrusted, and the delete control must survive them (#323).
+    """The delete control must survive untrusted titles AND actually work (#323).
 
-    Titles come from OCR and from PowerPoint decks, so they carry whatever the
-    slide carried. The confirm() message originally interpolated the title
-    straight into a JavaScript string inside an HTML attribute, which does not
-    work: Jinja autoescaping is HTML escaping, so an apostrophe becomes `&#39;`,
-    the HTML parser decodes it back to `'` BEFORE the attribute is parsed as
-    JavaScript, and the string literal terminates early.
+    Three separate ways this control was silently broken, all found in a real
+    browser and none visible from a passing test suite:
 
-    That is not a theoretical title. "I'll Fly Away" is a standard hymn — it
-    would have broken the handler, so the confirm never fires and the form
-    submits unconfirmed, on the one control in the app that destroys data.
+    1. The confirm() message interpolated the title into a JavaScript string
+       inside an HTML attribute. Jinja autoescaping is HTML escaping, so an
+       apostrophe becomes `&#39;` and the HTML parser decodes it back to `'`
+       BEFORE the attribute is parsed as JS — the string terminates early.
+       "I'll Fly Away" is enough; `');alert(1);//` executes.
+    2. A plain `<form method="post">` sends no `X-CSRFToken` header, and the
+       middleware reads the token from nowhere else. Every browser click was
+       403. A hidden form field would not have helped.
+    3. `script-src 'self'` refuses inline event handlers, so the confirm never
+       ran — meaning once (2) was fixed a misclick would destroy data silently.
+
+    The test client sets the CSRF header itself and executes no JavaScript, so
+    it cannot see (2) or (3). These tests assert the structural properties that
+    make those failures impossible instead.
     """
 
     _CREDS = ("highland", "s3cret")
@@ -4817,43 +4834,75 @@ class TestServiceSongDeleteControlEscaping:
         reload(app_module)
         return CsrfAwareClient(TestClient(app_module.app))
 
-    def _onsubmit_lines(self, client):
-        body = client.get("/services/1", auth=self._CREDS).text
-        return [ln for ln in body.splitlines() if "onsubmit" in ln]
+    def test_no_template_uses_an_inline_event_handler(self):
+        """The guard the repo did not have.
 
-    def test_an_apostrophe_title_does_not_break_out_of_the_js_string(
+        `TestUploadFormCSPCompatible` scans for inline <script> tags, which is why
+        an inline `onsubmit` slipped past it. CSP `script-src 'self'` blocks inline
+        event handlers too, and hashes do not apply to them — only `unsafe-hashes`
+        would, and the app does not send it. Review #247 was the same defect class.
+        """
+        import re
+        from pathlib import Path
+
+        import worship_catalog.web as web_pkg
+
+        templates = Path(web_pkg.__file__).parent / "templates"
+        offenders = []
+        for tpl in templates.glob("*.html"):
+            for i, line in enumerate(tpl.read_text().splitlines(), 1):
+                if re.search(r"\son(?:submit|click|change|input|load|error)\s*=", line):
+                    offenders.append(f"{tpl.name}:{i}: {line.strip()[:90]}")
+        assert not offenders, (
+            "inline event handlers are blocked by CSP script-src 'self' and will "
+            "silently never run:\n" + "\n".join(offenders)
+        )
+
+    def test_the_delete_form_carries_no_inline_handler(self, hostile_client):
+        body = hostile_client.get("/services/1", auth=self._CREDS).text
+        form_lines = [ln for ln in body.splitlines() if "/delete" in ln]
+        assert form_lines, "no delete control rendered for an authenticated viewer"
+        for line in form_lines:
+            assert "onsubmit" not in line, line
+
+    def test_the_editor_page_loads_the_script_that_binds_the_control(
         self, hostile_client
     ):
-        lines = self._onsubmit_lines(hostile_client)
-        assert len(lines) == 2, lines
-        for line in lines:
-            assert "&#39;" not in line, (
-                "the title is being interpolated into the onsubmit JavaScript; "
-                "the HTML parser decodes &#39; to an apostrophe before the "
-                f"attribute is parsed as JS, terminating the string: {line}"
-            )
-
-    def test_a_hostile_title_cannot_reach_the_js_source(self, hostile_client):
+        """Without it there is no confirm and no CSRF header — a dead button."""
         body = hostile_client.get("/services/1", auth=self._CREDS).text
-        # Unescaped anywhere on the page would be the plain XSS.
+        assert "/static/service_detail.js" in body
+        public = hostile_client.get("/services/1").text
+        assert "/static/service_detail.js" not in public, (
+            "the script is only useful to an editor and should not load publicly"
+        )
+
+    def test_the_script_sends_the_csrf_header(self, hostile_client):
+        """The one property that makes the endpoint reachable from a browser.
+
+        The middleware reads the token only from the X-CSRFToken header; a form
+        field is ignored. Asserted on the served asset, not the source tree, so a
+        packaging mistake is caught too.
+        """
+        resp = hostile_client.get("/static/service_detail.js")
+        assert resp.status_code == 200, resp.status_code
+        assert "X-CSRFToken" in resp.text
+        assert "csrftoken" in resp.text
+
+    def test_the_title_travels_in_a_data_attribute_html_escaped(self, hostile_client):
+        body = hostile_client.get("/services/1", auth=self._CREDS).text
+        assert 'data-song-title="I&#39;ll Fly Away"' in body
+        assert 'data-song-title="&#39;);alert(1);//"' in body
         assert "');alert(1);//" not in body, (
             "an unescaped hostile title reached the page source"
         )
-        # And it must not appear in the JS attribute even escaped: the HTML parser
-        # decodes entities before the attribute is parsed as JavaScript, so an
-        # escaped payload there still executes.
-        for line in self._onsubmit_lines(hostile_client):
-            assert "alert" not in line, f"title reached the onsubmit JS: {line}"
-        # It IS present, HTML-escaped, in the data attribute — which is inert.
-        assert "data-song-title=\"&#39;);alert(1);//\"" in body
 
-    def test_the_title_is_still_shown_to_the_user_in_the_confirm(self, hostile_client):
-        """The escaping fix must not silently drop the title from the message —
-        'Remove this song?' with no name is how the wrong row gets deleted."""
-        lines = self._onsubmit_lines(hostile_client)
-        for line in lines:
-            assert "dataset.songTitle" in line, (
-                f"confirm no longer names the song being removed: {line}"
-            )
-        body = hostile_client.get("/services/1", auth=self._CREDS).text
-        assert 'data-song-title="I&#39;ll Fly Away"' in body
+    def test_the_confirm_still_names_the_song(self):
+        """The escaping fix must not solve the problem by dropping the title —
+        "Remove this song?" with no name is how the wrong row gets deleted."""
+        from pathlib import Path
+
+        import worship_catalog.web as web_pkg
+
+        js = (Path(web_pkg.__file__).parent / "static" / "service_detail.js").read_text()
+        assert "data-song-title" in js
+        assert "confirm" in js

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4766,3 +4766,94 @@ class TestServiceSongDeletion:
         after upload (#138) — so a misclick has no cheap undo."""
         body = auth_client.get("/services/1", auth=self._CREDS).text
         assert "confirm" in body.lower()
+
+
+class TestServiceSongDeleteControlEscaping:
+    """Song titles are untrusted, and the delete control must survive them (#323).
+
+    Titles come from OCR and from PowerPoint decks, so they carry whatever the
+    slide carried. The confirm() message originally interpolated the title
+    straight into a JavaScript string inside an HTML attribute, which does not
+    work: Jinja autoescaping is HTML escaping, so an apostrophe becomes `&#39;`,
+    the HTML parser decodes it back to `'` BEFORE the attribute is parsed as
+    JavaScript, and the string literal terminates early.
+
+    That is not a theoretical title. "I'll Fly Away" is a standard hymn — it
+    would have broken the handler, so the confirm never fires and the form
+    submits unconfirmed, on the one control in the app that destroys data.
+    """
+
+    _CREDS = ("highland", "s3cret")
+
+    @pytest.fixture
+    def hostile_client(self, tmp_path, monkeypatch):
+        from worship_catalog.db import Database
+
+        db_path = tmp_path / "t.db"
+        db = Database(db_path)
+        db.connect()
+        db.init_schema()
+        a = db.insert_or_get_song("ill fly away", "I'll Fly Away")
+        b = db.insert_or_get_song("hostile", "');alert(1);//")
+        svc = db.insert_or_update_service(
+            service_date="2026-02-15",
+            service_name="AM Worship",
+            source_file="t.pptx",
+            source_hash="h",
+        )
+        db.insert_service_song(svc, a, ordinal=1)
+        db.insert_service_song(svc, b, ordinal=2)
+        db.close()
+
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_path))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        monkeypatch.setenv("UPLOAD_PASSWORD", "s3cret")
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+
+        reload(app_module)
+        return CsrfAwareClient(TestClient(app_module.app))
+
+    def _onsubmit_lines(self, client):
+        body = client.get("/services/1", auth=self._CREDS).text
+        return [ln for ln in body.splitlines() if "onsubmit" in ln]
+
+    def test_an_apostrophe_title_does_not_break_out_of_the_js_string(
+        self, hostile_client
+    ):
+        lines = self._onsubmit_lines(hostile_client)
+        assert len(lines) == 2, lines
+        for line in lines:
+            assert "&#39;" not in line, (
+                "the title is being interpolated into the onsubmit JavaScript; "
+                "the HTML parser decodes &#39; to an apostrophe before the "
+                f"attribute is parsed as JS, terminating the string: {line}"
+            )
+
+    def test_a_hostile_title_cannot_reach_the_js_source(self, hostile_client):
+        body = hostile_client.get("/services/1", auth=self._CREDS).text
+        # Unescaped anywhere on the page would be the plain XSS.
+        assert "');alert(1);//" not in body, (
+            "an unescaped hostile title reached the page source"
+        )
+        # And it must not appear in the JS attribute even escaped: the HTML parser
+        # decodes entities before the attribute is parsed as JavaScript, so an
+        # escaped payload there still executes.
+        for line in self._onsubmit_lines(hostile_client):
+            assert "alert" not in line, f"title reached the onsubmit JS: {line}"
+        # It IS present, HTML-escaped, in the data attribute — which is inert.
+        assert "data-song-title=\"&#39;);alert(1);//\"" in body
+
+    def test_the_title_is_still_shown_to_the_user_in_the_confirm(self, hostile_client):
+        """The escaping fix must not silently drop the title from the message —
+        'Remove this song?' with no name is how the wrong row gets deleted."""
+        lines = self._onsubmit_lines(hostile_client)
+        for line in lines:
+            assert "dataset.songTitle" in line, (
+                f"confirm no longer names the song being removed: {line}"
+            )
+        body = hostile_client.get("/services/1", auth=self._CREDS).text
+        assert 'data-song-title="I&#39;ll Fly Away"' in body


### PR DESCRIPTION
Closes #323 (the delete half). Re-import is split out to #616 — **it is blocked, and building it would have shipped a button that fails.**

## Why

The extractor classifies slides and gets things wrong: service 36 (2026-03-15 PM) carried a scripture reference and two sermon-outline slides as songs (#313, #314). The only remedy was `cleanup delete-service` plus a full re-import — CLI access the church admin does not have. Every extraction error needed a developer, and #313/#314 prove they happen.

## What

`POST /services/{id}/songs/{song_id}/delete`, gated by the same upload auth as `/upload` and the missing-services edits (#483) — a destructive write on a publicly reachable site. **303**, not 200, so a refresh re-issues the GET rather than re-posting a delete that would now 404. The page stays publicly readable; controls render only for an authenticated viewer, and **the route enforces auth itself** rather than relying on the template hiding them.

The delete is surgical in two directions, both tested:

- **It removes the copy events too.** A copy event that outlives its setlist row keeps the phantom song in the **CCLI report** — which is where a misidentified song actually does harm, because it gets submitted to a licensing body. There is a test asserting the deleted song is gone from the CSV, not merely from the page.
- **It does not touch the `songs` row.** Songs are shared across services; deleting it would erase the song's history everywhere it legitimately appears, to fix one slide that was misread.

Ordinals are deliberately not renumbered — unique per service but not required to be contiguous, and a gap is honest: it says a slide was removed.

## Re-import is blocked, with evidence

#323 proposed triggering `run_import()` on `services.source_file`. `run_import()` really is idempotent and the column really holds a path — but `web/app.py` deletes the uploaded deck in the `finally` of every import, success or failure (#138):

```python
# Always clean up the inbox file regardless of success or failure (#138)
if pptx_path.exists():
    pptx_path.unlink()
```

So for anything uploaded through the web UI — everything the admin does — that path dangles. Worse, a CLI-imported service may still have its file, so the feature would appear to work for the developer and fail for the actual user. Options and their trades are in #616. Re-uploading the same deck already works today and may be the whole answer.

## Tests

| Test | Proves |
|---|---|
| `test_removes_the_setlist_row_and_its_copy_events` | copy events go too |
| `test_leaves_the_song_row_alone_because_songs_are_shared` | other services keep the song |
| `test_returns_false_when_the_song_is_not_in_that_service` | the route can 404 rather than report a no-op success |
| `test_deleted_song_no_longer_reaches_the_ccli_report` | the actual point — gone from the CSV |
| `test_delete_requires_auth` | 401 unauthenticated, and the song survives |
| `test_controls_are_hidden_from_an_unauthenticated_viewer` | page public, controls not |
| `test_delete_control_asks_for_confirmation` | irreversible without the deck, which is gone |
| 404 cases for unknown service and unknown song | a stale page's button reports something rather than appearing to succeed |

`ruff` and `mypy` clean; `test_web`, `test_web_security`, `test_accessibility`, `test_db_integration` — **682 passed**.
