### PR TITLE
chore(deploy): pin the Pi to the Sprint 8 build

### DIFF
--- a/deploy/pi/docker-compose.yml
+++ b/deploy/pi/docker-compose.yml
@@ -46,15 +46,15 @@ services:
     # :latest silently swaps running app code with no digest record and no
     # rollback target. Pin to the sha- tag + digest CI publishes; Dependabot's
     # `docker` ecosystem entry (#502) bumps this on a reviewed PR.
-    # Tag sha-<commit> = main@1af1d57, released as v1.6.0. Digest is from the
-    # release build (run 30729704380), which bakes version `1.6.0`.
+    # Tag sha-<commit> = main@04c98ee (Sprint 8). Digest is from the
+    # workflow_dispatch build of main (run 30736475295).
     #
     # The sha- TAG is not immutable in practice: the release workflow (#583)
     # rebuilds the same commit for the version tags and re-pushes sha-<commit>
     # along with them, so it moved from sha256:2df310d1 (the main-ref build) to
     # the digest below for identical source. The digest is what actually pins —
     # this is the drift #512 was about, observed rather than theorised.
-    image: ghcr.io/mshirel/song-history:sha-1af1d5723fb61ad8a3de59c1458009ad7d65d011@sha256:9266dc8db785cc1553d2e9290d9602e64db62d915634ef80f1df8f2ac28d68dd
+    image: ghcr.io/mshirel/song-history:sha-04c98ee0f5b3a7aa8da7bd5e8c7616c1214025f5@sha256:2f93a2c0820544cffd819970d050e7603a7b29c3388dddab5d771263d3dc4661
     restart: unless-stopped
     init: true
     # The app image ships a HEALTHCHECK that probes :8000 (#402); the watcher
@@ -95,9 +95,9 @@ services:
   song-history:
     # Immutably pinned (#512) — was the mutable :latest. Keep this in lockstep
     # with the `watcher` service above; Dependabot (#502) bumps both.
-    # Tag sha-<commit> = main@1af1d57, released as v1.6.0 (see the note above on
-    # why the digest, not the tag, is the pin).
-    image: ghcr.io/mshirel/song-history:sha-1af1d5723fb61ad8a3de59c1458009ad7d65d011@sha256:9266dc8db785cc1553d2e9290d9602e64db62d915634ef80f1df8f2ac28d68dd
+    # Tag sha-<commit> = main@04c98ee (Sprint 8); see the note above on why the
+    # digest, not the tag, is the pin.
+    image: ghcr.io/mshirel/song-history:sha-04c98ee0f5b3a7aa8da7bd5e8c7616c1214025f5@sha256:2f93a2c0820544cffd819970d050e7603a7b29c3388dddab5d771263d3dc4661
     restart: unless-stopped
     # Bound the public upload process on the 512 MB Pi host (#503). Uploads are
     # streamed to disk, so even the 200 MB maximum file fits this budget.


### PR DESCRIPTION
Sprint 8 batch close. Pins `deploy/pi/docker-compose.yml` to `main@04c98ee`, published by workflow_dispatch run [30736475295](https://github.com/mshirel/song-history/actions/runs/30736475295).

```
ghcr.io/mshirel/song-history:sha-04c98ee0f5b3a7aa8da7bd5e8c7616c1214025f5
  @sha256:2f93a2c0820544cffd819970d050e7603a7b29c3388dddab5d771263d3dc4661
```

Digest resolved from **GHCR**, not scraped from the build log — the log carries every layer hash and picking the wrong one pins something that is not the image. The manifest index has a **linux/arm64** child (`sha256:50bd6a1e…`), which is what the Pi needs.

Ships: #541 (rate_limits.db WAL), #554 (OCR budget-exhausted boundary anomaly), #86 (CCLI export contract tests + reproduction-type constants), #323 (setlist-entry delete control).

Both services stay in lockstep. `tests/test_ci_config.py` — 38 passed.