### PR TITLE
fix(db): remove a song when its last appearance is deleted

### DIFF
--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1169,12 +1169,24 @@ class Database:
         the occurrences; deleting them while another entry survives would erase
         that song's reporting for the service it is still in.
 
-        Two things this deliberately does NOT do:
+        The ``songs`` row goes only when the deleted entry was its LAST
+        appearance anywhere (#618). Songs are shared across services, so
+        deleting one to fix a single misread slide would erase its history
+        everywhere it legitimately appears — but a song with no appearances at
+        all is not shared with anyone. Left behind it stays listed in the public
+        catalogue with zero performances, and clearing it needs the CLI access
+        this whole feature exists to avoid: #313/#314 are a scripture reference
+        and two sermon-outline slides, each appearing exactly once, and they are
+        the reason the delete exists.
 
-        * It does not touch the ``songs`` row. Songs are shared across services;
-          deleting it would erase the song's history everywhere it legitimately
-          appears, to fix one slide that was misread. A song left with no
-          appearances at all is tracked separately (#618).
+        THE COUNT IS GLOBAL, NOT PER-SERVICE — the one place this is easy to get
+        wrong, because the copy-events count directly above it is correctly
+        scoped to ``service_id`` and this one must not be. Scoped, it would
+        delete a song another service is still performing, taking that service's
+        setlist row and CCLI reporting with it.
+
+        One thing this deliberately does NOT do:
+
         * It does not renumber the remaining ``ordinal`` values. They are unique
           per service but need not be contiguous, and a gap is honest — it says a
           slide was removed. (A later re-import is unaffected: ``run_import``
@@ -1222,10 +1234,39 @@ class Database:
                     "DELETE FROM copy_events WHERE service_id = ? AND song_id = ?",
                     (service_id, song_id),
                 )
+
+            # NO service_id predicate here, unlike every query above it (#618).
+            # This asks "does this song appear ANYWHERE any more", and only a
+            # song that appears nowhere may be deleted.
+            appearances = cursor.execute(
+                "SELECT COUNT(*) AS n FROM service_songs WHERE song_id = ?",
+                (song_id,),
+            ).fetchone()["n"]
+            if appearances == 0:
+                self._delete_song_rows(cursor, song_id)
         # sqlite3 runs at its default isolation_level, so these statements share
         # one implicit transaction: a process death between them cannot half-commit.
         self._maybe_commit()
         return removed
+
+    @staticmethod
+    def _delete_song_rows(cursor: sqlite3.Cursor, song_id: int) -> None:
+        """Delete a song and everything keyed on it, without committing.
+
+        Shared by ``delete_song`` (the CLI's ``cleanup orphaned-songs``) and
+        ``delete_setlist_entry`` so there is one definition of what "remove a
+        song" means. Neither ``song_editions`` nor ``copy_events`` is reachable
+        from ``songs`` by a database constraint, so a partial delete leaves rows
+        nothing will ever notice — and a surviving copy event keeps the phantom
+        song in the CCLI report, which is where a misidentified song does its
+        real harm.
+
+        Does not commit: the caller owns the transaction.
+        """
+        cursor.execute("DELETE FROM copy_events WHERE song_id = ?", (song_id,))
+        cursor.execute("DELETE FROM service_songs WHERE song_id = ?", (song_id,))
+        cursor.execute("DELETE FROM song_editions WHERE song_id = ?", (song_id,))
+        cursor.execute("DELETE FROM songs WHERE id = ?", (song_id,))
 
     # ------------------------------------------------------------------
     # Import job methods (#45)
@@ -1707,10 +1748,7 @@ class Database:
     def delete_song(self, song_id: int) -> None:
         """Delete a song, its editions, and any related copy_events."""
         cursor = self._conn.cursor()
-        cursor.execute("DELETE FROM copy_events WHERE song_id = ?", (song_id,))
-        cursor.execute("DELETE FROM service_songs WHERE song_id = ?", (song_id,))
-        cursor.execute("DELETE FROM song_editions WHERE song_id = ?", (song_id,))
-        cursor.execute("DELETE FROM songs WHERE id = ?", (song_id,))
+        self._delete_song_rows(cursor, song_id)
         self._maybe_commit()
 
     def query_song_by_id(self, song_id: int) -> dict[str, Any] | None:

--- a/src/worship_catalog/db.py
+++ b/src/worship_catalog/db.py
@@ -1244,6 +1244,16 @@ class Database:
             ).fetchone()["n"]
             if appearances == 0:
                 self._delete_song_rows(cursor, song_id)
+                # The one destructive step here that reaches beyond the service
+                # the admin was looking at, so it leaves a record. Without it the
+                # only trace of a song's disappearance is its absence, and
+                # "where did that song go?" has no answer short of a backup diff.
+                _log.info(
+                    "deleted orphaned song song_id=%d after its last appearance "
+                    "was removed from service_id=%d",
+                    song_id,
+                    service_id,
+                )
         # sqlite3 runs at its default isolation_level, so these statements share
         # one implicit transaction: a process death between them cannot half-commit.
         self._maybe_commit()

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -3756,3 +3756,182 @@ class TestDeleteSetlistEntry:
         assert db.delete_setlist_entry(svc, self._entry_id(db, svc, song)) is True
         assert db.query_service_songs(svc) == []
         db.close()
+
+
+class TestOrphanedSongAfterDeletion:
+    """Removing a song's LAST appearance removes the song itself (#618).
+
+    #617 shipped the delete half of #323 and deliberately left the `songs` row
+    alone — songs are shared across services, and erasing one to fix a single
+    misread slide would destroy its history everywhere it legitimately appears.
+    Right call, but it half-fixes the motivating case. #313/#314 are a scripture
+    reference and two sermon-outline slides misread as songs; each appears
+    exactly once. After the admin removes them, the rows survive with zero
+    performances and stay listed publicly at songs.highland-coc.com, and
+    clearing them still needs the CLI access the whole feature exists to avoid.
+
+    So the song goes when — and only when — nothing references it any more. The
+    guard is the whole risk of this change, and it fails in two directions:
+
+    * Count per-service (a copy-paste of the copy-events count directly above
+      it, which IS correctly service-scoped) and a song used in another service
+      is destroyed along with its entire history.
+    * Count only `service_songs` rows in this service while the song appears
+      twice here, and a real performance vanishes from the CCLI report.
+
+    Both are silent. Each test below fails under exactly one of them.
+    """
+
+    def _entry_id(self, db, service_id, song_id, ordinal=None):
+        rows = [
+            r
+            for r in db.query_service_songs(service_id)
+            if r["song_id"] == song_id and (ordinal is None or r["ordinal"] == ordinal)
+        ]
+        assert rows, f"no setlist entry for song {song_id} in service {service_id}"
+        return rows[0]["entry_id"]
+
+    def _db(self, tmp_path):
+        from worship_catalog.db import Database
+
+        db = Database(tmp_path / "t.db")
+        db.connect()
+        db.init_schema()
+        return db
+
+    def test_a_song_with_no_remaining_appearances_is_deleted(self, tmp_path):
+        """The #313/#314 case: one misread slide, one appearance, now gone."""
+        db = self._db(tmp_path)
+        keeper = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        misread = db.insert_or_get_song("micah 6 6 8", "MICAH 6:6 – 8")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="PM", source_file="a", source_hash="a"
+        )
+        db.insert_service_song(svc, keeper, ordinal=1)
+        db.insert_service_song(svc, misread, ordinal=2)
+
+        assert db.delete_setlist_entry(svc, self._entry_id(db, svc, misread)) is True
+
+        assert db.query_song_by_id(misread) is None, (
+            "the song row survived with zero performances — it stays listed in "
+            "the public catalogue and still needs the CLI to clear"
+        )
+        assert [s["song_id"] for s in db.query_orphaned_songs()] == [], (
+            "the delete left an orphan behind for `cleanup orphaned-songs` to sweep"
+        )
+        assert db.query_song_by_id(keeper) is not None, "the wrong song was deleted"
+        db.close()
+
+    def test_a_song_still_used_in_another_service_is_untouched(self, tmp_path):
+        """The guard must count appearances GLOBALLY, not within this service.
+
+        Scoped to `service_id` — the shape of the copy-events count immediately
+        above it — this deletes a song that another service is still using,
+        taking that service's setlist row and CCLI reporting with it.
+        """
+        db = self._db(tmp_path)
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc1 = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+        svc2 = db.insert_or_update_service(
+            service_date="2026-03-22", service_name="AM", source_file="b", source_hash="b"
+        )
+        db.insert_service_song(svc1, song, ordinal=1)
+        db.insert_service_song(svc2, song, ordinal=1)
+        db.insert_or_get_copy_event(svc2, song, "projection")
+
+        db.delete_setlist_entry(svc1, self._entry_id(db, svc1, song))
+
+        assert db.query_song_by_id(song) is not None, (
+            "a song still performed in another service was deleted"
+        )
+        assert [s["song_id"] for s in db.query_service_songs(svc2)] == [song], (
+            "the other service's setlist row went with the song"
+        )
+        assert [
+            e
+            for e in db.query_copy_events("2020-01-01", "2030-12-31")
+            if e["service_date"] == "2026-03-22"
+        ], "the other service's CCLI reporting for this song is gone"
+        db.close()
+
+    def test_a_second_appearance_in_the_same_service_keeps_the_song(self, tmp_path):
+        """`service_songs` is UNIQUE(service_id, ordinal), not (service_id, song_id).
+
+        A blank slide mid-song closes a group, so the extractor renders one song
+        as two entries with the same song_id — exactly the case this feature is
+        used on. Removing the spurious half must leave the real performance.
+        """
+        db = self._db(tmp_path)
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+        db.insert_service_song(svc, song, ordinal=1)
+        db.insert_service_song(svc, song, ordinal=4)
+        db.insert_or_get_copy_event(svc, song, "projection")
+
+        db.delete_setlist_entry(svc, self._entry_id(db, svc, song, ordinal=4))
+
+        assert db.query_song_by_id(song) is not None, (
+            "the song was deleted while it is still in this service's setlist"
+        )
+        assert [s["ordinal"] for s in db.query_service_songs(svc)] == [1]
+        db.close()
+
+    def test_the_orphans_editions_and_copy_events_go_with_it(self, tmp_path):
+        """No dangling rows keyed on a song_id that no longer exists.
+
+        `song_editions` and `copy_events` both key on `song_id` with no database
+        constraint that would notice. A leftover edition is invisible; a leftover
+        copy event is not — it keeps the phantom song in the CCLI report, which
+        is the one place a misidentified song does real harm.
+        """
+        db = self._db(tmp_path)
+        misread = db.insert_or_get_song("micah 6 6 8", "MICAH 6:6 – 8")
+        edition = db.insert_or_get_song_edition(
+            misread, words_by="nobody", music_by=None, arranger=None
+        )
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="PM", source_file="a", source_hash="a"
+        )
+        db.insert_service_song(svc, misread, ordinal=1, song_edition_id=edition)
+        db.insert_or_get_copy_event(svc, misread, "projection", song_edition_id=edition)
+
+        db.delete_setlist_entry(svc, self._entry_id(db, svc, misread))
+
+        assert db.query_song_by_id(misread) is None
+        assert db.query_song_editions(misread) == [], (
+            "song_editions rows outlived the song they belong to"
+        )
+        assert not [
+            e
+            for e in db.query_copy_events("2020-01-01", "2030-12-31")
+            if e["display_title"] == "MICAH 6:6 – 8"
+        ], "a copy event outlived the song — the phantom is still in the CCLI report"
+        db.close()
+
+    def test_a_missing_entry_deletes_nothing_at_all(self, tmp_path):
+        """A False return must not have destroyed a song on the way out.
+
+        The song-delete is the last statement in the method, so a guard that
+        reads a stale `removed` — or none at all — would answer 404 to the admin
+        while having erased the song. #617's review found this exact shape once
+        already, in the copy-events delete.
+        """
+        db = self._db(tmp_path)
+        song = db.insert_or_get_song("amazing grace", "Amazing Grace")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="AM", source_file="a", source_hash="a"
+        )
+        db.insert_service_song(svc, song, ordinal=1)
+
+        assert db.delete_setlist_entry(svc, 9999) is False
+
+        assert db.query_song_by_id(song) is not None, (
+            "the method reported the entry was not in this service, and deleted "
+            "a song anyway"
+        )
+        assert len(db.query_service_songs(svc)) == 1
+        db.close()

