### PR TITLE
docs(web): say how to re-import a service, because re-upload already does it

### DIFF
--- a/docs/data-cleanup.md
+++ b/docs/data-cleanup.md
@@ -62,7 +62,27 @@ docker compose run --rm cli worship-catalog cleanup orphaned-songs --db /data/wo
 
 ## Re-import Workflow
 
-After fixing a bug that caused bad data, follow this workflow:
+### For the church admin: just upload the deck again
+
+**There is no re-import button, and none is needed** (#616). Uploading the same service's deck
+through `/upload` replaces that service rather than duplicating it: `run_import` matches an existing
+service on `(service_date, service_name)`, calls `delete_service_data`, and re-inserts — all inside
+one `IMMEDIATE` transaction. A corrected deck therefore removes whatever the previous extraction got
+wrong, including phantom songs.
+
+This is the whole answer for the common case, it needs no CLI access, and the service page links to
+it. The CLI workflow below is for a developer cleaning up after a *bug*, where several services are
+affected at once and the decks may not be to hand.
+
+> **Why not a button wired to the stored path?** #323 proposed re-running the import against
+> `services.source_file`. That cannot work: `web/app.py` deletes the uploaded file in the `finally`
+> of every import (#138), so `source_file` is a dangling path for every web-uploaded service — which
+> is all of them. It would appear to work for a developer importing from the CLI and fail for the
+> actual user. `tests/test_web.py::TestReimportByReuploadingTheDeck` pins both halves: that
+> re-upload replaces, and that the deck really is deleted. If the second ever starts failing,
+> re-import from the stored path has become buildable and #616 is worth revisiting.
+
+### For a developer: after fixing a bug that caused bad data
 
 ```bash
 # 1. ALWAYS backup before cleanup

--- a/src/worship_catalog/web/templates/service_detail.html
+++ b/src/worship_catalog/web/templates/service_detail.html
@@ -119,6 +119,20 @@
       {% endfor %}
     </tbody>
   </table>
+  {% if can_edit %}
+  {# The re-import answer (#616). There is no re-import button and there cannot
+     be one wired the way #323 proposed: `services.source_file` records a path
+     the app deletes in the `finally` of every import (#138), so it is dangling
+     for every web-uploaded service. Uploading the deck again does the whole job
+     — `run_import` matches on (service_date, service_name), deletes the existing
+     service's data and re-inserts, inside one IMMEDIATE transaction. Saying so
+     here is the entire feature; a button would only be a second way to do it. #}
+  <p style="font-size:0.85rem;color:#6c757d;margin-top:0.75rem;">
+    Something else wrong with this service? <a href="/upload">Upload the deck again</a> —
+    re-importing the same date and service name replaces this service rather than
+    duplicating it.
+  </p>
+  {% endif %}
   </div>
 </div>
 {% endif %}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -4993,3 +4993,243 @@ class TestOrphanedSongIsNotLeftInThePublicCatalogue:
             "a song still performed in another service was removed from the catalogue"
         )
         assert auth_client.get("/songs/2").status_code == 200
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+class TestReimportByReuploadingTheDeck:
+    """Re-uploading the same service's deck replaces it rather than duplicating (#616).
+
+    #323 proposed a "re-import service" button wired to `services.source_file`.
+    It cannot be built that way: `web/app.py` deletes the uploaded deck in the
+    `finally` of every import (#138), so `source_file` is a dangling path for
+    every web-uploaded service — which is all of them, since the web UI is what
+    the church admin uses. A button wired to it would fail for the actual user
+    while appearing to work for a developer importing from the CLI.
+
+    #616 offers re-upload as the option that costs nothing because it is claimed
+    to already work. THIS CLASS IS THAT CLAIM'S ONLY EVIDENCE. If these fail,
+    re-upload is not a workaround and the card is a real build — retaining decks
+    on the Pi, or storing the extracted intermediate, each with their own costs.
+    So they are written to fail loudly rather than to pass easily.
+
+    `run_import` matches an existing service on (service_date, service_name) and
+    calls `delete_service_data` before re-inserting, all inside one IMMEDIATE
+    transaction. These tests pin that behaviour through the real HTTP upload
+    path, because that is the path the admin uses and the one that deletes the
+    file afterwards.
+    """
+
+    def _deck(self, *, songs, date="2026-01-04", service="AM Worship", leader="Alice"):
+        """Build a Paperless-Hymnal-shaped PPTX in memory and return its bytes."""
+        from pptx import Presentation
+        from pptx.util import Inches
+
+        prs = Presentation()
+        blank = prs.slide_layouts[6]
+
+        meta = prs.slides.add_slide(blank)
+        table = meta.shapes.add_table(3, 2, Inches(1), Inches(1), Inches(8), Inches(1.2)).table
+        for r, (k, v) in enumerate(
+            [("Date", date), ("Service", service), ("Song Leader", leader)]
+        ):
+            table.cell(r, 0).text = k
+            table.cell(r, 1).text = v
+
+        for title, body in songs:
+            slide = prs.slides.add_slide(blank)
+            box = slide.shapes.add_textbox(Inches(0.5), Inches(0.5), Inches(9), Inches(2))
+            tf = box.text_frame
+            tf.paragraphs[0].text = title
+            tf.add_paragraph().text = body
+            tf.add_paragraph().text = "PaperlessHymnal.com"
+
+        buf = io.BytesIO()
+        prs.save(buf)
+        return buf.getvalue()
+
+    def _client(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "reimport.db"
+        _db = Database(db_path)
+        _db.connect()
+        _db.init_schema()
+        _db.close()
+
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_path))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+
+        reload(app_module)
+        return CsrfAwareClient(TestClient(app_module.app)), db_path, inbox
+
+    def _upload(self, client, deck_bytes, filename="AM Worship 2026.01.04.pptx"):
+        import time
+
+        resp = client.post(
+            "/upload",
+            files={"file": (filename, io.BytesIO(deck_bytes), VALID_PPTX_MIME)},
+        )
+        assert resp.status_code == 202, resp.text
+        job_id = resp.json()["job_id"]
+
+        deadline = time.monotonic() + 15.0
+        status = "pending"
+        while time.monotonic() < deadline and status not in ("complete", "failed"):
+            status = client.get(f"/jobs/{job_id}").json()["status"]
+            time.sleep(0.05)
+        job = client.get(f"/jobs/{job_id}").json()
+        assert status == "complete", f"import did not complete: {job}"
+        return job
+
+    def _services(self, db_path):
+        db = Database(db_path)
+        db.connect()
+        rows = db.cursor().execute(
+            "SELECT id, service_date, service_name FROM services ORDER BY id"
+        ).fetchall()
+        out = [dict(r) for r in rows]
+        db.close()
+        return out
+
+    def _titles(self, db_path, service_id):
+        db = Database(db_path)
+        db.connect()
+        titles = [s["display_title"] for s in db.query_service_songs(service_id)]
+        db.close()
+        return titles
+
+    def test_reuploading_the_same_deck_replaces_rather_than_duplicates(
+        self, tmp_path, monkeypatch
+    ):
+        """Option 2's whole premise — if this fails, re-upload is not a workaround."""
+        client, db_path, _ = self._client(tmp_path, monkeypatch)
+        deck = self._deck(
+            songs=[("Amazing Grace", "How sweet the sound"), ("Be Thou My Vision", "O Lord of my heart")]
+        )
+
+        self._upload(client, deck)
+        first = self._services(db_path)
+        assert len(first) == 1, f"expected one service after the first import, got {first}"
+
+        self._upload(client, deck)
+        second = self._services(db_path)
+
+        assert len(second) == 1, (
+            f"the same deck imported twice produced {len(second)} services — re-upload "
+            f"duplicates rather than replaces, so it is NOT a re-import workaround: {second}"
+        )
+        titles = self._titles(db_path, second[0]["id"])
+        assert len(titles) == len(set(titles)), (
+            f"the setlist gained duplicate entries on re-upload: {titles}"
+        )
+
+    def test_reuploading_a_corrected_deck_removes_the_misidentified_song(
+        self, tmp_path, monkeypatch
+    ):
+        """The reason anyone re-imports at all.
+
+        A deck whose extraction produced a phantom song is corrected and
+        re-uploaded. Replacement is only useful if the phantom actually goes —
+        an append-only import would leave it behind and the admin would be no
+        better off than before.
+        """
+        client, db_path, _ = self._client(tmp_path, monkeypatch)
+
+        wrong = self._deck(
+            songs=[
+                ("Amazing Grace", "How sweet the sound"),
+                ("Be Thou My Vision", "O Lord of my heart"),
+            ]
+        )
+        self._upload(client, wrong)
+        service_id = self._services(db_path)[0]["id"]
+        before = self._titles(db_path, service_id)
+        # Assert on what the extractor actually produced rather than on a
+        # hardcoded title: a slide's title is the extractor's decision, and
+        # pinning a guess here would fail as a "finding" when only the fixture
+        # was wrong. (It did, on the first run: a scripture reference used as the
+        # phantom was read as a body line and the title came out as the lyric.)
+        assert len(before) == 2, f"fixture problem, not a finding: imported {before}"
+        phantom = before[1]
+
+        corrected = self._deck(songs=[("Amazing Grace", "How sweet the sound")])
+        self._upload(client, corrected)
+
+        services = self._services(db_path)
+        assert len(services) == 1, f"the corrected re-upload forked the service: {services}"
+        after = self._titles(db_path, services[0]["id"])
+        assert phantom not in after, (
+            f"{phantom!r} survived the corrected re-upload — re-import does not "
+            f"correct anything: {after}"
+        )
+        assert before[0] in after, f"the real song was lost: {after}"
+
+    def test_the_uploaded_deck_is_deleted_after_import(self, tmp_path, monkeypatch):
+        """Pins WHY the #323 design cannot work, so the docs stay honest.
+
+        `services.source_file` records a path the app itself removes (#138). If
+        this ever stops being true, re-import from the stored path becomes
+        buildable and #616's premise should be revisited.
+        """
+        client, db_path, inbox = self._client(tmp_path, monkeypatch)
+        self._upload(client, self._deck(songs=[("Amazing Grace", "How sweet the sound")]))
+
+        assert list(inbox.iterdir()) == [], (
+            f"the inbox still holds the uploaded deck: {list(inbox.iterdir())}"
+        )
+        db = Database(db_path)
+        db.connect()
+        source = db.cursor().execute("SELECT source_file FROM services").fetchone()[0]
+        db.close()
+        assert not Path(source).exists(), (
+            f"services.source_file still resolves ({source}) — re-import from the "
+            "stored path may now be buildable; revisit #616"
+        )
+
+
+class TestReimportGuidanceOnTheServicePage:
+    """The service page tells the admin how to re-import (#616).
+
+    The guidance IS the feature. #616 is closed by saying the right thing in the
+    right place, not by shipping a button — so if this text stops rendering, the
+    feature is gone even though nothing else fails.
+
+    Editor-only on purpose: it points at `/upload`, which needs the upload
+    password, and it is operator guidance rather than something a visitor
+    browsing the catalogue should see.
+    """
+
+    _CREDS = ("highland", "s3cret")
+
+    @pytest.fixture
+    def client(self, db_with_songs, tmp_path, monkeypatch):
+        inbox = tmp_path / "inbox"
+        inbox.mkdir()
+        monkeypatch.setenv("DB_PATH", str(db_with_songs))
+        monkeypatch.setenv("INBOX_DIR", str(inbox))
+        monkeypatch.setenv("UPLOAD_PASSWORD", "s3cret")
+        from importlib import reload
+
+        import worship_catalog.web.app as app_module
+
+        reload(app_module)
+        return CsrfAwareClient(TestClient(app_module.app))
+
+    def test_an_editor_is_told_to_upload_the_deck_again(self, client):
+        body = client.get("/services/1", auth=self._CREDS).text
+        assert "Upload the deck again" in body, (
+            "the service page no longer tells the admin how to re-import — #616 "
+            "is closed by this text existing"
+        )
+        assert 'href="/upload"' in body
+
+    def test_an_anonymous_visitor_is_not(self, client):
+        body = client.get("/services/1").text
+        assert "Upload the deck again" not in body, (
+            "operator guidance is rendering for the public catalogue"
+        )


### PR DESCRIPTION
Closes #616. Second card of **Sprint 9**.

## The card asked which option to build; the answer is none of them

#616 offered three ways to give the admin a re-import, and put option 2 — "the admin re-uploads the
same deck" — first, on the grounds that it costs nothing and **already works**. That claim was
unverified, so the first thing written here was the test, not the docs.

It holds. `TestReimportByReuploadingTheDeck` drives the real HTTP upload path twice:

- **the same deck twice → one service**, no duplicated setlist entries;
- **a corrected deck → the phantom is gone**, which is the only reason anyone re-imports;
- `run_import` matches on `(service_date, service_name)`, calls `delete_service_data` and re-inserts,
  all inside one `IMMEDIATE` transaction.

So there is nothing to build, and options 1 and 3 — retaining every deck on the Pi (0.5–3 GB/year,
plus a new place copyrighted material sits) or storing the extracted intermediate — buy nothing that
re-upload does not already give. This card is a **documentation gap**.

## What changed

Guidance in the two places someone actually looks:

- **The service page** — an editor-only line pointing at `/upload`: re-importing the same date and
  service name replaces the service rather than duplicating it. Editor-only because it points at an
  authenticated route and is operator guidance, not something a visitor browsing the catalogue needs.
- **`docs/data-cleanup.md`** — its *Re-import Workflow* previously offered only a CLI procedure the
  church admin cannot run. It now leads with the admin's answer and keeps the CLI path, correctly
  framed, for a developer cleaning up after a bug across several services.

## One test is a tripwire, not a regression guard

`test_the_uploaded_deck_is_deleted_after_import` asserts the deck is **gone** — pinning *why* the
#323 design cannot be built. `web/app.py` deletes the upload in the `finally` of every import (#138),
so `services.source_file` is a dangling path for every web-uploaded service, which is all of them; a
button wired to it would work for a developer importing from the CLI and fail for the actual user.

If that test ever fails it does not mean someone broke something. It means decks are being retained,
re-import from the stored path has become buildable, and #616's premise should be revisited. Both the
test and the docs say so, so a future reader does not simply "fix" it.

## A fixture correction, recorded because it looked like a finding

The phantom song was first written as a scripture reference. The extractor read it as a body line, so
the imported title was the lyric rather than the reference, and the test failed. That was my fixture,
not a defect — the assertion was written to say so ("fixture problem, not a finding") precisely so it
could not be misread. It now asserts on what the extractor actually produced rather than a guess.

## Validation

- `uv run --frozen ruff check src/` — clean
- `uv run --frozen mypy src/` — clean, 19 files
- **Mandatory suites for `src/worship_catalog/web/**`** (`test_web.py`, `test_web_security.py`,
  `test_accessibility.py`) — **501 passed**
- Full local suite: the background run was stopped before it reported, so **CI's `test` job is the
  gate here** — and it is the stricter one, since it has the `sqlite3` binary this workstation lacks.
  Not merging until it is green.

## Review routing

No AI review, per standing rule §12: a template string, docs, and tests — not destructive, not
prod-affecting infra, no secrets or auth surface, validation green. Reviewers are exception handlers,
not a toll booth.