--- a/tests/test_db_integration.py
+++ b/tests/test_db_integration.py
@@ -3912,6 +3912,32 @@ class TestOrphanedSongAfterDeletion:
         ], "a copy event outlived the song — the phantom is still in the CCLI report"
         db.close()
 
+    def test_the_song_delete_is_recorded_in_the_log(self, tmp_path, caplog):
+        """A destructive step that reaches past what the admin was looking at.
+
+        The admin's action was "remove this song from this service"; the effect
+        is also "and delete the song". Without a log line the only trace of a
+        song's disappearance is its absence, and "where did that song go?" has
+        no answer short of diffing a backup.
+        """
+        import logging
+
+        db = self._db(tmp_path)
+        misread = db.insert_or_get_song("micah 6 6 8", "MICAH 6:6 - 8")
+        svc = db.insert_or_update_service(
+            service_date="2026-03-15", service_name="PM", source_file="a", source_hash="a"
+        )
+        db.insert_service_song(svc, misread, ordinal=1)
+
+        with caplog.at_level(logging.INFO, logger="worship_catalog.db"):
+            db.delete_setlist_entry(svc, self._entry_id(db, svc, misread))
+
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("deleted orphaned song" in m and f"song_id={misread}" in m for m in messages), (
+            f"the song delete left no record: {messages}"
+        )
+        db.close()
+
     def test_a_missing_entry_deletes_nothing_at_all(self, tmp_path):
         """A False return must not have destroyed a song on the way out.
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4906,3 +4906,90 @@ class TestServiceSongDeleteControlEscaping:
         js = (Path(web_pkg.__file__).parent / "static" / "service_detail.js").read_text()
         assert "data-song-title" in js
         assert "confirm" in js
+
+
+class TestOrphanedSongIsNotLeftInThePublicCatalogue:
+    """After the last appearance goes, the song must leave /songs too (#618).
+
+    The delete shipped in #617 fixes the service page. It did not fix the page
+    the church's visitors actually see: `query_songs_paginated` LEFT JOINs
+    `service_songs` with no HAVING guard, so a song with zero performances is
+    still listed. #313/#314 — a scripture reference and two sermon-outline
+    slides misread as songs — would stay visible at songs.highland-coc.com
+    forever, and clearing them would still need the CLI the feature exists to
+    avoid. Reproduced by the #617 reviewer:
+
+        /songs after removing its only appearance: [('MICAH 6:6 - 8', 0)]
+
+    Asserted end-to-end through HTTP on purpose: the DB-level tests pin
+    `delete_setlist_entry`, but only the rendered page proves the public
+    catalogue actually changed.
+    """
+
+    _CREDS = ("highland", "s3cret")
+
+    @pytest.fixture
+    def auth_client(self, db_with_songs, tmp_path, monkeypatch):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        monkeypatch.setenv("UPLOAD_PASSWORD", "s3cret")
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+
+        reload(app_module)
+        return CsrfAwareClient(TestClient(app_module.app))
+
+    def test_a_song_with_no_remaining_appearances_leaves_the_public_catalogue(
+        self, auth_client
+    ):
+        assert "How Great Thou Art" in auth_client.get("/songs").text
+        assert auth_client.get("/songs/2").status_code == 200
+
+        # Harness detail, not behaviour: CsrfAwareClient caches the token from
+        # the FIRST response's Set-Cookie and the page fetches above rotated the
+        # cookie. Re-read from the jar — clearing the cache is worse, because a
+        # re-fetch sends no Set-Cookie once the client holds a valid cookie.
+        auth_client._csrf_token = auth_client._inner.cookies.get("csrftoken")
+        resp = auth_client.post(
+            "/services/1/setlist/2/delete", auth=self._CREDS, follow_redirects=False
+        )
+        assert resp.status_code in (302, 303), resp.status_code
+
+        after = auth_client.get("/songs").text
+        assert "How Great Thou Art" not in after, (
+            "the song is still listed publicly with zero performances"
+        )
+        assert "Amazing Grace" in after, "the wrong song left the catalogue"
+        assert auth_client.get("/songs/2").status_code == 404, (
+            "the song page still resolves, so the orphan is reachable by URL "
+            "even when it is not listed"
+        )
+
+    def test_a_song_still_performed_elsewhere_stays_listed(self, auth_client, db_with_songs):
+        """The guard that must not over-reach, exercised through the web stack."""
+        from worship_catalog.db import Database
+
+        db = Database(db_with_songs)
+        db.connect()
+        second = db.insert_or_update_service(
+            service_date="2026-03-01",
+            service_name="PM Worship",
+            source_file="b.pptx",
+            source_hash="def456",
+        )
+        db.insert_service_song(second, 2, ordinal=1)
+        db.close()
+
+        auth_client._csrf_token = auth_client._inner.cookies.get("csrftoken")
+        resp = auth_client.post(
+            "/services/1/setlist/2/delete", auth=self._CREDS, follow_redirects=False
+        )
+        assert resp.status_code in (302, 303), resp.status_code
+
+        assert "How Great Thou Art" in auth_client.get("/songs").text, (
+            "a song still performed in another service was removed from the catalogue"
+        )
+        assert auth_client.get("/songs/2").status_code == 200


### PR DESCRIPTION
Closes #618. First card of **Sprint 9**.

## The gap

#617 shipped the delete half of #323 and deliberately left the `songs` row alone — songs are shared
across services, so erasing one to fix a single misread slide would destroy its history everywhere it
legitimately appears. Still right. But it half-fixes the case the feature exists for.

#313/#314 are a scripture reference and two sermon-outline slides misread as songs. Each appears
exactly once. After the admin removes them the rows survive with **zero performances**, and
`query_songs_paginated` LEFT JOINs `service_songs` with no `HAVING` guard — so `MICAH 6:6 – 8` stays
visible in the public catalogue at songs.highland-coc.com, clearable only with the CLI access this
whole feature exists to avoid.

## The change

`delete_setlist_entry` now deletes the song too, when the entry it removed was that song's **last
appearance anywhere**. A song nothing references is not shared with anyone.

`song_editions` and `copy_events` go with it. Neither is reachable from `songs` by a database
constraint, so a partial delete leaves rows nothing will ever notice — and a surviving copy event
keeps the phantom in the CCLI report, which is where a misidentified song does its real harm. The
four deletes are factored into `_delete_song_rows`, shared with `delete_song` (the CLI's `cleanup
orphaned-songs`), so there is one definition of what removing a song means.

## Where to look hardest

**The count is global, not per-service.** That is the whole risk here, and it is easy to get wrong
because the copy-events count *directly above it in the same method* is correctly scoped to
`service_id` — so the wrong version is the one that looks locally consistent. Scoped, this deletes a
song another service is still performing and takes that service's setlist row and CCLI reporting with
it, silently.

## Tests

Written first, red before the change, green after. Each fails under exactly one wrong variant rather
than restating the happy path:

| Test | Wrong variant it catches |
|---|---|
| `test_a_song_still_used_in_another_service_is_untouched` | the count scoped to `service_id` |
| `test_a_second_appearance_in_the_same_service_keeps_the_song` | counting entries instead of appearances — `service_songs` is `UNIQUE(service_id, ordinal)`, **not** `(service_id, song_id)` |
| `test_a_missing_entry_deletes_nothing_at_all` | a guard that ignores `removed` and destroys a song behind a 404 |
| `test_the_orphans_editions_and_copy_events_go_with_it` | a partial delete leaving dangling rows |
| `test_a_song_with_no_remaining_appearances_is_deleted` | the behaviour itself |

Two more assert it end-to-end through HTTP (`TestOrphanedSongIsNotLeftInThePublicCatalogue`), because
only the rendered `/songs` page proves the public catalogue actually changed — and they check
`/songs/{id}` returns 404, so the orphan is not merely unlisted while still reachable by URL.

## Validation

- `uv run --frozen ruff check src/` — clean
- `uv run --frozen mypy src/` — clean, 19 files
- `uv run --frozen pytest` — **1516 passed**, 11 failed
- The 11 failures are the documented host trap: `tests/test_backup_{restore,sh}.py` and
  `tests/test_seed_pi_db_sh.py` shell out to the `sqlite3` CLI, which this workstation lacks.
  Verified environmental by running the same three files on **untouched `main` in the canonical
  checkout** — byte-identical 11 failures. CI has the binary.

## Decision recorded

Deleting the row was chosen over filtering zero-performance songs out of the list (Matt, 2026-08-02).
The filter hides rather than removes: the row stays in the database, `/songs/{id}` still resolves,
and `insert_or_get_song` still matches it on the next import.

## Review

Routes to `adversarial-pr-review` per standing rule §12 — a destructive write on shared data, inside
a request whose user-visible scope ("remove this song from this service") is narrower than its effect.
